### PR TITLE
nsec import preview, Enter-to-submit modals, port-aware site identity

### DIFF
--- a/background.js
+++ b/background.js
@@ -570,7 +570,7 @@ chrome.runtime.onStartup && chrome.runtime.onStartup.addListener(createPayMenu);
 chrome.contextMenus &&
   chrome.contextMenus.onClicked.addListener((info, tab) => {
     let host = '';
-    try { host = new URL(info.pageUrl || (tab && tab.url) || '').hostname; } catch (_) {}
+    try { host = new URL(info.pageUrl || (tab && tab.url) || '').host; } catch (_) {}
     const pay = (getInvoice) =>
       Promise.resolve(getInvoice)
         .then((inv) => payFromPage(inv, host).then((r) => ({ r, inv })))
@@ -823,7 +823,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   // user is actually signed into — a live invoice elsewhere is almost always noise.
   if (message.type === 'SIDECAR_IS_CONNECTED') {
     let h = '';
-    try { h = new URL((sender && sender.url) || '').hostname; } catch (_) {}
+    try { h = new URL((sender && sender.url) || '').host; } catch (_) {}
     getSiteAccount(h)
       .then((pk) => sendResponse({ ok: true, connected: !!pk }))
       .catch(() => sendResponse({ ok: true, connected: false }));
@@ -833,7 +833,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.type === 'SIDECAR_PAY_PAGE_INVOICE') {
     const tabId = sender && sender.tab && sender.tab.id;
     let host = '';
-    try { host = new URL((sender && sender.url) || '').hostname; } catch (_) {}
+    try { host = new URL((sender && sender.url) || '').host; } catch (_) {}
     payFromPage(message.invoice, host)
       .then((r) => {
         notify(r.sats != null ? 'Payment sent — ' + r.sats.toLocaleString('en-US') + ' sats' : 'Payment sent');

--- a/content.js
+++ b/content.js
@@ -14,7 +14,7 @@
   };
   (document.head || document.documentElement).appendChild(script);
 
-  const host = location.hostname; // trusted origin identity, set by the content script
+  const host = location.host; // trusted origin identity (includes port, e.g. localhost:3000)
 
   // Whether this page is signed into Sidecar's signer. Seeded from the persistent
   // site binding on startup, then flipped live the moment the page successfully
@@ -271,7 +271,7 @@
     shownInvoice = invoice;
     const sats = invoiceSats(invoice);
     const memo = invoiceMemo(invoice);
-    const site = location.hostname.replace(/^www\./, '');
+    const site = location.host.replace(/^www\./, '');
 
     const eyebrow = sats != null ? "You're paying" : 'Pay with Sidecar';
     const amountBlock =

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -399,6 +399,46 @@
     return Object.keys(map).filter((u) => (writableOnly ? map[u].write !== false : true));
   }
 
+  // Derive the public key (hex) from a pasted nsec/hex secret, locally, so the
+  // import modal can preview which account it belongs to before saving. The raw
+  // secret is already in the panel's input; this only computes the public half.
+  // Returns '' for anything that isn't a valid secret yet.
+  function pubkeyFromSecret(secret) {
+    try {
+      let sk = null;
+      if (/^nsec1/i.test(secret)) {
+        const d = NT.nip19.decode(secret);
+        if (d.type !== 'nsec') return '';
+        sk = d.data; // Uint8Array
+      } else if (/^[0-9a-f]{64}$/i.test(secret)) {
+        sk = new Uint8Array(32);
+        for (let i = 0; i < 32; i++) sk[i] = parseInt(secret.substr(i * 2, 2), 16);
+      } else {
+        return '';
+      }
+      return NT.getPublicKey(sk) || '';
+    } catch (_) {
+      return '';
+    }
+  }
+
+  // Fetch just name + picture from kind 0 for a preview (without storing it).
+  async function fetchPreviewProfile(pubkey) {
+    try {
+      const relays = await relayUrls(false);
+      if (!relays.length) return null;
+      const ev = await Promise.race([
+        poolGet(relays, { kinds: [0], authors: [pubkey] }),
+        new Promise((r) => setTimeout(() => r(null), 6000)),
+      ]);
+      if (!ev) return null;
+      const m = JSON.parse(ev.content) || {};
+      return { name: m.display_name || m.displayName || m.name || '', picture: m.picture || '' };
+    } catch (_) {
+      return null;
+    }
+  }
+
   // ---- NIP-65 (kind 10002) relay list, cached per account ----
   const nip65Cache = new Map(); // pubkey -> { read:[], write:[] } | null
 
@@ -708,6 +748,17 @@
     show($('modal-overlay'));
     document.documentElement.classList.add('modal-open');
   }
+  // These modals are built from loose inputs + buttons (not a <form>), so Enter
+  // wouldn't submit. Treat Enter in a text input as a click on the primary action.
+  // (Textareas keep Enter for newlines.)
+  $('modal').addEventListener('keydown', (e) => {
+    if (e.key !== 'Enter' || e.target.tagName !== 'INPUT') return;
+    const primary = $('modal').querySelector('button.primary');
+    if (primary && !primary.disabled) {
+      e.preventDefault();
+      primary.click();
+    }
+  });
   function closeModal() {
     if (modalCleanup) { try { modalCleanup(); } catch (_) {} modalCleanup = null; }
     hide($('modal-overlay'));
@@ -750,6 +801,43 @@
       const err = h('div', { className: 'error' });
       const secretInput = h('input', { type: 'password', className: 'nsec-field', placeholder: 'nsec1… or 64-char hex' });
       modal.append(h('label', { textContent: 'Private key' }), secretInput);
+
+      // Live preview: once the pasted key is valid, show whose account it is
+      // (npub + kind 0 name/picture) so the user can confirm before importing.
+      const pav = h('span', { className: 'ip-av' });
+      const pname = h('div', { className: 'ip-name' });
+      const pnpub = h('div', { className: 'ip-npub' });
+      const preview = h('div', { className: 'import-preview hidden' }, [
+        pav,
+        h('div', { className: 'ip-info' }, [pname, pnpub]),
+      ]);
+      modal.append(preview);
+
+      let previewSeq = 0;
+      let previewTimer = null;
+      async function updatePreview() {
+        const pubkey = pubkeyFromSecret(secretInput.value.trim());
+        const seq = ++previewSeq;
+        if (!pubkey) return preview.classList.add('hidden');
+        const npub = NT.nip19.npubEncode(pubkey);
+        applyAvatar(pav, {});
+        pname.textContent = 'Fetching profile…';
+        pnpub.textContent = shortNpub(npub);
+        preview.classList.remove('hidden');
+        const prof = await fetchPreviewProfile(pubkey);
+        if (seq !== previewSeq) return; // a newer key superseded this fetch
+        if (prof && (prof.name || prof.picture)) {
+          applyAvatar(pav, { picture: prof.picture, name: prof.name });
+          pname.textContent = prof.name || shortNpub(npub);
+        } else {
+          pname.textContent = 'No profile found';
+        }
+      }
+      secretInput.addEventListener('input', () => {
+        clearTimeout(previewTimer);
+        previewTimer = setTimeout(updatePreview, 350);
+      });
+
       modal.append(
         h('p', {
           className: 'hint',

--- a/styles.css
+++ b/styles.css
@@ -360,6 +360,21 @@ button:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(203, 161, 78, 0
 .acct-row-check { width: 18px; height: 18px; color: var(--gold); flex-shrink: 0; }
 .acct-row.foot { justify-content: center; color: var(--lav); border-top: 1px solid var(--border); border-radius: 0; margin-top: 4px; padding-top: 11px; }
 
+/* nsec import preview — confirm the account a pasted key belongs to */
+.import-preview {
+  display: flex; align-items: center; gap: 11px; padding: 10px 12px; margin-top: 8px;
+  border: 1px solid var(--gold-soft); border-radius: 12px;
+  background: linear-gradient(150deg, var(--velvet-1), var(--velvet-2));
+}
+.ip-av {
+  width: 40px; height: 40px; border-radius: 50%; overflow: hidden; flex-shrink: 0;
+  background: linear-gradient(180deg, #2a1257, #160a30); border: 1px solid var(--border);
+}
+.ip-av img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.ip-info { flex: 1; min-width: 0; }
+.ip-name { font-weight: 600; font-size: 14px; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.ip-npub { font-family: var(--font-mono); font-size: 11px; color: var(--muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; margin-top: 2px; }
+
 .tabs { display: flex; border-bottom: 1px solid var(--border); padding: 0 6px; }
 .tab {
   position: relative;


### PR DESCRIPTION
## Summary

Three small account/import UX fixes.

### nsec import preview
As you paste a valid `nsec1…`/hex into the Import account modal, a preview capsule shows **whose account it is** before you save: the pubkey is derived locally (the secret was already in the field; only the public half is computed), the npub appears immediately, and kind 0 name/picture are fetched from your relays (6s timeout, **not stored**, race-guarded so a newer paste supersedes an in-flight fetch). Invalid/empty input hides the preview.

### Enter-to-submit in modals
Modals built from loose inputs + buttons (Import, Change PIN, reveal-key step-up, …) didn't submit on Enter. A keydown handler on `#modal` now treats Enter in a text input as a click on the primary button. Textareas keep Enter for newlines; disabled buttons are ignored. (Onboarding/unlock were already `<form>`s; the approval popup already handled Enter on its PIN.)

### Port-aware site identity
Switched the trusted origin from `location.hostname` to `location.host`, so `localhost:3000` and `localhost:5173` are **distinct** connected sites with their own permissions and account bindings. `location.host` only includes the port when it's non-default, so standard sites (`example.com`, 443/80) are unchanged. Applied consistently in `content.js` and every background host derivation.

## Notes
- Localhost dev apps previously approved as bare `localhost` will need a one-time re-approval (now keyed with the port). Normal sites unaffected.

## Test plan
- [ ] Import modal: paste an nsec whose owner has a kind 0 → avatar/name/npub populate; clear it → preview hides.
- [ ] Open Import / Change PIN, type, press Enter → primary action fires.
- [ ] Sign into two localhost ports → they appear as separate connected sites.

🍷 Generated with [Claude Code](https://claude.com/claude-code)