### PR TITLE
Remove redundant active-account card; update README image

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ web apps you use, so you can sign in and sign events across nostr clients withou
 pasting your nsec anywhere. It also has a built-in Lightning wallet (Nostr Wallet
 Connect) for sending and receiving sats.
 
-<img width="2820" height="1570" alt="image" src="https://github.com/user-attachments/assets/1cfcad43-ae12-433a-a371-f57235496a36" />
+<img width="2816" height="1566" alt="Sidecar" src="https://github.com/user-attachments/assets/7bcefeed-9cad-4dd7-a767-f4d68930d87d" />
 
 ## Features
 

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -553,24 +553,14 @@
     applyAvatar($('chip-av'), active || {});
     $('chip-name').textContent = active ? displayName(active) : 'No account';
 
+    // The active account already shows in the header chip and is marked (check +
+    // highlight) in the list below, so the big "booth" card was a third copy.
+    // Keep this slot only for the empty-state welcome hero.
     const head = $('active-account');
     head.innerHTML = '';
     head.classList.toggle('welcome-mode', !hasAccounts);
-    if (hasAccounts && active) {
-      head.appendChild(avatarEl(active, 'aa-avatar'));
-      const info = document.createElement('div');
-      info.className = 'aa-info';
-      const label = document.createElement('div');
-      label.className = 'aa-label';
-      label.textContent = displayName(active);
-      const npub = document.createElement('div');
-      npub.className = 'aa-npub';
-      npub.textContent = shortNpub(active.npub);
-      info.append(label, npub);
-      head.appendChild(info);
-    } else {
-      head.appendChild(buildWelcome());
-    }
+    head.classList.toggle('hidden', hasAccounts);
+    if (!hasAccounts) head.appendChild(buildWelcome());
 
     const list = $('account-list');
     list.innerHTML = '';


### PR DESCRIPTION
## Summary

- **Accounts tab declutter** — the active account was shown three times: the header chip, a big "booth" card, and the checkmarked row in the list. Removed the booth card; the chip (who you are / switcher) and the highlighted, checkmarked list row already convey the active account. The `#active-account` slot is kept (hidden when accounts exist) for the empty-state welcome hero, and the `.active-account` styles stay since the approval prompt reuses them.
- **README** — swapped the hero image (2816×1566).

## Test plan
- [ ] Accounts tab with one account: active shown only in the chip + the highlighted list row, no big card.
- [ ] No accounts: welcome hero still renders in that slot.
- [ ] Approval prompt still renders its account capsule correctly.

🍷 Generated with [Claude Code](https://claude.com/claude-code)