### PR TITLE
WebLN provider + wallet UX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ npm-debug.log*
 *.log
 # Generated build stamp
 version.js
+
+# Temp font preview
+font-preview.html

--- a/background.js
+++ b/background.js
@@ -399,6 +399,8 @@ async function weblnSendPayment(params, host, pubkey) {
 
   await setSiteAccount(host, pubkey);
   logActivity({ ts: Date.now(), host, method: 'webln.sendPayment', amountSats: sats, pubkey });
+  // Tell an open side panel to refresh its balance/history.
+  chrome.runtime.sendMessage({ type: 'SIDECAR_EVENT', event: 'walletChanged' }).catch(() => {});
   return { preimage: preimage || '' };
 }
 

--- a/background.js
+++ b/background.js
@@ -8,11 +8,13 @@
 // Decrypted private keys live only in the keystore's in-memory map here. If this worker
 // is killed (MV3 ~30s idle), that map is gone and the keystore re-locks — a feature.
 
-importScripts('nostr-tools.js', 'crypto.js', 'keystore.js', 'permissions.js', 'signer.js');
+importScripts('nostr-tools.js', 'crypto.js', 'keystore.js', 'permissions.js', 'signer.js', 'wallet-budgets.js', 'nwc-client.js');
 
 const KS = self.SidecarKeystore;
 const PERMS = self.SidecarPermissions;
 const SIGNER = self.SidecarSigner;
+const BUDGETS = self.SidecarBudgets;
+const NWC = self.SidecarNWC;
 
 const DEFAULT_RELAYS = {
   'wss://relay.damus.io': { read: true, write: true },
@@ -150,13 +152,13 @@ chrome.windows.onRemoved.addListener((windowId) => {
   }
 });
 
