### PR TITLE
Improved relay coverage

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1547,7 +1547,6 @@ img:not(.avatar-img) {
 }
 
 .repost {
-    border-left: 3px solid #a78bfa;
     padding-left: 8px;
 }
 


### PR DESCRIPTION
Improve relay coverage and fix repost visual separation

  - Expand relay list from 4 to 12 relays for better content discovery
  - Add automatic user relay discovery via NIP-65 (kind 10002 events)
  - Connect to user's personal relays on sign-in to find missing posts
  - Remove left border from reposts to prevent visual connection between consecutive reposts
  - Preserve left border styling for quoted notes