### PR TITLE
Inline approvals + WebLN approval UI

### DIFF
--- a/background.js
+++ b/background.js
@@ -122,17 +122,35 @@ chrome.runtime.onConnect.addListener((port) => {
   });
 });
 
+// A page RPC can wake a fresh worker before the open side panel has reconnected
+// its port to this instance. Without waiting, panelPort is null and we'd wrongly
+// open a popup while the panel is sitting right there. Give the panel a brief
+// moment to (re)connect; if it's genuinely closed, nothing connects and we
+// fall through to the popup.
+function waitForPanelPort(ms) {
+  if (panelPort) return Promise.resolve(panelPort);
+  return new Promise((resolve) => {
+    const deadline = Date.now() + ms;
+    const tick = () => {
+      if (panelPort || Date.now() >= deadline) return resolve(panelPort);
+      setTimeout(tick, 40);
+    };
+    tick();
+  });
+}
+
 function openPrompt(data) {
   // Chain onto the mutex: each prompt waits for the previous to finish.
   const run = () =>
-    new Promise((resolve) => {
+    new Promise(async (resolve) => {
       const promptId = 'p_' + Date.now() + '_' + Math.random().toString(36).slice(2);
 
       // Panel open → render inline; the panel decides via SIDECAR_PROMPT_RESULT.
-      if (panelPort) {
+      const port = await waitForPanelPort(600);
+      if (port) {
         pendingPrompts.set(promptId, { resolve, windowId: null, data, settled: false });
         try {
-          panelPort.postMessage({ type: 'SIDECAR_PANEL_APPROVAL', id: promptId, data });
+          port.postMessage({ type: 'SIDECAR_PANEL_APPROVAL', id: promptId, data });
           return;
         } catch (_) {
           // Port died between the check and post; fall through to the popup.
@@ -240,6 +258,7 @@ async function handleNostrRpc(method, params, host, sendResponse) {
         activePubkey,
         npub: self.NostrTools.nip19.npubEncode(activePubkey),
         accountName: (acct && acct.name) || '',
+        accountPicture: (acct && acct.picture) || '',
         needUnlock,
         needApproval,
         level: await PERMS.getLevel(activePubkey, host),
@@ -319,6 +338,7 @@ async function weblnUnlockGate(host, method, pubkey) {
     method: 'webln.' + method,
     npub: self.NostrTools.nip19.npubEncode(pubkey),
     accountName: (acct && acct.name) || '',
+        accountPicture: (acct && acct.picture) || '',
     needUnlock: true,
     needApproval: false,
   });
@@ -408,6 +428,7 @@ async function weblnSendPayment(params, host, pubkey) {
       method: 'sendPayment',
       npub: self.NostrTools.nip19.npubEncode(pubkey),
       accountName: (acct && acct.name) || '',
+        accountPicture: (acct && acct.picture) || '',
       amountSats: sats, // null for amountless invoices
       memo: (params && params.memo) || '',
       needUnlock: KS.isLocked(),

--- a/background.js
+++ b/background.js
@@ -100,11 +100,47 @@ chrome.action.onClicked.addListener((tab) => {
 const pendingPrompts = new Map(); // promptId -> { resolve, windowId, data, settled }
 let promptMutex = Promise.resolve(); // serialize prompts so only one window is open
 
+// The side panel keeps a long-lived port open while it's visible. When it's open
+// we render approvals inline in the panel (it can't get lost behind a window);
+// when it's closed we fall back to the popup window below — Chrome only lets us
+// open the side panel from a user gesture, so the worker can't force it open.
+let panelPort = null;
+chrome.runtime.onConnect.addListener((port) => {
+  if (port.name !== 'sidepanel') return;
+  panelPort = port;
+  port.onDisconnect.addListener(() => {
+    if (panelPort === port) panelPort = null;
+    // Closing the panel mid-approval would otherwise leave the page hanging;
+    // reject any inline (windowless) prompts that were awaiting a decision.
+    for (const [id, p] of pendingPrompts) {
+      if (p.windowId == null && !p.settled) {
+        p.settled = true;
+        pendingPrompts.delete(id);
+        p.resolve({ action: 'reject' });
+      }
+    }
+  });
+});
+
 function openPrompt(data) {
   // Chain onto the mutex: each prompt waits for the previous to finish.
   const run = () =>
     new Promise((resolve) => {
       const promptId = 'p_' + Date.now() + '_' + Math.random().toString(36).slice(2);
+
+      // Panel open → render inline; the panel decides via SIDECAR_PROMPT_RESULT.
+      if (panelPort) {
+        pendingPrompts.set(promptId, { resolve, windowId: null, data, settled: false });
+        try {
+          panelPort.postMessage({ type: 'SIDECAR_PANEL_APPROVAL', id: promptId, data });
+          return;
+        } catch (_) {
+          // Port died between the check and post; fall through to the popup.
+          pendingPrompts.delete(promptId);
+          panelPort = null;
+        }
+      }
+
       const W = 440;
       const H = 600;
       chrome.windows.getCurrent((cur) => {

--- a/content.js
+++ b/content.js
@@ -28,20 +28,26 @@
     const type = SCOPE_TO_TYPE[d.scope];
     if (!type) return;
 
+    // Always answer the page exactly once. If the service worker dies mid-request
+    // (MV3 recycles it) the callback may never fire, which would hang the page's
+    // window.nostr/webln promise — so a timeout guarantees a (failed) response.
+    let replied = false;
+    function reply(response) {
+      if (replied) return;
+      replied = true;
+      clearTimeout(timer);
+      window.postMessage({ ext: 'sidecar', scope: d.scope, kind: 'response', id: d.id, response }, '*');
+    }
+    const timer = setTimeout(
+      () => reply({ ok: false, error: 'Sidecar did not respond (timed out). Try again.' }),
+      180000
+    );
+
     chrome.runtime.sendMessage(
       { type, scope: d.scope, method: d.method, params: d.params, host },
       function (response) {
         const err = chrome.runtime.lastError;
-        window.postMessage(
-          {
-            ext: 'sidecar',
-            scope: d.scope,
-            kind: 'response',
-            id: d.id,
-            response: err ? { ok: false, error: err.message } : response,
-          },
-          '*'
-        );
+        reply(err ? { ok: false, error: err.message } : response);
       }
     );
   });

--- a/prompt.html
+++ b/prompt.html
@@ -42,7 +42,8 @@
       background-repeat: repeat, no-repeat, no-repeat, no-repeat;
       background-attachment: fixed;
     }
-    .brand { display: flex; align-items: center; margin-bottom: 18px; }
+    body { text-align: center; }
+    .brand { display: flex; align-items: center; justify-content: center; margin-bottom: 18px; }
     .brand img { height: 26px; width: auto; display: block; filter: drop-shadow(0 2px 8px rgba(0, 0, 0, 0.4)); }
     .host {
       font-family: var(--font-display); font-weight: 700;
@@ -51,7 +52,7 @@
     }
     .ask { font-size: 14px; color: var(--muted); margin-bottom: 18px; }
     .card {
-      position: relative;
+      position: relative; text-align: left;
       background: linear-gradient(160deg, var(--velvet-1), var(--velvet-2));
       border: 1px solid var(--border); border-radius: 12px;
       padding: 13px; margin-bottom: 16px; font-size: 13px;
@@ -66,9 +67,17 @@
       font-size: 12px; white-space: pre-wrap; word-break: break-word;
       max-height: 160px; overflow: auto; color: var(--text);
     }
-    .account { font-size: 13px; color: var(--muted); margin-bottom: 18px; }
-    .account b { color: var(--lav); }
-    .account .acct-npub { font-family: var(--font-mono); font-size: 11.5px; color: var(--faint); margin-left: 2px; }
+    .account { margin-bottom: 18px; }
+    .as-label { font-size: 10.5px; color: var(--muted); margin-bottom: 8px; text-transform: uppercase; letter-spacing: 0.22em; }
+    .acct-capsule {
+      display: flex; align-items: center; justify-content: center; gap: 12px;
+      background: linear-gradient(150deg, var(--velvet-1), var(--velvet-2));
+      border: 1px solid var(--border); border-radius: 14px; padding: 12px 14px; box-shadow: var(--sheen);
+    }
+    .acct-av { width: 46px; height: 46px; border-radius: 50%; object-fit: cover; flex-shrink: 0; background: #2a1257; box-shadow: 0 0 0 1px var(--gold-soft); }
+    .acct-meta { min-width: 0; text-align: center; }
+    .acct-name { font-family: var(--font-display); font-weight: 700; font-size: 17px; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .acct-np { font-family: var(--font-mono); font-size: 11.5px; color: var(--faint); margin-top: 4px; word-break: break-all; }
     label { display: block; font-size: 12px; letter-spacing: 0.03em; color: var(--muted); margin: 0 0 6px; }
     input[type=password] {
       width: 100%; padding: 11px 13px; border-radius: 10px; border: 1px solid var(--border);
@@ -78,9 +87,9 @@
     }
     input[type=password]:focus { outline: none; border-color: var(--gold-soft); box-shadow: 0 0 0 3px rgba(203, 161, 78, 0.16); }
     .remember { margin-bottom: 14px; }
-    .remember .check { display: flex; align-items: center; gap: 8px; color: var(--text); font-size: 13px; text-transform: none; letter-spacing: 0; margin-bottom: 8px; cursor: pointer; }
+    .remember .check { display: flex; align-items: center; justify-content: center; gap: 8px; color: var(--text); font-size: 13px; text-transform: none; letter-spacing: 0; margin-bottom: 8px; cursor: pointer; }
     .remember input[type=checkbox] { width: 16px; height: 16px; accent-color: var(--orange); cursor: pointer; }
-    .budget-row { display: flex; align-items: center; gap: 8px; }
+    .budget-row { display: flex; align-items: center; justify-content: center; gap: 8px; }
     .remember input[type=number] {
       width: 110px; padding: 9px 11px; border-radius: 10px; border: 1px solid var(--border);
       background: linear-gradient(180deg, rgba(8, 2, 20, 0.6), rgba(20, 4, 40, 0.6));
@@ -101,6 +110,11 @@
       box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35), 0 8px 22px rgba(234, 119, 47, 0.28);
     }
     .primary:hover { filter: brightness(1.06); transform: translateY(-1px); }
+    .lav-btn {
+      background: linear-gradient(180deg, #cebfff, var(--lav) 58%, var(--purple)); color: #190a33;
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 8px 22px rgba(167, 139, 250, 0.24);
+    }
+    .lav-btn:hover { filter: brightness(1.05); transform: translateY(-1px); }
     .secondary {
       background: linear-gradient(180deg, var(--velvet-1), var(--velvet-2));
       color: var(--text); border: 1px solid var(--border); box-shadow: var(--sheen);
@@ -137,7 +151,7 @@
 
   <div class="actions">
     <button class="primary" id="allow">Allow once</button>
-    <button class="secondary" id="trust">Trust this site</button>
+    <button class="lav-btn" id="trust">Trust this site</button>
     <button class="ghost" id="reject">Reject</button>
   </div>
 

--- a/prompt.js
+++ b/prompt.js
@@ -102,11 +102,7 @@
     els.host.textContent = data.host;
     const verb = isPayment ? 'wants to send a Lightning payment' : 'wants to ' + (METHOD_LABELS[data.method] || data.method);
     els.ask.textContent = verb;
-    els.account.innerHTML =
-      (isPayment ? 'Paying from <b>' : 'Signing as <b>') +
-      escapeHtml(data.accountName || shortNpub(data.npub)) +
-      '</b>' +
-      (data.accountName ? ' <span class="acct-npub">' + escapeHtml(shortNpub(data.npub)) + '</span>' : '');
+    buildAccountCapsule();
     renderPreview();
 
     if (data.needUnlock) {
@@ -142,6 +138,32 @@
   function shortNpub(npub) {
     if (!npub) return '—';
     return npub.length > 20 ? npub.slice(0, 12) + '…' + npub.slice(-6) : npub;
+  }
+
+  // Account capsule (pfp + name + npub), matching the side panel's account card.
+  function buildAccountCapsule() {
+    els.account.innerHTML = '';
+    const label = document.createElement('div');
+    label.className = 'as-label';
+    label.textContent = isPayment ? 'Paying from' : 'Signing as';
+    const av = document.createElement('img');
+    av.className = 'acct-av';
+    av.referrerPolicy = 'no-referrer';
+    av.onerror = () => { av.onerror = null; av.src = 'icons/avatar-default.svg'; };
+    av.src = data.accountPicture || 'icons/avatar-default.svg';
+    const name = document.createElement('div');
+    name.className = 'acct-name';
+    name.textContent = data.accountName || shortNpub(data.npub);
+    const np = document.createElement('div');
+    np.className = 'acct-np';
+    np.textContent = shortNpub(data.npub);
+    const meta = document.createElement('div');
+    meta.className = 'acct-meta';
+    meta.append(name, np);
+    const cap = document.createElement('div');
+    cap.className = 'acct-capsule';
+    cap.append(av, meta);
+    els.account.append(label, cap);
   }
 
   async function decide(action) {

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -200,6 +200,14 @@
       <input type="password" id="approval-pin" autocomplete="off" maxlength="32" />
     </div>
 
+    <div id="approval-remember" class="remember hidden">
+      <label class="check"><input type="checkbox" id="approval-remember-budget" /> Allow this site to spend up to</label>
+      <div class="budget-row">
+        <input type="text" inputmode="numeric" id="approval-budget-amount" placeholder="sats" />
+        <span class="budget-unit">sats / day without asking</span>
+      </div>
+    </div>
+
     <div class="error" id="approval-error"></div>
 
     <div class="approval-actions">

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -184,38 +184,38 @@
   </section>
 
   <!-- ===== Signing approval (inline, replaces the popup when the panel is open) ===== -->
-  <section id="view-approval" class="screen hidden">
-    <div class="brand-lg">
-      <img class="brand-logo" src="icons/sidecar-logo.svg" alt="Sidecar" />
-    </div>
-    <div class="approval-host" id="approval-host">…</div>
-    <div class="approval-ask" id="approval-ask">wants to…</div>
+  <div id="view-approval" class="approval-overlay hidden">
+    <div class="approval-card">
+      <div class="brand"><img class="brand-logo-sm" src="icons/sidecar-logo.svg" alt="Sidecar" /></div>
+      <div class="approval-host" id="approval-host">…</div>
+      <div class="approval-ask" id="approval-ask">wants to…</div>
 
-    <div id="approval-preview" class="card hidden"></div>
+      <div id="approval-preview" class="card hidden"></div>
 
-    <div class="approval-account" id="approval-account"></div>
+      <div class="approval-account" id="approval-account"></div>
 
-    <div id="approval-unlock" class="hidden stack">
-      <label for="approval-pin">Enter your PIN to unlock</label>
-      <input type="password" id="approval-pin" autocomplete="off" maxlength="32" />
-    </div>
+      <div id="approval-unlock" class="hidden stack">
+        <label for="approval-pin">Enter your PIN to unlock</label>
+        <input type="password" id="approval-pin" autocomplete="off" maxlength="32" />
+      </div>
 
-    <div id="approval-remember" class="remember hidden">
-      <label class="check"><input type="checkbox" id="approval-remember-budget" /> Allow this site to spend up to</label>
-      <div class="budget-row">
-        <input type="text" inputmode="numeric" id="approval-budget-amount" placeholder="sats" />
-        <span class="budget-unit">sats / day without asking</span>
+      <div id="approval-remember" class="remember hidden">
+        <label class="check"><input type="checkbox" id="approval-remember-budget" /> Allow this site to spend up to</label>
+        <div class="budget-row">
+          <input type="text" inputmode="numeric" id="approval-budget-amount" placeholder="sats" />
+          <span class="budget-unit">sats / day without asking</span>
+        </div>
+      </div>
+
+      <div class="error" id="approval-error"></div>
+
+      <div class="approval-actions">
+        <button class="primary" id="approval-allow">Allow once</button>
+        <button class="lav-btn" id="approval-trust">Trust this site</button>
+        <button class="ghost" id="approval-reject">Reject</button>
       </div>
     </div>
-
-    <div class="error" id="approval-error"></div>
-
-    <div class="approval-actions">
-      <button class="primary" id="approval-allow">Allow once</button>
-      <button class="secondary" id="approval-trust">Trust this site</button>
-      <button class="ghost" id="approval-reject">Reject</button>
-    </div>
-  </section>
+  </div>
 
   <!-- ===== Modal host ===== -->
   <div id="modal-overlay" class="modal-overlay hidden">

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -183,6 +183,32 @@
     </main>
   </section>
 
+  <!-- ===== Signing approval (inline, replaces the popup when the panel is open) ===== -->
+  <section id="view-approval" class="screen hidden">
+    <div class="brand-lg">
+      <img class="brand-logo" src="icons/sidecar-logo.svg" alt="Sidecar" />
+    </div>
+    <div class="approval-host" id="approval-host">…</div>
+    <div class="approval-ask" id="approval-ask">wants to…</div>
+
+    <div id="approval-preview" class="card hidden"></div>
+
+    <div class="approval-account" id="approval-account"></div>
+
+    <div id="approval-unlock" class="hidden stack">
+      <label for="approval-pin">Enter your PIN to unlock</label>
+      <input type="password" id="approval-pin" autocomplete="off" maxlength="32" />
+    </div>
+
+    <div class="error" id="approval-error"></div>
+
+    <div class="approval-actions">
+      <button class="primary" id="approval-allow">Allow once</button>
+      <button class="secondary" id="approval-trust">Trust this site</button>
+      <button class="ghost" id="approval-reject">Reject</button>
+    </div>
+  </section>
+
   <!-- ===== Modal host ===== -->
   <div id="modal-overlay" class="modal-overlay hidden">
     <div class="modal" id="modal"></div>

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -2931,14 +2931,22 @@
     'nip04.decrypt': 'decrypt a message (NIP-04)',
     'nip44.encrypt': 'encrypt a message (NIP-44)',
     'nip44.decrypt': 'decrypt a message (NIP-44)',
+    'webln.getInfo': 'see your wallet info',
+    'webln.getBalance': 'see your wallet balance',
+    'webln.makeInvoice': 'create a Lightning invoice',
   };
+
+  const isPaymentApproval = (data) => data.scope === 'webln' && data.method === 'sendPayment';
 
   function renderApprovalPreview(data) {
     const box = $('approval-preview');
     box.innerHTML = '';
     const row = (k, v) =>
       h('div', { className: 'row' }, [h('span', { textContent: k }), h('span', { textContent: v })]);
-    if (data.method === 'signEvent') {
+    if (isPaymentApproval(data)) {
+      box.append(row('Amount', data.amountSats != null ? fmtSats(data.amountSats) + ' sats' : 'set by invoice'));
+      if (data.memo) box.append(row('Memo', String(data.memo)));
+    } else if (data.method === 'signEvent') {
       const ev = (data.params && (data.params.event || data.params)) || {};
       box.append(row('Kind', String(ev.kind ?? '—')));
       if (Array.isArray(ev.tags)) box.append(row('Tags', String(ev.tags.length)));
@@ -2961,12 +2969,15 @@
     [$('view-onboarding'), $('view-lock'), $('view-main'), $('view-settings'), $('view-profile-edit')].forEach(hide);
     show($('view-approval'));
 
+    const payment = isPaymentApproval(data);
     $('approval-host').textContent = data.host;
-    $('approval-ask').textContent = 'wants to ' + (APPROVAL_METHOD_LABELS[data.method] || data.method);
+    $('approval-ask').textContent = payment
+      ? 'wants to send a Lightning payment'
+      : 'wants to ' + (APPROVAL_METHOD_LABELS[data.method] || data.method);
 
     const acct = $('approval-account');
     acct.innerHTML = '';
-    acct.append(document.createTextNode('Signing as '));
+    acct.append(document.createTextNode(payment ? 'Paying from ' : 'Signing as '));
     acct.append(h('b', { textContent: data.accountName || shortNpub(data.npub) }));
     if (data.accountName) acct.append(h('span', { className: 'acct-npub', textContent: shortNpub(data.npub) }));
 
@@ -2983,14 +2994,33 @@
     } else {
       hide($('approval-unlock'));
     }
-    // A pure unlock (site already trusted, keystore just locked) has nothing to
-    // approve — relabel and drop the "Trust this site" choice.
-    if (data.needUnlock && !data.needApproval) {
-      allow.textContent = 'Unlock & continue';
+
+    // Payment: one Pay button + an optional "remember a budget" toggle (no Trust).
+    const remember = $('approval-remember');
+    const rememberBudget = $('approval-remember-budget');
+    const budgetAmount = $('approval-budget-amount');
+    if (payment) {
+      allow.textContent = data.amountSats != null ? 'Pay ' + fmtSats(data.amountSats) + ' sats' : 'Pay';
       hide(trust);
+      show(remember);
+      rememberBudget.checked = false;
+      budgetAmount.value = String(data.amountSats != null ? Math.max(data.amountSats * 5, 5000) : 5000);
+      budgetAmount.disabled = true;
+      rememberBudget.onchange = () => {
+        budgetAmount.disabled = !rememberBudget.checked;
+        if (rememberBudget.checked) budgetAmount.focus();
+      };
     } else {
-      allow.textContent = 'Allow once';
-      show(trust);
+      hide(remember);
+      // A pure unlock (site already trusted, keystore just locked) has nothing to
+      // approve — relabel and drop the "Trust this site" choice.
+      if (data.needUnlock && !data.needApproval) {
+        allow.textContent = 'Unlock & continue';
+        hide(trust);
+      } else {
+        allow.textContent = 'Allow once';
+        show(trust);
+      }
     }
   }
 
@@ -3014,7 +3044,18 @@
         return;
       }
     }
-    await bg({ type: 'SIDECAR_PROMPT_RESULT', id, action });
+    let extra = null;
+    // Payment + "remember a budget" checked → set an allowance for this site.
+    if (isPaymentApproval(data) && action === 'once' && $('approval-remember-budget').checked) {
+      const budgetSats = parseInt($('approval-budget-amount').value, 10);
+      if (!budgetSats || budgetSats < 1) {
+        err.textContent = 'Enter a budget in sats, or uncheck the box.';
+        return;
+      }
+      action = 'budget';
+      extra = { budgetSats, perPaymentSats: 0 };
+    }
+    await bg({ type: 'SIDECAR_PROMPT_RESULT', id, action, extra });
     pendingApproval = null;
     $('approval-pin').value = '';
     refresh(); // back to the normal view (now unlocked, if we just unlocked)
@@ -3025,6 +3066,12 @@
   $('approval-reject').addEventListener('click', () => decideApproval('reject'));
   $('approval-pin').addEventListener('keydown', (e) => {
     if (e.key === 'Enter') decideApproval('once');
+  });
+  // Numeric-only, capped budget input (static element, so not built via satsInput).
+  $('approval-budget-amount').addEventListener('input', (e) => {
+    let v = e.target.value.replace(/[^0-9]/g, '');
+    if (v) v = String(Math.min(parseInt(v, 10), MAX_SATS));
+    e.target.value = v;
   });
 
   try {

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -2966,7 +2966,7 @@
     if (!pendingApproval) return;
     const data = pendingApproval.data;
     closeAcctMenu();
-    [$('view-onboarding'), $('view-lock'), $('view-main'), $('view-settings'), $('view-profile-edit')].forEach(hide);
+    // Overlay on top of whatever's showing — don't hide the base view.
     show($('view-approval'));
 
     const payment = isPaymentApproval(data);
@@ -2977,9 +2977,16 @@
 
     const acct = $('approval-account');
     acct.innerHTML = '';
-    acct.append(document.createTextNode(payment ? 'Paying from ' : 'Signing as '));
-    acct.append(h('b', { textContent: data.accountName || shortNpub(data.npub) }));
-    if (data.accountName) acct.append(h('span', { className: 'acct-npub', textContent: shortNpub(data.npub) }));
+    acct.append(h('div', { className: 'approval-as', textContent: payment ? 'Paying from' : 'Signing as' }));
+    acct.append(
+      h('div', { className: 'active-account approval-capsule' }, [
+        avatarEl({ picture: data.accountPicture }, 'aa-avatar'),
+        h('div', { className: 'aa-info' }, [
+          h('div', { className: 'aa-label', textContent: data.accountName || shortNpub(data.npub) }),
+          h('div', { className: 'aa-npub', textContent: shortNpub(data.npub) }),
+        ]),
+      ])
+    );
 
     renderApprovalPreview(data);
 
@@ -3064,6 +3071,10 @@
   $('approval-allow').addEventListener('click', () => decideApproval('once'));
   $('approval-trust').addEventListener('click', () => decideApproval('trust'));
   $('approval-reject').addEventListener('click', () => decideApproval('reject'));
+  // Tapping the dimmed backdrop (outside the card) rejects, like closing the popup.
+  $('view-approval').addEventListener('click', (e) => {
+    if (e.target === $('view-approval')) decideApproval('reject');
+  });
   $('approval-pin').addEventListener('keydown', (e) => {
     if (e.key === 'Enter') decideApproval('once');
   });
@@ -3074,17 +3085,36 @@
     e.target.value = v;
   });
 
-  try {
-    const port = chrome.runtime.connect({ name: 'sidepanel' });
+  // Keep a live port to the worker so inline approvals always reach us. MV3
+  // recycles the service worker (~30s idle; Chrome also force-drops ports after
+  // ~5 min), which silently kills the port — without reconnecting, the panel
+  // goes deaf and a page's request hangs until a refresh. So we re-establish the
+  // connection whenever it drops. (Reconnecting also wakes a sleeping worker.)
+  function connectApprovalPort() {
+    let port;
+    try {
+      port = chrome.runtime.connect({ name: 'sidepanel' });
+    } catch (_) {
+      setTimeout(connectApprovalPort, 1000);
+      return;
+    }
     port.onMessage.addListener((msg) => {
       if (msg && msg.type === 'SIDECAR_PANEL_APPROVAL') {
         pendingApproval = { id: msg.id, data: msg.data };
         showApproval();
       }
     });
-  } catch (_) {
-    // No port → approvals just fall back to the popup window in the worker.
+    port.onDisconnect.addListener(() => {
+      // The worker that owned any in-flight approval is gone, so a showing card
+      // is now stale (the page is failed via the content-script timeout). Drop it.
+      if (pendingApproval) {
+        pendingApproval = null;
+        hide($('view-approval'));
+      }
+      setTimeout(connectApprovalPort, 250);
+    });
   }
+  connectApprovalPort();
 
   // ---- boot ----
   document.addEventListener('DOMContentLoaded', refresh);

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -120,12 +120,18 @@
 
   // ---- top-level routing ----
   async function refresh() {
+    // A pending signing approval is modal — it stays put until the user decides,
+    // so don't let an incidental refresh navigate away from it.
+    if (pendingApproval) {
+      showApproval();
+      return;
+    }
     state = await call({ type: 'SIDECAR_GET_STATE' });
     const settings = await call({ type: 'SIDECAR_GET_SETTINGS' });
     hideBalances = !!(settings && settings.hideBalances);
     applyHideBalances();
     closeAcctMenu();
-    [$('view-onboarding'), $('view-lock'), $('view-main'), $('view-settings'), $('view-profile-edit')].forEach(hide);
+    [$('view-onboarding'), $('view-lock'), $('view-main'), $('view-settings'), $('view-profile-edit'), $('view-approval')].forEach(hide);
     if (!state.initialized) {
       show($('view-onboarding'));
       setTimeout(() => $('ob-pin').focus(), 50);
@@ -2910,6 +2916,128 @@
       );
     });
   });
+
+  // ---- inline signing approval ----
+  // The service worker keeps a "sidepanel" port open while this panel is visible and,
+  // when it is, pushes approval requests here (SIDECAR_PANEL_APPROVAL) instead of
+  // opening a popup window. We render them inline and reply with SIDECAR_PROMPT_RESULT.
+  let pendingApproval = null; // { id, data }
+
+  const APPROVAL_METHOD_LABELS = {
+    getPublicKey: 'see your public key (npub)',
+    signEvent: 'sign an event with your key',
+    getRelays: 'read your relay list',
+    'nip04.encrypt': 'encrypt a message (NIP-04)',
+    'nip04.decrypt': 'decrypt a message (NIP-04)',
+    'nip44.encrypt': 'encrypt a message (NIP-44)',
+    'nip44.decrypt': 'decrypt a message (NIP-44)',
+  };
+
+  function renderApprovalPreview(data) {
+    const box = $('approval-preview');
+    box.innerHTML = '';
+    const row = (k, v) =>
+      h('div', { className: 'row' }, [h('span', { textContent: k }), h('span', { textContent: v })]);
+    if (data.method === 'signEvent') {
+      const ev = (data.params && (data.params.event || data.params)) || {};
+      box.append(row('Kind', String(ev.kind ?? '—')));
+      if (Array.isArray(ev.tags)) box.append(row('Tags', String(ev.tags.length)));
+      if (ev.content) box.append(h('pre', { textContent: String(ev.content) }));
+    } else if (data.method === 'nip04.decrypt' || data.method === 'nip44.decrypt') {
+      box.append(row('From', (data.params && data.params.pubkey) || '—'));
+    } else if (data.method === 'nip04.encrypt' || data.method === 'nip44.encrypt') {
+      box.append(row('To', (data.params && data.params.pubkey) || '—'));
+    } else {
+      hide(box);
+      return;
+    }
+    show(box);
+  }
+
+  function showApproval() {
+    if (!pendingApproval) return;
+    const data = pendingApproval.data;
+    closeAcctMenu();
+    [$('view-onboarding'), $('view-lock'), $('view-main'), $('view-settings'), $('view-profile-edit')].forEach(hide);
+    show($('view-approval'));
+
+    $('approval-host').textContent = data.host;
+    $('approval-ask').textContent = 'wants to ' + (APPROVAL_METHOD_LABELS[data.method] || data.method);
+
+    const acct = $('approval-account');
+    acct.innerHTML = '';
+    acct.append(document.createTextNode('Signing as '));
+    acct.append(h('b', { textContent: data.accountName || shortNpub(data.npub) }));
+    if (data.accountName) acct.append(h('span', { className: 'acct-npub', textContent: shortNpub(data.npub) }));
+
+    renderApprovalPreview(data);
+
+    $('approval-error').textContent = '';
+    const allow = $('approval-allow');
+    const trust = $('approval-trust');
+    const pin = $('approval-pin');
+    pin.value = '';
+    if (data.needUnlock) {
+      show($('approval-unlock'));
+      setTimeout(() => pin.focus(), 50);
+    } else {
+      hide($('approval-unlock'));
+    }
+    // A pure unlock (site already trusted, keystore just locked) has nothing to
+    // approve — relabel and drop the "Trust this site" choice.
+    if (data.needUnlock && !data.needApproval) {
+      allow.textContent = 'Unlock & continue';
+      hide(trust);
+    } else {
+      allow.textContent = 'Allow once';
+      show(trust);
+    }
+  }
+
+  async function decideApproval(action) {
+    if (!pendingApproval) return;
+    const { id, data } = pendingApproval;
+    const err = $('approval-error');
+    err.textContent = '';
+    // Unlock first if needed (Allow once / Trust only).
+    if (data.needUnlock && (action === 'once' || action === 'trust')) {
+      const pin = $('approval-pin').value;
+      if (!pin) {
+        err.textContent = 'Enter your PIN.';
+        return;
+      }
+      const resp = await bg({ type: 'SIDECAR_UNLOCK', pin });
+      if (!resp || !resp.ok) {
+        err.textContent = (resp && resp.error) || 'Incorrect PIN';
+        $('approval-pin').value = '';
+        $('approval-pin').focus();
+        return;
+      }
+    }
+    await bg({ type: 'SIDECAR_PROMPT_RESULT', id, action });
+    pendingApproval = null;
+    $('approval-pin').value = '';
+    refresh(); // back to the normal view (now unlocked, if we just unlocked)
+  }
+
+  $('approval-allow').addEventListener('click', () => decideApproval('once'));
+  $('approval-trust').addEventListener('click', () => decideApproval('trust'));
+  $('approval-reject').addEventListener('click', () => decideApproval('reject'));
+  $('approval-pin').addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') decideApproval('once');
+  });
+
+  try {
+    const port = chrome.runtime.connect({ name: 'sidepanel' });
+    port.onMessage.addListener((msg) => {
+      if (msg && msg.type === 'SIDECAR_PANEL_APPROVAL') {
+        pendingApproval = { id: msg.id, data: msg.data };
+        showApproval();
+      }
+    });
+  } catch (_) {
+    // No port → approvals just fall back to the popup window in the worker.
+  }
 
   // ---- boot ----
   document.addEventListener('DOMContentLoaded', refresh);

--- a/styles.css
+++ b/styles.css
@@ -240,7 +240,7 @@ input:focus, select:focus, textarea:focus {
 
 /* ===== buttons ===== */
 button { cursor: pointer; }
-.primary, .secondary, .ghost, .danger {
+.primary, .secondary, .ghost, .danger, .lav-btn {
   padding: 12px 16px;
   border-radius: 10px;
   border: none;
@@ -249,6 +249,14 @@ button { cursor: pointer; }
   letter-spacing: 0.01em;
   transition: transform 0.12s, box-shadow 0.15s, filter 0.15s, border-color 0.15s;
 }
+/* filled lavender — a visible secondary action (e.g. Trust this site) */
+.lav-btn {
+  background: linear-gradient(180deg, #cebfff, var(--lav) 58%, var(--purple));
+  color: #190a33;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 8px 22px rgba(167, 139, 250, 0.24);
+}
+.lav-btn:hover { filter: brightness(1.05); transform: translateY(-1px); }
+.lav-btn:active { transform: translateY(0); }
 .primary {
   background: linear-gradient(180deg, #f29248, var(--orange) 55%, #d4621f);
   color: #1c0c00;
@@ -927,7 +935,22 @@ button:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(203, 161, 78, 0
 /* ===== inline signing approval ===== */
 /* Top-aligned + scrollable so a long event preview never pushes the buttons
    out of view (the .screen default centers vertically). */
-#view-approval { justify-content: flex-start; min-height: 100vh; overflow-y: auto; }
+/* inline approval — a centered card over a dimmed backdrop (backdrop tap = reject) */
+.approval-overlay {
+  position: fixed; inset: 0; z-index: 50;
+  display: flex; align-items: center; justify-content: center; padding: 18px;
+  background: rgba(8, 2, 20, 0.72); backdrop-filter: blur(3px);
+}
+.approval-card {
+  width: 100%; max-width: 360px; max-height: 90vh; overflow-y: auto;
+  padding: 22px; border-radius: 16px;
+  background: linear-gradient(160deg, var(--velvet-1), var(--velvet-2));
+  border: 1px solid var(--border-strong); box-shadow: var(--shadow), var(--sheen);
+}
+/* everything in the approval card is centered (except the data preview) */
+.approval-card { text-align: center; }
+.approval-card .card { text-align: left; }
+.approval-card .brand { margin-bottom: 16px; justify-content: center; }
 .approval-host {
   font-family: var(--font-display); font-weight: 700;
   font-size: 19px; color: var(--lav);
@@ -950,17 +973,22 @@ button:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(203, 161, 78, 0
   font-size: 12px; white-space: pre-wrap; word-break: break-word;
   max-height: 160px; overflow: auto; color: var(--text);
 }
-.approval-account { font-size: 13px; color: var(--muted); margin: 4px 0 18px; }
-.approval-account b { color: var(--lav); }
-.approval-account .acct-npub { font-family: var(--font-mono); font-size: 11.5px; color: var(--faint); margin-left: 2px; }
+.approval-account { margin: 4px 0 18px; }
+.approval-as {
+  font-size: 10.5px; color: var(--muted); margin-bottom: 8px;
+  text-transform: uppercase; letter-spacing: 0.22em; text-align: center;
+}
+/* center the capsule's avatar + text as a group */
+.approval-capsule { margin-bottom: 0; justify-content: center; }
+.approval-capsule .aa-info { text-align: center; }
 .approval-actions { display: flex; flex-direction: column; gap: 8px; }
 .approval-actions button { width: 100%; }
 
 /* "allow this site to spend up to N/day" budget toggle (inline approval + popup) */
 .remember { margin-bottom: 14px; }
-.remember .check { display: flex; align-items: center; gap: 8px; color: var(--text); font-size: 13px; margin-bottom: 8px; cursor: pointer; }
+.remember .check { display: flex; align-items: center; justify-content: center; gap: 8px; color: var(--text); font-size: 13px; margin-bottom: 8px; cursor: pointer; }
 .remember input[type=checkbox] { width: 16px; height: 16px; accent-color: var(--orange); cursor: pointer; flex-shrink: 0; }
-.budget-row { display: flex; align-items: center; gap: 8px; }
+.budget-row { display: flex; align-items: center; justify-content: center; gap: 8px; }
 .remember input[type=text], .remember input[type=number] {
   width: 110px; flex-shrink: 0; padding: 9px 11px; font-size: 14px; font-family: var(--font-mono);
 }

--- a/styles.css
+++ b/styles.css
@@ -923,3 +923,35 @@ button:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(203, 161, 78, 0
 ::-webkit-scrollbar-track { background: transparent; }
 ::-webkit-scrollbar-thumb { background: linear-gradient(180deg, #3a2470, #251147); border-radius: 8px; border: 2px solid transparent; background-clip: padding-box; }
 ::-webkit-scrollbar-thumb:hover { background: #4a2f8a; background-clip: padding-box; }
+
+/* ===== inline signing approval ===== */
+/* Top-aligned + scrollable so a long event preview never pushes the buttons
+   out of view (the .screen default centers vertically). */
+#view-approval { justify-content: flex-start; min-height: 100vh; overflow-y: auto; }
+.approval-host {
+  font-family: var(--font-display); font-weight: 700;
+  font-size: 19px; color: var(--lav);
+  word-break: break-all; margin-bottom: 3px;
+}
+.approval-ask { font-size: 14px; color: var(--muted); margin-bottom: 18px; }
+.card {
+  position: relative;
+  background: linear-gradient(160deg, var(--velvet-1), var(--velvet-2));
+  border: 1px solid var(--border); border-radius: 12px;
+  padding: 13px; margin-bottom: 16px; font-size: 13px;
+  box-shadow: var(--sheen);
+}
+.card .row { display: flex; justify-content: space-between; gap: 8px; padding: 3px 0; }
+.card .row span:first-child { color: var(--muted); }
+.card .row span:last-child { word-break: break-all; text-align: right; font-family: var(--font-mono); font-size: 12px; }
+.card pre {
+  background: rgba(8, 2, 20, 0.6); border-radius: 8px; padding: 10px; margin: 8px 0 0;
+  font-family: var(--font-mono);
+  font-size: 12px; white-space: pre-wrap; word-break: break-word;
+  max-height: 160px; overflow: auto; color: var(--text);
+}
+.approval-account { font-size: 13px; color: var(--muted); margin: 4px 0 18px; }
+.approval-account b { color: var(--lav); }
+.approval-account .acct-npub { font-family: var(--font-mono); font-size: 11.5px; color: var(--faint); margin-left: 2px; }
+.approval-actions { display: flex; flex-direction: column; gap: 8px; }
+.approval-actions button { width: 100%; }

--- a/styles.css
+++ b/styles.css
@@ -955,3 +955,14 @@ button:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(203, 161, 78, 0
 .approval-account .acct-npub { font-family: var(--font-mono); font-size: 11.5px; color: var(--faint); margin-left: 2px; }
 .approval-actions { display: flex; flex-direction: column; gap: 8px; }
 .approval-actions button { width: 100%; }
+
+/* "allow this site to spend up to N/day" budget toggle (inline approval + popup) */
+.remember { margin-bottom: 14px; }
+.remember .check { display: flex; align-items: center; gap: 8px; color: var(--text); font-size: 13px; margin-bottom: 8px; cursor: pointer; }
+.remember input[type=checkbox] { width: 16px; height: 16px; accent-color: var(--orange); cursor: pointer; flex-shrink: 0; }
+.budget-row { display: flex; align-items: center; gap: 8px; }
+.remember input[type=text], .remember input[type=number] {
+  width: 110px; flex-shrink: 0; padding: 9px 11px; font-size: 14px; font-family: var(--font-mono);
+}
+.remember input:disabled { opacity: 0.4; cursor: not-allowed; }
+.budget-unit { font-size: 12.5px; color: var(--muted); }


### PR DESCRIPTION
Render signing/payment approvals inline in the side panel when it's open (popup window fallback when closed), with the WebLN payment + spending-budget flow, an account capsule, centered layout, and amber/lavender buttons. Includes service-worker lifecycle fixes (port auto-reconnect, grace-wait before popup fallback, content-script timeout) so approvals don't go deaf or hang the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)