-function settlePrompt(promptId, action) {
+function settlePrompt(promptId, action, extra) {
   const p = pendingPrompts.get(promptId);
   if (!p || p.settled) return;
   p.settled = true;
   pendingPrompts.delete(promptId);
   if (p.windowId != null) chrome.windows.remove(p.windowId).catch(() => {});
-  p.resolve({ action });
+  p.resolve(Object.assign({ action }, extra || {}));
 }
 
 // ============================================================================
@@ -237,11 +239,176 @@ async function handleNostrRpc(method, params, host, sendResponse) {
 }
 
 // ============================================================================
+// Page WebLN handling (window.webln.*) — backed by the account's NWC wallet
+// ============================================================================
+// The NWC client runs here in the SW (it only needs NostrTools + WebSocket), so
+// WebLN works whether or not the side panel is open.
+let swNwc = null; // { client, pubkey }
+async function getSwNwc(pubkey) {
+  if (swNwc && swNwc.pubkey === pubkey) return swNwc.client;
+  if (swNwc) { try { swNwc.client.close(); } catch (_) {} swNwc = null; }
+  const connection = await KS.getNwc(pubkey); // requires unlocked
+  if (!connection) return null;
+  swNwc = { client: NWC.makeClient(connection), pubkey };
+  return swNwc.client;
+}
+function closeSwNwc() {
+  if (swNwc) { try { swNwc.client.close(); } catch (_) {} swNwc = null; }
+}
+
+const msatToSat = (m) => Math.floor((m || 0) / 1000);
+
+// Parse the sat amount out of a BOLT11 invoice's human-readable part, without a
+// full decoder. Returns null for amountless invoices (caller must then prompt).
+function invoiceSats(bolt11) {
+  if (!bolt11) return null;
+  const m = /^ln(?:bc|tb|bcrt)(\d+)([munp]?)/i.exec(String(bolt11).replace(/^lightning:/i, '').trim());
+  if (!m) return null;
+  const digits = m[1];
+  const mult = m[2].toLowerCase();
+  if (!digits) return null; // amountless invoice
+  // BOLT11 amount is in BTC * multiplier; convert to sats (1 BTC = 1e8 sats).
+  const FACTOR = { m: 1e5, u: 1e2, n: 1e-1, p: 1e-4, '': 1e8 };
+  return Math.round(Number(digits) * FACTOR[mult]);
+}
+
+// Open an unlock-only popup for low-risk wallet reads when the keystore is locked.
+async function weblnUnlockGate(host, method, pubkey) {
+  if (!KS.isLocked()) return;
+  const st = await KS.getState();
+  const acct = st.accounts.find((a) => a.pubkey === pubkey);
+  const decision = await openPrompt({
+    scope: 'webln',
+    host,
+    method: 'webln.' + method,
+    npub: self.NostrTools.nip19.npubEncode(pubkey),
+    accountName: (acct && acct.name) || '',
+    needUnlock: true,
+    needApproval: false,
+  });
+  if (decision.action === 'reject') throw new Error('You rejected this request');
+  if (KS.isLocked()) throw new Error('Keystore is locked');
+}
+
+async function handleWeblnRpc(method, params, host, sendResponse) {
+  try {
+    if (!host) throw new Error('Missing host');
+    await KS.ensureLoaded();
+    if (!(await KS.isInitialized())) throw new Error('Sidecar has no accounts set up yet');
+    const pubkey = await resolveSiteAccount(host);
+    if (!pubkey) throw new Error('No active Sidecar account');
+
+    // A site blocked for signing is blocked for payments too.
+    if ((await PERMS.getLevel(pubkey, host)) === 'blocked') throw new Error('This site is blocked in Sidecar');
+
+    const hasWallet = await KS.hasNwc(pubkey);
+
+    // isEnabled reports availability without throwing. enable() rejects when no
+    // wallet is connected, so apps get the standard WebLN "unavailable" signal
+    // and can fall back. Neither needs an unlock.
+    if (method === 'isEnabled') {
+      sendResponse({ ok: true, result: { enabled: hasWallet } });
+      return;
+    }
+    if (!hasWallet) throw new Error('No wallet connected in Sidecar');
+    if (method === 'enable') {
+      sendResponse({ ok: true, result: { enabled: true } });
+      return;
+    }
+
+    let result;
+    if (method === 'getInfo') {
+      await weblnUnlockGate(host, method, pubkey);
+      const c = await getSwNwc(pubkey);
+      const info = (await c.getInfo()) || {};
+      result = {
+        node: { alias: info.alias || 'Sidecar wallet', pubkey: info.pubkey || '', color: info.color || '' },
+        methods: ['getInfo', 'makeInvoice', 'sendPayment', 'getBalance'],
+        supports: ['lightning'],
+      };
+    } else if (method === 'getBalance') {
+      await weblnUnlockGate(host, method, pubkey);
+      const c = await getSwNwc(pubkey);
+      const b = await c.getBalance();
+      result = { balance: msatToSat(b && b.balance), currency: 'sats' };
+    } else if (method === 'makeInvoice') {
+      await weblnUnlockGate(host, method, pubkey);
+      const c = await getSwNwc(pubkey);
+      const sats = parseInt(params && params.amount, 10);
+      if (!sats || sats < 1) throw new Error('A positive amount is required to make an invoice');
+      const res = await c.makeInvoice(sats * 1000, (params && params.memo) || '');
+      const invoice = res && (res.invoice || res.payment_request || res.bolt11);
+      if (!invoice) throw new Error('Wallet returned no invoice');
+      result = { paymentRequest: invoice };
+    } else if (method === 'sendPayment') {
+      result = await weblnSendPayment(params, host, pubkey);
+    } else {
+      throw new Error('Sidecar does not support webln.' + method);
+    }
+
+    await setSiteAccount(host, pubkey);
+    sendResponse({ ok: true, result });
+  } catch (e) {
+    sendResponse({ ok: false, error: e.message });
+  }
+}
+
+async function weblnSendPayment(params, host, pubkey) {
+  const invoice = (params && (params.paymentRequest || params.invoice) ? (params.paymentRequest || params.invoice) : '')
+    .replace(/^lightning:/i, '')
+    .trim();
+  if (!invoice) throw new Error('No invoice provided');
+  const sats = invoiceSats(invoice);
+
+  // Pay without a prompt only when unlocked AND the site's budget covers a known amount.
+  const autoOk = !KS.isLocked() && sats != null && (await BUDGETS.covers(pubkey, host, sats));
+
+  if (!autoOk) {
+    const st = await KS.getState();
+    const acct = st.accounts.find((a) => a.pubkey === pubkey);
+    const decision = await openPrompt({
+      scope: 'webln',
+      host,
+      method: 'sendPayment',
+      npub: self.NostrTools.nip19.npubEncode(pubkey),
+      accountName: (acct && acct.name) || '',
+      amountSats: sats, // null for amountless invoices
+      memo: (params && params.memo) || '',
+      needUnlock: KS.isLocked(),
+      needApproval: true,
+    });
+    if (decision.action === 'reject') throw new Error('You rejected this payment');
+    if (KS.isLocked()) throw new Error('Keystore is locked');
+    // 'budget' → remember an allowance for this site before paying.
+    if (decision.action === 'budget' && decision.budgetSats) {
+      await BUDGETS.setBudget(pubkey, host, {
+        budgetSats: decision.budgetSats,
+        perPaymentSats: decision.perPaymentSats || 0,
+      });
+    }
+  }
+
+  bumpAutoLock();
+  const c = await getSwNwc(pubkey);
+  if (!c) throw new Error('No wallet connected in Sidecar');
+  const res = await c.payInvoice(invoice);
+  const preimage = res && (res.preimage || res.payment_preimage);
+
+  // Decrement the budget by the paid amount (known amount only).
+  if (sats != null) await BUDGETS.consume(pubkey, host, sats);
+
+  await setSiteAccount(host, pubkey);
+  logActivity({ ts: Date.now(), host, method: 'webln.sendPayment', amountSats: sats, pubkey });
+  return { preimage: preimage || '' };
+}
+
+// ============================================================================
 // Keystore control messages (from side panel and prompt)
 // ============================================================================
 async function lockKeystore() {
   await KS.lock();
   SIGNER.clearCache();
+  closeSwNwc();
   chrome.alarms.clear(AUTO_LOCK_ALARM);
 }
 
@@ -285,6 +452,7 @@ async function handleControl(message, sendResponse) {
       case 'SIDECAR_REMOVE_ACCOUNT': {
         result = await KS.removeAccount(message.pubkey);
         await PERMS.clearAccount(message.pubkey);
+        await BUDGETS.clearAccount(message.pubkey);
         await clearSiteAccountsForPubkey(message.pubkey);
         const acts = (await sget(ACTIVITY_KEY))[ACTIVITY_KEY] || [];
         await sset({ [ACTIVITY_KEY]: acts.filter((e) => e.pubkey !== message.pubkey) });
@@ -395,6 +563,7 @@ async function handleControl(message, sendResponse) {
       }
       case 'SIDECAR_SET_NWC':
         await KS.setNwc(message.pubkey, message.connection);
+        closeSwNwc(); // rebuild against the new connection on next use
         result = { ok: true };
         break;
       case 'SIDECAR_GET_NWC':
@@ -405,7 +574,20 @@ async function handleControl(message, sendResponse) {
         break;
       case 'SIDECAR_CLEAR_NWC':
         await KS.clearNwc(message.pubkey);
+        closeSwNwc();
         result = { ok: true };
+        break;
+      case 'SIDECAR_GET_BUDGETS':
+        result = await BUDGETS.getAll(await KS.getActivePubkey());
+        break;
+      case 'SIDECAR_SET_BUDGET':
+        result = await BUDGETS.setBudget(await KS.getActivePubkey(), message.host, {
+          budgetSats: message.budgetSats,
+          perPaymentSats: message.perPaymentSats,
+        });
+        break;
+      case 'SIDECAR_REVOKE_BUDGET':
+        result = await BUDGETS.revoke(await KS.getActivePubkey(), message.host);
         break;
       default:
         throw new Error('Unknown control message: ' + message.type);
@@ -430,6 +612,10 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     handleNostrRpc(message.method, message.params, message.host, sendResponse);
     return true;
   }
+  if (message.type === 'SIDECAR_WEBLN_RPC') {
+    handleWeblnRpc(message.method, message.params, message.host, sendResponse);
+    return true;
+  }
 
   // Prompt window asking for its context, or returning a decision.
   if (message.type === 'SIDECAR_GET_PROMPT_DATA') {
@@ -438,7 +624,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     return false;
   }
   if (message.type === 'SIDECAR_PROMPT_RESULT') {
-    settlePrompt(message.id, message.action);
+    settlePrompt(message.id, message.action, message.extra);
     sendResponse({ ok: true });
     return false;
   }

--- a/nostr-provider.js
+++ b/nostr-provider.js
@@ -70,6 +70,10 @@
       return { amount: args.amount != null ? args.amount : args.defaultAmount, memo: args.defaultMemo || args.memo };
     }
 
+    // Minimal event emitter — clients commonly call webln.on(...) right after
+    // enabling (e.g. for "accountChanged"). A missing on/off would throw a
+    // TypeError and crash the page, so we provide a real (if quiet) emitter.
+    const listeners = {};
     const webln = {
       enable: async () => {
         const r = await call('webln', 'enable');
@@ -91,6 +95,23 @@
       keysend: () => Promise.reject(new Error('keysend is not supported by Sidecar')),
       signMessage: () => Promise.reject(new Error('signMessage is not supported by Sidecar')),
       verifyMessage: () => Promise.reject(new Error('verifyMessage is not supported by Sidecar')),
+      // Raw NIP-47-style passthrough some clients probe for; unsupported for now.
+      request: () => Promise.reject(new Error('webln.request is not supported by Sidecar')),
+      // Event subscription (no-op sink so callers never hit an undefined method).
+      on: (name, cb) => {
+        (listeners[name] || (listeners[name] = [])).push(cb);
+        return webln;
+      },
+      off: (name, cb) => {
+        if (listeners[name]) listeners[name] = listeners[name].filter((f) => f !== cb);
+        return webln;
+      },
+      emit: (name, data) => {
+        (listeners[name] || []).forEach((f) => {
+          try { f(data); } catch (_) {}
+        });
+        return webln;
+      },
     };
 
     try {
@@ -98,5 +119,13 @@
     } catch (e) {
       window.webln = webln;
     }
+
+    // Discovery handshake: webln.requestProvider() resolves immediately if
+    // window.webln already exists, otherwise it waits for this event. We inject
+    // asynchronously, so an app that called requestProvider() before we arrived
+    // only learns about us via webln:ready.
+    try {
+      window.dispatchEvent(new Event('webln:ready'));
+    } catch (e) {}
   }
 })();

--- a/nostr-provider.js
+++ b/nostr-provider.js
@@ -1,8 +1,9 @@
-// Sidecar NIP-07 provider — runs in the PAGE context and defines window.nostr.
+// Sidecar page providers — runs in the PAGE context and defines window.nostr
+// (NIP-07) and window.webln (Lightning, backed by Sidecar's NWC wallet).
 //
 // This is the inversion of the old injected.js: instead of reading an existing
