### PR TITLE
Connected sites: paginate long list

### DIFF
--- a/sidepanel.html
+++ b/sidepanel.html
@@ -91,6 +91,7 @@
           <h3>Connected sites</h3>
           <p class="hint">Each site stays pinned to the account it signed in with. To move a site to your active account, tap <b>Use</b> on it, then sign out and back in on that site.</p>
           <div id="sites-list" class="list flat"></div>
+          <button class="ghost show-more-btn hidden" id="sites-more">Show more</button>
         </div>
         <div class="setting">
           <h3>Recent activity</h3>

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -1050,12 +1050,28 @@
     // a site pinned to a different account still shows up (and can be switched).
     const hosts = [...new Set([...Object.keys(perms), ...Object.keys(bindings)])].sort();
     sites.classList.toggle('empty', !hosts.length);
+    const sitesMore = $('sites-more');
     if (!hosts.length) {
       sites.append(h('p', { className: 'hint', textContent: 'No sites have connected yet.' }));
+      hide(sitesMore);
+    } else {
+      // The list can get long — show a handful, then paginate (like the log below).
+      const SITES_PAGE = 6;
+      let shownSites = 0;
+      const renderSitesPage = () => {
+        hosts.slice(shownSites, shownSites + SITES_PAGE).forEach((host) =>
+          sites.append(siteRow(host, perms[host] ? perms[host].level : 'ask', bindings[host] || null))
+        );
+        shownSites = Math.min(shownSites + SITES_PAGE, hosts.length);
+        if (shownSites >= hosts.length) hide(sitesMore);
+        else {
+          show(sitesMore);
+          sitesMore.textContent = 'Show more (' + (hosts.length - shownSites) + ')';
+        }
+      };
+      sitesMore.onclick = renderSitesPage;
+      renderSitesPage();
     }
-    hosts.forEach((host) =>
-      sites.append(siteRow(host, perms[host] ? perms[host].level : 'ask', bindings[host] || null))
-    );
 
     const log = await call({ type: 'SIDECAR_GET_ACTIVITY' });
     const list = $('activity-list');


### PR DESCRIPTION
Show the first 6 connected sites, then a "Show more (N)" button (mirrors the Recent Activity pagination), so a long list no longer pushes Recent Activity down the Activity tab.

🥃 Generated with [Claude Code](https://claude.com/claude-code)