### PR TITLE
Connected sites: inline forget confirm

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,15 @@ Or regenerate it manually any time:
 Decrypted private keys live only in the service worker's in-memory map. If the worker
 is killed (MV3 idles after ~30s), that map is cleared and the keystore re-locks.
 
+## Acknowledgments
+
+- Inspired by Nostr Build Shack by [Fishcake](https://github.com/fishcakeday) and [Clave](https://github.com/DocNR/clave) by [Doc](https://github.com/DocNR)
+
+## Author
+
+- Created by The Daniel 🖖
+- Vibed with Claude ☕️
+
 ## License
 
 MIT. Bundled fonts are licensed under the SIL Open Font License (see `fonts/`).

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -968,9 +968,19 @@
       sel.append(o);
     });
     sel.addEventListener('change', () => call({ type: 'SIDECAR_SET_LEVEL', host, level: sel.value }));
-    const rm = iconButton('Forget site', 'trash', async () => {
-      await call({ type: 'SIDECAR_REMOVE_HOST', host });
-      renderActivity();
+    // Forget needs a deliberate step — first tap swaps the controls for an inline
+    // "Forget this site?" confirm so a stray click can't wipe a site's trust.
+    const rm = iconButton('Forget site', 'trash', () => {
+      controls.innerHTML = '';
+      const msg = h('span', { className: 'confirm-msg', textContent: 'Forget this site?' });
+      const yes = h('button', { className: 'mini del-confirm', textContent: 'Forget' });
+      const no = h('button', { className: 'mini ghost', textContent: 'Cancel' });
+      no.addEventListener('click', () => renderActivity());
+      yes.addEventListener('click', async () => {
+        await call({ type: 'SIDECAR_REMOVE_HOST', host });
+        renderActivity();
+      });
+      controls.append(msg, yes, no);
     });
     controls.append(sel, rm);
     return row;

--- a/styles.css
+++ b/styles.css
@@ -548,6 +548,10 @@ button:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(203, 161, 78, 0
 .site-controls { display: flex; align-items: center; gap: 8px; }
 .site-controls .level-select { flex: 1; width: auto; }
 .site-controls .switch-site-btn { flex: 1; }
+/* inline "Forget this site?" confirm (replaces the controls on a trash tap) */
+.confirm-msg { flex: 1; font-size: 12.5px; color: var(--text-2); }
+.del-confirm { color: var(--red); border-color: rgba(240, 86, 107, 0.45); }
+.del-confirm:hover { color: var(--red); border-color: var(--red); }
 .level-select {
   width: auto;
   flex-shrink: 0;


### PR DESCRIPTION
Tapping the trash on a connected site now swaps the row controls for an inline "Forget this site? [Forget] [Cancel]" step, so a stray tap can't wipe a site's trust + binding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)