-// window.nostr, Sidecar now *is* the provider. Each method posts a request to the
-// content script (which forwards it to the extension's service worker for signing) and
+// window.nostr / window.webln, Sidecar now *is* the provider. Each method posts a
+// request to the content script (which forwards it to the service worker) and
 // resolves when the matching response comes back.
 
 (function () {
@@ -11,21 +12,19 @@
   let idCounter = 0;
   const pending = new Map();
 
-  function call(method, params) {
+  function call(scope, method, params) {
     return new Promise((resolve, reject) => {
-      const id = 'n' + ++idCounter;
+      const id = scope[0] + ++idCounter;
       pending.set(id, { resolve, reject });
-      window.postMessage(
-        { ext: 'sidecar', scope: 'nostr', kind: 'request', id, method, params },
-        '*'
-      );
+      window.postMessage({ ext: 'sidecar', scope, kind: 'request', id, method, params }, '*');
     });
   }
 
   window.addEventListener('message', function (event) {
     if (event.source !== window) return;
     const d = event.data;
-    if (!d || d.ext !== 'sidecar' || d.scope !== 'nostr' || d.kind !== 'response') return;
+    if (!d || d.ext !== 'sidecar' || d.kind !== 'response') return;
+    if (d.scope !== 'nostr' && d.scope !== 'webln') return;
     const p = pending.get(d.id);
     if (!p) return;
     pending.delete(d.id);
@@ -34,17 +33,18 @@
     else p.reject(new Error((r && r.error) || 'Sidecar request failed'));
   });
 
+  // ---- window.nostr (NIP-07) ----
   const nostr = {
-    getPublicKey: () => call('getPublicKey'),
-    signEvent: (event) => call('signEvent', { event }),
-    getRelays: () => call('getRelays'),
+    getPublicKey: () => call('nostr', 'getPublicKey'),
+    signEvent: (event) => call('nostr', 'signEvent', { event }),
+    getRelays: () => call('nostr', 'getRelays'),
     nip04: {
-      encrypt: (pubkey, plaintext) => call('nip04.encrypt', { pubkey, plaintext }),
-      decrypt: (pubkey, ciphertext) => call('nip04.decrypt', { pubkey, ciphertext }),
+      encrypt: (pubkey, plaintext) => call('nostr', 'nip04.encrypt', { pubkey, plaintext }),
+      decrypt: (pubkey, ciphertext) => call('nostr', 'nip04.decrypt', { pubkey, ciphertext }),
     },
     nip44: {
-      encrypt: (pubkey, plaintext) => call('nip44.encrypt', { pubkey, plaintext }),
-      decrypt: (pubkey, ciphertext) => call('nip44.decrypt', { pubkey, ciphertext }),
+      encrypt: (pubkey, plaintext) => call('nostr', 'nip44.encrypt', { pubkey, plaintext }),
+      decrypt: (pubkey, ciphertext) => call('nostr', 'nip44.decrypt', { pubkey, ciphertext }),
     },
   };
 
@@ -54,5 +54,49 @@
     Object.defineProperty(window, 'nostr', { value: nostr, configurable: false, writable: false });
   } catch (e) {
     window.nostr = nostr;
+  }
+
+  // ---- window.webln (Lightning) ----
+  // Only define it if no other WebLN provider is already present, so Sidecar
+  // doesn't fight Alby or a wallet the user prefers on this page.
+  if (!window.webln) {
+    let enabled = false;
+    const ensure = () => (enabled ? Promise.resolve() : webln.enable());
+
+    // WebLN makeInvoice accepts a number, a string, or an options object.
+    function normInvoice(args) {
+      if (args == null) return {};
+      if (typeof args === 'number' || typeof args === 'string') return { amount: args };
+      return { amount: args.amount != null ? args.amount : args.defaultAmount, memo: args.defaultMemo || args.memo };
+    }
+
+    const webln = {
+      enable: async () => {
+        const r = await call('webln', 'enable');
+        enabled = !!(r && r.enabled !== false);
+        return r || { enabled };
+      },
+      isEnabled: async () => {
+        if (enabled) return true;
+        try {
+          const r = await call('webln', 'isEnabled');
+          enabled = !!(r && r.enabled);
+        } catch (_) {}
+        return enabled;
+      },
+      getInfo: () => ensure().then(() => call('webln', 'getInfo')),
+      getBalance: () => ensure().then(() => call('webln', 'getBalance')),
+      makeInvoice: (args) => ensure().then(() => call('webln', 'makeInvoice', normInvoice(args))),
+      sendPayment: (paymentRequest) => ensure().then(() => call('webln', 'sendPayment', { paymentRequest })),
+      keysend: () => Promise.reject(new Error('keysend is not supported by Sidecar')),
+      signMessage: () => Promise.reject(new Error('signMessage is not supported by Sidecar')),
+      verifyMessage: () => Promise.reject(new Error('verifyMessage is not supported by Sidecar')),
+    };
+
+    try {
+      Object.defineProperty(window, 'webln', { value: webln, configurable: true, writable: false });
+    } catch (e) {
+      window.webln = webln;
+    }
   }
 })();

--- a/prompt.html
+++ b/prompt.html
@@ -77,6 +77,17 @@
       transition: border-color 0.15s, box-shadow 0.15s;
     }
     input[type=password]:focus { outline: none; border-color: var(--gold-soft); box-shadow: 0 0 0 3px rgba(203, 161, 78, 0.16); }
+    .remember { margin-bottom: 14px; }
+    .remember .check { display: flex; align-items: center; gap: 8px; color: var(--text); font-size: 13px; text-transform: none; letter-spacing: 0; margin-bottom: 8px; cursor: pointer; }
+    .remember input[type=checkbox] { width: 16px; height: 16px; accent-color: var(--orange); cursor: pointer; }
+    .budget-row { display: flex; align-items: center; gap: 8px; }
+    .remember input[type=number] {
+      width: 110px; padding: 9px 11px; border-radius: 10px; border: 1px solid var(--border);
+      background: linear-gradient(180deg, rgba(8, 2, 20, 0.6), rgba(20, 4, 40, 0.6));
+      color: var(--text); font-size: 14px; font-family: var(--font-mono);
+    }
+    .remember input[type=number]:focus { outline: none; border-color: var(--gold-soft); }
+    .budget-unit { font-size: 12.5px; color: var(--muted); }
     .error { color: var(--red); font-size: 13px; min-height: 18px; margin-bottom: 8px; }
     .actions { display: flex; flex-direction: column; gap: 8px; }
     button {
@@ -111,6 +122,14 @@
   <div id="unlock" class="hidden">
     <label for="pin">Enter your PIN to unlock</label>
     <input type="password" id="pin" autocomplete="off" maxlength="32" autofocus />
+  </div>
+
+  <div id="remember" class="remember hidden">
+    <label class="check"><input type="checkbox" id="remember-budget" /> Allow this site to spend up to</label>
+    <div class="budget-row">
+      <input type="number" id="budget-amount" min="1" placeholder="sats" />
+      <span class="budget-unit">sats / day without asking</span>
+    </div>
   </div>
 
   <div class="error" id="error"></div>

--- a/prompt.html
+++ b/prompt.html
@@ -87,6 +87,7 @@
       color: var(--text); font-size: 14px; font-family: var(--font-mono);
     }
     .remember input[type=number]:focus { outline: none; border-color: var(--gold-soft); }
+    .remember input[type=number]:disabled { opacity: 0.4; cursor: not-allowed; }
     .budget-unit { font-size: 12.5px; color: var(--muted); }
     .error { color: var(--red); font-size: 13px; min-height: 18px; margin-bottom: 8px; }
     .actions { display: flex; flex-direction: column; gap: 8px; }

--- a/prompt.js
+++ b/prompt.js
@@ -119,7 +119,15 @@
       els.allow.textContent = data.amountSats != null ? 'Pay ' + fmtSats(data.amountSats) + ' sats' : 'Pay';
       els.trust.classList.add('hidden');
       els.remember.classList.remove('hidden');
-      if (data.amountSats != null) els.budgetAmount.value = String(Math.max(data.amountSats * 5, 1000));
+      // Suggest a daily budget; the field is disabled until the box is ticked, so
+      // it's unambiguous whether a budget is actually being set.
+      const suggested = data.amountSats != null ? Math.max(data.amountSats * 5, 5000) : 5000;
+      els.budgetAmount.value = String(suggested);
+      els.budgetAmount.disabled = true;
+      els.rememberBudget.addEventListener('change', () => {
+        els.budgetAmount.disabled = !els.rememberBudget.checked;
+        if (els.rememberBudget.checked) els.budgetAmount.focus();
+      });
       return;
     }
 

