### PR TITLE
Collapse duplicate unlock prompts on browser restart

### DIFF
--- a/background.js
+++ b/background.js
@@ -144,6 +144,17 @@ function openPrompt(data) {
   // Chain onto the mutex: each prompt waits for the previous to finish.
   const run = () =>
     new Promise(async (resolve) => {
+      // Re-evaluate the lock at execution time. Prompts are serialized, so an
+      // earlier one in the queue may have already unlocked the keystore — the
+      // classic browser-restart case where several signed-in apps each fire a
+      // request at once and would otherwise each demand the PIN. Once unlocked,
+      // collapse the now-redundant unlock prompts: a pure unlock just proceeds,
+      // and an approval still shows but without asking for the PIN again.
+      if (data && data.needUnlock && !KS.isLocked()) {
+        data.needUnlock = false;
+        if (!data.needApproval) return resolve({ action: 'once' });
+      }
+
       const promptId = 'p_' + Date.now() + '_' + Math.random().toString(36).slice(2);
 
       // Panel open → render inline; the panel decides via SIDECAR_PROMPT_RESULT.


### PR DESCRIPTION
## Problem

On browser restart, every app you'd signed into with Sidecar fires a `window.nostr` request (relay auth / `getPublicKey`) almost simultaneously while the keystore is locked and the side panel is closed. Each request computed `needUnlock` **up front**, so the serialized prompt queue demanded the PIN **once per app** — even though the very first unlock already unlocked the keystore for the whole session.

## Fix

Re-evaluate the lock at the moment each queued prompt actually runs (prompts are already serialized by a mutex):

- **Pure unlock, now unlocked** → proceed silently, no window.
- **Approval still needed** → show the approval prompt but drop the PIN field (already unlocked).

So one PIN entry releases every queued request. Untrusted sites can still ask for approval (as intended), but never re-ask for the passcode.

## Test plan
- [ ] Lock Sidecar, close the side panel.
- [ ] Open 2–3 clients you're signed into at once (or restart the browser with them as startup tabs).
- [ ] Confirm you're prompted for the PIN **once**; the rest flow through with no further popups.
- [ ] An untrusted site still shows an approval prompt — but with no PIN field once unlocked.

🥃 Generated with [Claude Code](https://claude.com/claude-code)