--- a/prompt.js
+++ b/prompt.js
@@ -19,6 +19,9 @@
     allow: $('allow'),
     trust: $('trust'),
     reject: $('reject'),
+    remember: $('remember'),
+    rememberBudget: $('remember-budget'),
+    budgetAmount: $('budget-amount'),
   };
 
   function send(message) {
@@ -33,11 +36,27 @@
     'nip04.decrypt': 'decrypt a message (NIP-04)',
     'nip44.encrypt': 'encrypt a message (NIP-44)',
     'nip44.decrypt': 'decrypt a message (NIP-44)',
+    'webln.getInfo': 'see your wallet info',
+    'webln.getBalance': 'see your wallet balance',
+    'webln.makeInvoice': 'create a Lightning invoice',
   };
 
   let data = null;
+  let isPayment = false;
+
+  function fmtSats(n) {
+    return Number(n).toLocaleString('en-US');
+  }
 
   function renderPreview() {
+    if (isPayment) {
+      const rows = [];
+      rows.push(row('Amount', data.amountSats != null ? fmtSats(data.amountSats) + ' sats' : 'set by invoice'));
+      if (data.memo) rows.push(row('Memo', String(data.memo)));
+      els.preview.innerHTML = rows.join('');
+      els.preview.classList.remove('hidden');
+      return;
+    }
     if (data.method === 'signEvent') {
       const ev = (data.params && (data.params.event || data.params)) || {};
       const rows = [];
@@ -73,23 +92,37 @@
     if (!resp || !resp.ok) {
       els.ask.textContent = 'This request has expired.';
       els.allow.classList.add('hidden');
-      els.allowForever.classList.add('hidden');
+      els.trust.classList.add('hidden');
       els.reject.textContent = 'Close';
       return;
     }
     data = resp.data;
+    isPayment = data.scope === 'webln' && data.method === 'sendPayment';
+
     els.host.textContent = data.host;
-    els.ask.textContent = 'wants to ' + (METHOD_LABELS[data.method] || data.method);
+    const verb = isPayment ? 'wants to send a Lightning payment' : 'wants to ' + (METHOD_LABELS[data.method] || data.method);
+    els.ask.textContent = verb;
     els.account.innerHTML =
-      'Signing as <b>' +
+      (isPayment ? 'Paying from <b>' : 'Signing as <b>') +
       escapeHtml(data.accountName || shortNpub(data.npub)) +
       '</b>' +
       (data.accountName ? ' <span class="acct-npub">' + escapeHtml(shortNpub(data.npub)) + '</span>' : '');
     renderPreview();
+
     if (data.needUnlock) {
       els.unlock.classList.remove('hidden');
       setTimeout(() => els.pin.focus(), 50);
     }
+
+    if (isPayment) {
+      // Payment: one Pay button + an optional "remember a budget" toggle.
+      els.allow.textContent = data.amountSats != null ? 'Pay ' + fmtSats(data.amountSats) + ' sats' : 'Pay';
+      els.trust.classList.add('hidden');
+      els.remember.classList.remove('hidden');
+      if (data.amountSats != null) els.budgetAmount.value = String(Math.max(data.amountSats * 5, 1000));
+      return;
+    }
+
     // A pure unlock (site already trusted, keystore just locked) doesn't need the
     // "Trust this site" choice — it's already remembered.
     if (data.needUnlock && !data.needApproval) {
@@ -105,7 +138,7 @@
 
   async function decide(action) {
     els.error.textContent = '';
-    // Unlock first if needed (Allow once / Trust only).
+    // Unlock first if needed (Allow once / Trust / Pay only).
     if (data.needUnlock && (action === 'once' || action === 'trust')) {
       const pin = els.pin.value;
       if (!pin) {
@@ -120,7 +153,20 @@
         return;
       }
     }
-    await send({ type: 'SIDECAR_PROMPT_RESULT', id: promptId, action });
+
+    let extra = null;
+    // Payment + "remember a budget" checked → set an allowance for this site.
+    if (isPayment && action === 'once' && els.rememberBudget.checked) {
+      const budgetSats = parseInt(els.budgetAmount.value, 10);
+      if (!budgetSats || budgetSats < 1) {
+        els.error.textContent = 'Enter a budget in sats, or uncheck the box.';
+        return;
+      }
+      action = 'budget';
+      extra = { budgetSats, perPaymentSats: 0 };
+    }
+
+    await send({ type: 'SIDECAR_PROMPT_RESULT', id: promptId, action, extra });
     window.close();
   }
 

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -66,6 +66,7 @@
       <button class="tab" data-tab="wallet">Wallet</button>
     </nav>
 
+
     <div id="post-banner" class="post-banner hidden"></div>
 
     <main class="content">

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -95,6 +95,19 @@
     if (main) main.classList.toggle('balances-hidden', hideBalances);
   }
 
+  // Collapse the balance card into a slim sticky header as the wallet content
+  // scrolls (mirrors zap.cooking). Listener is attached once; it acts only when
+  // a wallet card is present.
+  function syncWalletCardCompact() {
+    const content = document.querySelector('.content');
+    const card = document.querySelector('.wallet-card');
+    if (content && card) card.classList.toggle('compact', content.scrollTop > 8);
+  }
+  (function () {
+    const content = document.querySelector('.content');
+    if (content) content.addEventListener('scroll', syncWalletCardCompact, { passive: true });
+  })();
+
   // Background broadcasts (e.g. a WebLN payment paid via the service worker
   // while the panel is open) — refresh the wallet if it's the visible tab.
   chrome.runtime.onMessage.addListener((msg) => {
@@ -2251,6 +2264,12 @@
     // Balance card — show the last-known balance instantly, refresh below.
     const cached = balanceCache.pubkey === state.activePubkey && balanceCache.sats != null;
     const card = h('div', { className: 'wallet-card' });
+    // When collapsed, tapping the card (outside its buttons) scrolls back to top.
+    card.addEventListener('click', (e) => {
+      if (card.classList.contains('compact') && !e.target.closest('button')) {
+        document.querySelector('.content').scrollTo({ top: 0, behavior: 'smooth' });
+      }
+    });
     const bal = h('div', {
       className: 'wallet-balance' + (cached ? '' : ' loading'),
       textContent: cached ? fmtSats(balanceCache.sats) : '…',
@@ -2313,6 +2332,7 @@
     }
     bal.classList.remove('loading');
     loadTransactions(txList, client);
+    syncWalletCardCompact();
   }
 
   // Centered placeholder for list cards (loading / empty / error) so the text

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -2233,6 +2233,9 @@
     // Backup to relays (detection mirrors zap.cooking)
     view.append(renderWalletBackup());
 
+    // Per-site WebLN spending budgets
+    view.append(renderSitePayments());
+
     // Disconnect
     const disc = h('button', { className: 'ghost wallet-disconnect', textContent: 'Disconnect wallet' });
     disc.addEventListener('click', () => disconnectModal());
@@ -2366,6 +2369,44 @@
         status.textContent = 'Not backed up';
       });
     return wrap;
+  }
+
+  // Per-site WebLN spending budgets: sites allowed to pay from the wallet without
+  // a prompt, up to a daily allowance. Lets the user review and revoke them.
+  function renderSitePayments() {
+    const wrap = h('div', { className: 'setting wallet-budgets' });
+    wrap.append(h('h3', { textContent: 'Site payments' }));
+    wrap.append(h('p', { className: 'hint', textContent: 'Sites allowed to pay from your wallet without asking, up to a daily budget. Revoke any time.' }));
+    const list = h('div', { className: 'list flat' });
+    wrap.append(list);
+    listState(list, 'Loading…');
+    call({ type: 'SIDECAR_GET_BUDGETS' })
+      .then((budgets) => {
+        const hosts = Object.keys(budgets || {}).sort();
+        if (!hosts.length) { list.classList.add('empty'); listState(list, 'No sites have a spending budget.'); return; }
+        list.classList.remove('empty');
+        list.innerHTML = '';
+        hosts.forEach((host) => list.append(budgetRow(host, budgets[host])));
+      })
+      .catch(() => listState(list, 'Could not load budgets.'));
+    return wrap;
+  }
+
+  function budgetRow(host, b) {
+    const row = h('div', { className: 'item' });
+    const main = h('div', { className: 'item-main' }, [
+      h('div', { className: 'item-label', textContent: host }),
+      h('div', {
+        className: 'item-sub',
+        textContent: fmtSats(b.remainingSats) + ' of ' + fmtSats(b.budgetSats) + ' sats left today',
+      }),
+    ]);
+    const rm = iconButton('Revoke budget', 'trash', async () => {
+      await call({ type: 'SIDECAR_REVOKE_BUDGET', host });
+      renderWallet();
+    });
+    row.append(main, rm);
+    return row;
   }
 
   function sendModal() {

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -43,6 +43,9 @@
     'arrow-up': '<line x1="12" y1="19" x2="12" y2="5"></line><polyline points="5 12 12 5 19 12"></polyline>',
     'arrow-up-right': '<line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline>',
     'arrow-down-left': '<line x1="17" y1="7" x2="7" y2="17"></line><polyline points="17 17 7 17 7 7"></polyline>',
+    refresh: '<polyline points="23 4 23 10 17 10"></polyline><polyline points="1 20 1 14 7 14"></polyline><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"></path>',
+    eye: '<path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path><circle cx="12" cy="12" r="3"></circle>',
+    'eye-off': '<path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"></path><line x1="1" y1="1" x2="23" y2="23"></line>',
   };
   function icon(name) {
     const wrap = document.createElement('span');
@@ -81,10 +84,33 @@
   }
 
   let state = null;
+  let hideBalances = false; // privacy toggle (persisted in settings)
+  let balanceCache = { pubkey: null, sats: null }; // last known balance for instant display
+
+  // Privacy masking is done in CSS (-webkit-text-security on `.balances-hidden`),
+  // which masks each glyph at its real width so toggling never reflows. We always
+  // render the true value; this helper just toggles the container class.
+  function applyHideBalances() {
+    const main = document.getElementById('view-main');
+    if (main) main.classList.toggle('balances-hidden', hideBalances);
+  }
+
+  // Background broadcasts (e.g. a WebLN payment paid via the service worker
+  // while the panel is open) — refresh the wallet if it's the visible tab.
+  chrome.runtime.onMessage.addListener((msg) => {
+    if (!msg || msg.type !== 'SIDECAR_EVENT') return;
+    if (msg.event === 'walletChanged' && state && !state.locked) {
+      const active = document.querySelector('.tab.active');
+      if (active && active.dataset.tab === 'wallet') renderWallet();
+    }
+  });
 
   // ---- top-level routing ----
   async function refresh() {
     state = await call({ type: 'SIDECAR_GET_STATE' });
+    const settings = await call({ type: 'SIDECAR_GET_SETTINGS' });
+    hideBalances = !!(settings && settings.hideBalances);
+    applyHideBalances();
     closeAcctMenu();
     [$('view-onboarding'), $('view-lock'), $('view-main'), $('view-settings'), $('view-profile-edit')].forEach(hide);
     if (!state.initialized) {
@@ -92,6 +118,7 @@
       setTimeout(() => $('ob-pin').focus(), 50);
     } else if (state.locked) {
       if (nwc) { try { nwc.close(); } catch (_) {} nwc = null; nwcPubkey = null; }
+      balanceCache = { pubkey: null, sats: null };
       show($('view-lock'));
       setTimeout(() => $('unlock-pin').focus(), 50);
     } else {
@@ -107,6 +134,7 @@
       else if (name === 'wallet') renderWallet();
     }
   }
+
 
   // ---- onboarding ----
   $('onboarding-form').addEventListener('submit', async (e) => {
@@ -1290,7 +1318,6 @@
   // ---- About / zap-the-creator ----
   const GITHUB_URL = 'https://github.com/dmnyc/sidecar';
   const CREATOR_NPUB = 'npub1aeh2zw4elewy5682lxc6xnlqzjnxksq303gwu2npfaxd49vmde6qcq4nwx';
-  const CREATOR_HANDLE = '@thedaniel';
   const CREATOR_LN = 'daniel@breez.tips';
   const IMG_EXT = /\.(jpg|jpeg|png|gif|webp|svg|bmp|avif)(\?.*)?$/i;
   const VID_EXT = /\.(mp4|webm|mov|m4v)(\?.*)?$/i;
@@ -2119,6 +2146,20 @@
   const fmtSats = (n) => Math.round(n).toLocaleString('en-US');
   const msatToSat = (m) => Math.floor((m || 0) / 1000);
 
+  // Shared sats cap + a numeric-only, capped amount input used by send/receive/zap.
+  const MAX_SATS = 100000000; // 100M
+  function satsInput(placeholder) {
+    const el = h('input', { type: 'text', inputMode: 'numeric', placeholder: placeholder });
+    el.addEventListener('input', () => {
+      let v = el.value.replace(/[^0-9]/g, '');
+      if (v) v = String(Math.min(parseInt(v, 10), MAX_SATS));
+      el.value = v;
+    });
+    return el;
+  }
+  const isLnInvoice = (v) => /^ln(bc|tb)[0-9]/i.test(v);
+  const isLnAddress = (v) => /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(v);
+
   // Build (or reuse) the NWC client for the active account from its stored string.
   async function ensureNwc() {
     const pk = state.activePubkey;
@@ -2207,11 +2248,29 @@
   }
 
   async function renderWalletConnected(view) {
-    // Balance card
+    // Balance card — show the last-known balance instantly, refresh below.
+    const cached = balanceCache.pubkey === state.activePubkey && balanceCache.sats != null;
     const card = h('div', { className: 'wallet-card' });
-    const bal = h('div', { className: 'wallet-balance', textContent: '—' });
+    const bal = h('div', {
+      className: 'wallet-balance' + (cached ? '' : ' loading'),
+      textContent: cached ? fmtSats(balanceCache.sats) : '…',
+    });
     const unit = h('div', { className: 'wallet-unit', textContent: 'sats' });
-    card.append(h('div', { className: 'wallet-bal-label', textContent: 'Balance' }), bal, unit);
+    const refresh = h('button', { className: 'wallet-refresh', title: 'Refresh' });
+    refresh.appendChild(icon('refresh'));
+    refresh.addEventListener('click', () => renderWallet());
+    // Privacy toggle on the balance card (masks balance, history, budgets).
+    const eye = h('button', { className: 'wallet-eye', title: hideBalances ? 'Show balances' : 'Hide balances' });
+    eye.appendChild(icon(hideBalances ? 'eye-off' : 'eye'));
+    eye.addEventListener('click', async () => {
+      hideBalances = !hideBalances;
+      await call({ type: 'SIDECAR_SET_SETTINGS', settings: { hideBalances } });
+      applyHideBalances();
+      eye.innerHTML = '';
+      eye.appendChild(icon(hideBalances ? 'eye-off' : 'eye'));
+      eye.title = hideBalances ? 'Show balances' : 'Hide balances';
+    });
+    card.append(eye, refresh, h('div', { className: 'wallet-bal-label', textContent: 'Balance' }), bal, unit);
     view.append(card);
 
     // Actions
@@ -2247,11 +2306,12 @@
     if (!client) { view.innerHTML = ''; renderWalletConnect(view); return; }
     try {
       const b = await client.getBalance();
-      bal.textContent = fmtSats(msatToSat(b && b.balance));
+      balanceCache = { pubkey: state.activePubkey, sats: msatToSat(b && b.balance) };
+      bal.textContent = fmtSats(balanceCache.sats);
     } catch (_) {
-      bal.textContent = '—';
-      unit.textContent = 'balance unavailable';
+      if (!cached) { bal.textContent = '—'; unit.textContent = 'balance unavailable'; }
     }
+    bal.classList.remove('loading');
     loadTransactions(txList, client);
   }
 
@@ -2394,12 +2454,15 @@
 
   function budgetRow(host, b) {
     const row = h('div', { className: 'item' });
+    const sub = h('div', { className: 'item-sub' }, [
+      h('span', { className: 'amt-hide', textContent: fmtSats(b.remainingSats) }),
+      document.createTextNode(' of '),
+      h('span', { className: 'amt-hide', textContent: fmtSats(b.budgetSats) }),
+      document.createTextNode(' sats left today'),
+    ]);
     const main = h('div', { className: 'item-main' }, [
       h('div', { className: 'item-label', textContent: host }),
-      h('div', {
-        className: 'item-sub',
-        textContent: fmtSats(b.remainingSats) + ' of ' + fmtSats(b.budgetSats) + ' sats left today',
-      }),
+      sub,
     ]);
     const rm = iconButton('Revoke budget', 'trash', async () => {
       await call({ type: 'SIDECAR_REVOKE_BUDGET', host });
@@ -2412,29 +2475,43 @@
   function sendModal() {
     openModal((modal) => {
       const input = h('textarea', { className: 'compose-text', placeholder: 'Lightning invoice (lnbc…) or lightning address' });
-      const amount = h('input', { type: 'number', min: '1', placeholder: 'Amount in sats (for lightning addresses)' });
+      const amountLabel = h('label', { className: 'hidden', textContent: 'Amount (sats)' });
+      const amount = satsInput('Amount in sats');
+      amount.classList.add('hidden');
       const err = h('div', { className: 'error' });
       const pay = h('button', { className: 'primary', textContent: 'Pay' });
       const cancel = h('button', { className: 'ghost', textContent: 'Cancel' });
       cancel.addEventListener('click', closeModal);
+
+      // Auto-detect: only a lightning address needs an amount (invoices carry it).
+      function detect() {
+        const v = input.value.replace(/^lightning:/i, '').trim();
+        const needsAmount = isLnAddress(v) && !isLnInvoice(v);
+        amount.classList.toggle('hidden', !needsAmount);
+        amountLabel.classList.toggle('hidden', !needsAmount);
+      }
+      input.addEventListener('input', detect);
+
       pay.addEventListener('click', async () => {
-        const val = input.value.trim();
+        const val = input.value.replace(/^lightning:/i, '').trim();
         if (!val) return (err.textContent = 'Paste an invoice or lightning address.');
         err.textContent = '';
-        pay.disabled = true;
-        pay.textContent = 'Paying…';
         try {
           const client = await ensureNwc();
-          let invoice = val.replace(/^lightning:/i, '').trim();
-          // Lightning address (user@domain) → resolve to a BOLT11 invoice via LNURL-pay.
-          if (!/^ln(bc|tb)/i.test(invoice)) {
-            if (!/^[^@\s]+@[^@\s]+$/.test(invoice)) {
-              throw new Error('Enter a BOLT11 invoice (lnbc…) or a lightning address.');
-            }
+          let invoice = val;
+          if (isLnInvoice(val)) {
+            // BOLT11 — amount is already in the invoice.
+          } else if (isLnAddress(val)) {
             const sats = parseInt(amount.value, 10);
-            if (!sats || sats < 1) throw new Error('Enter an amount in sats for a lightning address.');
-            invoice = await lnAddressToInvoice(invoice, sats * 1000, 'Sidecar payment');
+            if (!sats || sats < 1) return (err.textContent = 'Enter an amount in sats.');
+            pay.disabled = true;
+            pay.textContent = 'Paying…';
+            invoice = await lnAddressToInvoice(val, sats * 1000, 'Sidecar payment');
+          } else {
+            return (err.textContent = 'Enter a BOLT11 invoice (lnbc…) or a lightning address.');
           }
+          pay.disabled = true;
+          pay.textContent = 'Paying…';
           await client.payInvoice(invoice);
           closeModal();
           toast('Payment sent', 'success');
@@ -2448,6 +2525,7 @@
       modal.append(
         h('h3', { textContent: 'Send' }),
         input,
+        amountLabel,
         amount,
         err,
         h('div', { className: 'actions' }, [pay, cancel])
@@ -2455,14 +2533,17 @@
     });
   }
 
-  const RECEIVE_PRESETS = [100, 1000, 5000, 21000, 100000];
+  const RECEIVE_PRESETS = [100, 1000, 5000, 10000];
 
   function receiveModal() {
     let pollTimer = null;
     const stopPoll = () => { if (pollTimer) { clearInterval(pollTimer); pollTimer = null; } };
 
     openModal((modal) => {
-      modal.append(h('h3', { textContent: 'Receive' }));
+      const xClose = h('button', { className: 'modal-x', title: 'Close' });
+      xClose.append(icon('x'));
+      xClose.addEventListener('click', closeModal);
+      modal.append(xClose, h('h3', { textContent: 'Receive' }));
 
       // Tabs: Invoice (always) + Lightning address (added if the profile has lud16).
       const tabs = h('div', { className: 'compose-tabs' });
@@ -2476,7 +2557,7 @@
         stopPoll();
         body.innerHTML = '';
         const presets = h('div', { className: 'amount-presets' });
-        const amount = h('input', { type: 'number', min: '1', placeholder: 'Amount in sats' });
+        const amount = satsInput('Amount in sats');
         const chipLabel = (n) => (n >= 1000 ? n / 1000 + 'K' : String(n));
         RECEIVE_PRESETS.forEach((p) => {
           const b = h('button', { className: 'preset-chip', textContent: chipLabel(p) });
@@ -2489,10 +2570,7 @@
         });
         const memo = h('input', { type: 'text', placeholder: 'Note (optional)' });
         const err = h('div', { className: 'error' });
-        const out = h('div', { className: 'recv-out' });
         const create = h('button', { className: 'primary', textContent: 'Create invoice' });
-        const cancel = h('button', { className: 'ghost', textContent: 'Cancel' });
-        cancel.addEventListener('click', closeModal);
         create.addEventListener('click', async () => {
           const sats = parseInt(amount.value, 10);
           if (!sats || sats < 1) return (err.textContent = 'Enter an amount in sats.');
@@ -2504,9 +2582,8 @@
             const res = await client.makeInvoice(sats * 1000, memo.value.trim());
             const invoice = res && (res.invoice || res.payment_request || res.bolt11);
             if (!invoice) throw new Error('Wallet returned no invoice');
-            showInvoice(out, invoice);
-            create.textContent = 'Create invoice';
-            create.disabled = false;
+            // Swap the whole form for the invoice + QR; the corner ✕ cancels.
+            showInvoice(body, invoice);
             // Poll for settlement so we can show a success state.
             const lookupArg = res.payment_hash ? { payment_hash: res.payment_hash } : { invoice };
             pollTimer = setInterval(async () => {
@@ -2532,8 +2609,7 @@
           h('label', { textContent: 'Note' }),
           memo,
           err,
-          h('div', { className: 'actions' }, [create, cancel]),
-          out
+          h('div', { className: 'actions' }, [create])
         );
       }
 
@@ -2553,9 +2629,7 @@
           } catch (_) {}
         });
         out.append(canvas, copy, h('p', { className: 'hint', textContent: 'Your reusable lightning address — anyone can pay it any amount.' }));
-        const cancel = h('button', { className: 'ghost', textContent: 'Close' });
-        cancel.addEventListener('click', closeModal);
-        body.append(out, h('div', { className: 'actions' }, [cancel]));
+        body.append(out);
       }
 
       tabInvoice.addEventListener('click', () => {
@@ -2597,12 +2671,15 @@
 
   function showInvoice(container, invoice) {
     container.innerHTML = '';
+    const out = h('div', { className: 'recv-out' });
     const canvas = document.createElement('canvas');
     canvas.className = 'recv-qr';
     try {
       new window.QRious({ element: canvas, value: invoice.toUpperCase(), size: 220, level: 'M' });
     } catch (_) {}
-    const copy = h('button', { className: 'secondary', textContent: 'Copy invoice' });
+    // Show a short middle-ellipsis of the invoice; the full string is on Copy.
+    const short = invoice.length > 36 ? invoice.slice(0, 22) + '…' + invoice.slice(-10) : invoice;
+    const copy = h('button', { className: 'secondary recv-copy', textContent: 'Copy invoice' });
     copy.addEventListener('click', async () => {
       try {
         await navigator.clipboard.writeText(invoice);
@@ -2611,7 +2688,8 @@
       } catch (_) {}
     });
     const waiting = h('div', { className: 'recv-waiting' }, [h('span', { className: 'recv-spinner' }), h('span', { textContent: 'Waiting for payment…' })]);
-    container.append(canvas, h('div', { className: 'recv-bolt', textContent: invoice }), copy, waiting);
+    out.append(canvas, h('div', { className: 'recv-bolt', textContent: short }), copy, waiting);
+    container.append(out);
   }
 
   function disconnectModal() {
@@ -2664,7 +2742,7 @@
 
       const logo = h('img', { className: 'about-logo', src: 'icons/sidecar-logo.svg', alt: 'Sidecar' });
       const creator = h('a', {
-        className: 'about-creator-link', textContent: CREATOR_HANDLE,
+        className: 'about-creator-link', textContent: shortNpub(CREATOR_NPUB),
         href: '#', target: '_blank', rel: 'noopener noreferrer',
       });
       // Open the creator's profile in the user's preferred client; resolve their
@@ -2689,8 +2767,6 @@
       );
     });
   }
-
-  const ZAP_MAX_SATS = 100000000; // 100M cap
 
   async function creatorZapModal() {
     const { has } = await call({ type: 'SIDECAR_HAS_NWC' });
@@ -2724,12 +2800,11 @@
       // Inline send via the connected NWC wallet.
       const err = h('div', { className: 'error' });
       const message = h('input', { type: 'text', placeholder: 'Message (optional)', value: 'Thanks for Sidecar! 🍸', maxLength: 200 });
-      const amount = h('input', { type: 'number', min: '1', max: String(ZAP_MAX_SATS), placeholder: 'sats' });
+      const amount = satsInput('sats');
       const send = h('button', { className: 'primary', textContent: 'Zap' });
       send.addEventListener('click', async () => {
         const sats = parseInt(amount.value, 10);
         if (!sats || sats < 1) return (err.textContent = 'Enter an amount in sats.');
-        if (sats > ZAP_MAX_SATS) return (err.textContent = 'Maximum is ' + fmtSats(ZAP_MAX_SATS) + ' sats.');
         err.textContent = '';
         send.disabled = true;
         send.textContent = 'Sending…';

--- a/styles.css
+++ b/styles.css
@@ -691,6 +691,10 @@ button:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(203, 161, 78, 0
 .countdown-num {
   position: absolute; inset: 0; display: flex; align-items: center; justify-content: center;
   font-family: var(--font-display); font-weight: 700; font-size: 28px; line-height: 1; color: var(--gold);
+  /* a lone counting digit reads best on the baseline; tabular keeps width steady
+     as it counts down (15 → 9 → 0) so it doesn't jiggle. */
+  font-variant-numeric: lining-nums tabular-nums;
+  font-feature-settings: 'lnum' 1, 'tnum' 1;
 }
 
 /* ===== wallet (NWC) ===== */
@@ -704,13 +708,19 @@ button:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(203, 161, 78, 0
 }
 
 .wallet-card {
-  position: relative;
+  position: sticky; top: 0; z-index: 5;
   text-align: center; padding: 22px 16px; border-radius: 16px; margin-bottom: 14px;
   background:
     radial-gradient(120% 120% at 50% 0%, rgba(203, 161, 78, 0.14), transparent 60%),
     linear-gradient(160deg, var(--velvet-1), var(--velvet-2));
   border: 1px solid var(--gold-soft); box-shadow: var(--sheen), var(--shadow-sm);
+  transition: padding 0.2s ease;
 }
+/* collapsed (scrolled) — slim sticky header; tap to scroll back to top */
+.wallet-card.compact { padding: 11px 16px; cursor: pointer; }
+.wallet-card.compact .wallet-bal-label,
+.wallet-card.compact .wallet-unit { display: none; }
+.wallet-card.compact .wallet-balance { font-size: 24px; margin: 0; line-height: 1; }
 .wallet-refresh {
   position: absolute; top: 10px; right: 10px;
   width: 30px; height: 30px; padding: 0; display: flex; align-items: center; justify-content: center;
@@ -727,7 +737,13 @@ button:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(203, 161, 78, 0
 .wallet-eye:hover { color: var(--gold); background: rgba(203, 161, 78, 0.12); }
 .wallet-eye svg { width: 16px; height: 16px; }
 .wallet-bal-label { font-size: 11px; letter-spacing: 0.05em; text-transform: uppercase; color: var(--muted); }
-.wallet-balance { font-family: var(--font-display); font-weight: 700; font-size: 40px; line-height: 1.1; color: var(--gold); margin: 4px 0 0; }
+.wallet-balance {
+  font-family: var(--font-display); font-weight: 700; font-size: 40px; line-height: 1; color: var(--gold);
+  margin: 6px 0 4px; transition: font-size 0.2s ease;
+  /* Keep Playfair's oldstyle figures, but nudge the numerals up so their
+     descenders (3/4/7…) don't make the number look like it sags. */
+  transform: translateY(-0.08em);
+}
 .wallet-balance.loading { animation: balance-pulse 1.1s ease-in-out infinite; }
 @keyframes balance-pulse { 0%, 100% { opacity: 0.35; } 50% { opacity: 1; } }
 .wallet-unit { font-size: 13px; color: var(--muted); }

--- a/styles.css
+++ b/styles.css
@@ -695,15 +695,41 @@ button:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(203, 161, 78, 0
 
 /* ===== wallet (NWC) ===== */
 .nwc-input { min-height: 84px; font-family: var(--font-mono); font-size: 12px; margin-bottom: 4px; }
+/* privacy masking — masks each glyph at its real width, so toggling never reflows */
+.balances-hidden .wallet-balance,
+.balances-hidden .tx-amt,
+.balances-hidden .amt-hide {
+  -webkit-text-security: disc;
+  text-security: disc;
+}
+
 .wallet-card {
+  position: relative;
   text-align: center; padding: 22px 16px; border-radius: 16px; margin-bottom: 14px;
   background:
     radial-gradient(120% 120% at 50% 0%, rgba(203, 161, 78, 0.14), transparent 60%),
     linear-gradient(160deg, var(--velvet-1), var(--velvet-2));
   border: 1px solid var(--gold-soft); box-shadow: var(--sheen), var(--shadow-sm);
 }
+.wallet-refresh {
+  position: absolute; top: 10px; right: 10px;
+  width: 30px; height: 30px; padding: 0; display: flex; align-items: center; justify-content: center;
+  background: none; border: none; border-radius: 8px; color: var(--muted); cursor: pointer;
+}
+.wallet-refresh:hover { color: var(--gold); background: rgba(203, 161, 78, 0.12); }
+.wallet-refresh:active svg { transform: rotate(-180deg); }
+.wallet-refresh svg { width: 16px; height: 16px; transition: transform 0.3s ease; }
+.wallet-eye {
+  position: absolute; top: 10px; left: 10px;
+  width: 30px; height: 30px; padding: 0; display: flex; align-items: center; justify-content: center;
+  background: none; border: none; border-radius: 8px; color: var(--muted); cursor: pointer;
+}
+.wallet-eye:hover { color: var(--gold); background: rgba(203, 161, 78, 0.12); }
+.wallet-eye svg { width: 16px; height: 16px; }
 .wallet-bal-label { font-size: 11px; letter-spacing: 0.05em; text-transform: uppercase; color: var(--muted); }
 .wallet-balance { font-family: var(--font-display); font-weight: 700; font-size: 40px; line-height: 1.1; color: var(--gold); margin: 4px 0 0; }
+.wallet-balance.loading { animation: balance-pulse 1.1s ease-in-out infinite; }
+@keyframes balance-pulse { 0%, 100% { opacity: 0.35; } 50% { opacity: 1; } }
 .wallet-unit { font-size: 13px; color: var(--muted); }
 .wallet-actions { display: flex; gap: 10px; margin-bottom: 20px; }
 .wallet-actions button { flex: 1; }
@@ -716,9 +742,14 @@ button:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(203, 161, 78, 0
 .tx-amt { font-family: var(--font-mono); font-size: 13px; font-weight: 600; flex-shrink: 0; }
 .tx-amt.in { color: #6ee7a8; }
 .tx-amt.out { color: var(--lav); }
-.recv-out { display: flex; flex-direction: column; align-items: center; gap: 10px; margin-top: 14px; }
-.recv-qr { background: #fff; border-radius: 12px; padding: 10px; width: 200px; height: 200px; }
-.recv-bolt { font-family: var(--font-mono); font-size: 10.5px; color: var(--muted); word-break: break-all; max-width: 100%; text-align: center; }
+.recv-out { display: flex; flex-direction: column; align-items: center; gap: 12px; margin-top: 16px; }
+.recv-qr { background: #fff; border-radius: 12px; padding: 10px; width: 220px; height: 220px; }
+.recv-bolt {
+  font-family: var(--font-mono); font-size: 12px; color: var(--muted); text-align: center;
+  padding: 7px 12px; border-radius: 8px; border: 1px solid var(--border);
+  background: rgba(8, 2, 20, 0.4); max-width: 100%;
+}
+.recv-copy { width: 100%; }
 
 /* centered loading/empty/error state inside list cards */
 .list-state { text-align: center; padding: 24px 14px; margin: 0; color: var(--faint); font-size: 13px; }
@@ -768,7 +799,7 @@ button:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(203, 161, 78, 0
   animation: recv-spin 0.8s linear infinite;
 }
 @keyframes recv-spin { to { transform: rotate(360deg); } }
-.recv-success { display: flex; flex-direction: column; align-items: center; gap: 8px; padding: 18px 0 6px; }
+.recv-success { display: flex; flex-direction: column; align-items: center; gap: 8px; padding: 18px 0 0; margin-bottom: 24px; }
 .recv-check {
   width: 56px; height: 56px; border-radius: 50%; display: flex; align-items: center; justify-content: center;
   color: #1a0d33; background: #6ee7a8; box-shadow: 0 0 0 6px rgba(110, 231, 168, 0.16);

--- a/wallet-budgets.js
+++ b/wallet-budgets.js
@@ -1,0 +1,111 @@
+// Sidecar WebLN spending budgets — per-ACCOUNT, per-site payment allowances.
+//
+// Inspired by Alby's allowance model, adapted for NWC + Sidecar's per-site
+// account binding. A site that has a budget can pay without a prompt until the
+// running balance runs out (or a single payment exceeds the per-payment cap);
+// then the next sendPayment prompts again. Budgets refill on a daily window.
+//
+// Storage: sidecar_wallet_budgets = { <pubkey>: { <host>: {
+//   budgetSats,        // total per window (0 = always prompt)
+//   remainingSats,     // left in the current window
+//   perPaymentSats,    // max single payment without a prompt (0 = no cap)
+//   resetAt,           // ms timestamp when the window refills
+//   updatedAt
+// } } }
+
+(function (root) {
+  'use strict';
+
+  const KEY = 'sidecar_wallet_budgets';
+  const DAY_MS = 24 * 60 * 60 * 1000;
+
+  function get(keys) {
+    return new Promise((resolve) => chrome.storage.local.get(keys, resolve));
+  }
+  function set(obj) {
+    return new Promise((resolve) => chrome.storage.local.set(obj, resolve));
+  }
+  async function loadRoot() {
+    return (await get(KEY))[KEY] || {};
+  }
+
+  // Apply the daily refill if the window has elapsed. Mutates `rec` in place and
+  // returns whether anything changed (so callers can persist).
+  function applyReset(rec, now) {
+    if (rec.budgetSats > 0 && rec.resetAt && now >= rec.resetAt) {
+      rec.remainingSats = rec.budgetSats;
+      rec.resetAt = now + DAY_MS;
+      return true;
+    }
+    return false;
+  }
+
+  async function getBudget(pubkey, host) {
+    const rootMap = await loadRoot();
+    const rec = rootMap[pubkey] && rootMap[pubkey][host];
+    if (!rec) return null;
+    const now = Date.now();
+    if (applyReset(rec, now)) await set({ [KEY]: rootMap });
+    return rec;
+  }
+
+  // Create/replace a site's budget. Resets the remaining balance and window.
+  async function setBudget(pubkey, host, { budgetSats, perPaymentSats }) {
+    const rootMap = await loadRoot();
+    if (!rootMap[pubkey]) rootMap[pubkey] = {};
+    const now = Date.now();
+    rootMap[pubkey][host] = {
+      budgetSats: Math.max(0, Math.floor(budgetSats || 0)),
+      remainingSats: Math.max(0, Math.floor(budgetSats || 0)),
+      perPaymentSats: Math.max(0, Math.floor(perPaymentSats || 0)),
+      resetAt: now + DAY_MS,
+      updatedAt: now,
+    };
+    await set({ [KEY]: rootMap });
+    return rootMap[pubkey][host];
+  }
+
+  // True if `sats` can be paid from the current budget without a prompt.
+  async function covers(pubkey, host, sats) {
+    const rec = await getBudget(pubkey, host);
+    if (!rec || rec.budgetSats <= 0) return false;
+    if (rec.perPaymentSats > 0 && sats > rec.perPaymentSats) return false;
+    return rec.remainingSats >= sats;
+  }
+
+  // Decrement the remaining balance after a successful payment.
+  async function consume(pubkey, host, sats) {
+    const rootMap = await loadRoot();
+    const rec = rootMap[pubkey] && rootMap[pubkey][host];
+    if (!rec) return;
+    applyReset(rec, Date.now());
+    rec.remainingSats = Math.max(0, rec.remainingSats - Math.floor(sats || 0));
+    await set({ [KEY]: rootMap });
+  }
+
+  async function revoke(pubkey, host) {
+    const rootMap = await loadRoot();
+    if (rootMap[pubkey]) delete rootMap[pubkey][host];
+    await set({ [KEY]: rootMap });
+    return rootMap[pubkey] || {};
+  }
+
+  // All budgets for an account (for the UI). Applies any pending resets.
+  async function getAll(pubkey) {
+    const rootMap = await loadRoot();
+    const m = rootMap[pubkey] || {};
+    let changed = false;
+    const now = Date.now();
+    for (const host of Object.keys(m)) if (applyReset(m[host], now)) changed = true;
+    if (changed) await set({ [KEY]: rootMap });
+    return m;
+  }
+
+  async function clearAccount(pubkey) {
+    const rootMap = await loadRoot();
+    delete rootMap[pubkey];
+    await set({ [KEY]: rootMap });
+  }
+
+  root.SidecarBudgets = { getBudget, setBudget, covers, consume, revoke, getAll, clearAccount };
+})(typeof self !== 'undefined' ? self : this);


### PR DESCRIPTION
Adds `window.webln` backed by the connected NWC wallet (enable/getInfo/getBalance/makeInvoice/sendPayment), per-site spending budgets with approval prompt, and wallet UX: balance cache/refresh, collapsing card, hide toggle, receive redesign, send address auto-detect + LNURL.

Heads-up: overlaps `feat/sidebar-approval` (inline approvals) in background.js / sidepanel.* — expect conflicts on whichever merges second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)