### PR TITLE
Settings: reset-all danger zone + footer logo on every screen

### DIFF
--- a/background.js
+++ b/background.js
@@ -687,6 +687,14 @@ async function handleControl(message, sendResponse) {
         await lockKeystore();
         result = await KS.getState();
         break;
+      case 'SIDECAR_RESET_ALL':
+        // Wipe everything: in-memory keys/session/wallet (lockKeystore) plus all
+        // persisted data (keystore, accounts, permissions, relays, settings, site
+        // bindings, activity, NWC connections, budgets). Unrecoverable.
+        await lockKeystore();
+        await new Promise((res) => chrome.storage.local.clear(() => res()));
+        result = true;
+        break;
       case 'SIDECAR_ADD_ACCOUNT':
         if (message.generate) result = await KS.generateAccount(message.name);
         else result = await KS.importSecret(message.secret, message.name);

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -79,9 +79,6 @@
           <button class="secondary" id="add-generate">Generate new</button>
           <button class="secondary" id="add-import">Import nsec</button>
         </div>
-        <div class="brand-foot">
-          <img src="icons/sidecar-logo.svg" alt="Sidecar" />
-        </div>
       </div>
 
       <!-- Activity: signing history + per-site permission tiers -->
@@ -111,6 +108,9 @@
         <div id="wallet-view"></div>
       </div>
 
+      <div class="brand-foot">
+        <img src="icons/sidecar-logo.svg" alt="Sidecar" />
+      </div>
     </main>
 
     <button id="compose-fab" class="fab" title="Post a note">
@@ -197,6 +197,16 @@
       <div class="setting">
         <h3>Change PIN</h3>
         <button class="secondary" id="change-pin-btn">Change PIN…</button>
+      </div>
+
+      <div class="setting danger-zone">
+        <h3>Danger zone</h3>
+        <p class="hint">Erase all accounts, keys, wallets, and settings on this device. This can't be undone. Back up your nsecs first.</p>
+        <button class="danger" id="reset-all-btn">Reset Sidecar</button>
+      </div>
+
+      <div class="brand-foot">
+        <img src="icons/sidecar-logo.svg" alt="Sidecar" />
       </div>
     </main>
   </section>

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -3146,12 +3146,12 @@
     });
   }
 
-  const brandFoot = document.querySelector('.brand-foot');
-  if (brandFoot) {
-    brandFoot.classList.add('brand-foot-btn');
-    brandFoot.title = 'About Sidecar';
-    brandFoot.addEventListener('click', aboutModal);
-  }
+  // Footer logo on every screen (main tabs + settings) opens the About card.
+  document.querySelectorAll('.brand-foot').forEach((foot) => {
+    foot.classList.add('brand-foot-btn');
+    foot.title = 'About Sidecar';
+    foot.addEventListener('click', aboutModal);
+  });
 
   $('autolock-select').addEventListener('change', async (e) => {
     await call({ type: 'SIDECAR_SET_SETTINGS', settings: { autoLockMinutes: Number(e.target.value) } });
@@ -3189,6 +3189,48 @@
     await call({ type: 'SIDECAR_SET_RELAYS', relays });
     input.value = '';
     renderSettings();
+  });
+
+  // Danger zone: wipe all Sidecar data. Type-to-confirm, since it's irreversible
+  // and destroys keys. The destructive button is .danger (not .primary), so the
+  // modal's Enter-to-submit shortcut won't fire it — a deliberate click is required.
+  $('reset-all-btn').addEventListener('click', () => {
+    openModal((modal) => {
+      const err = h('div', { className: 'error' });
+      const warn = h('p', {
+        className: 'hint',
+        textContent:
+          'This erases everything on this device: all accounts and private keys, wallet connections, per-site permissions, and settings. It cannot be undone — any account without a backed-up nsec is lost for good.',
+      });
+      const confirmInput = h('input', { type: 'text', placeholder: 'Type RESET to confirm' });
+      const del = h('button', { className: 'danger', textContent: 'Erase everything' });
+      del.disabled = true;
+      const matches = () => confirmInput.value.trim().toUpperCase() === 'RESET';
+      confirmInput.addEventListener('input', () => { del.disabled = !matches(); });
+      del.addEventListener('click', async () => {
+        if (!matches()) return;
+        try {
+          await call({ type: 'SIDECAR_RESET_ALL' });
+          closeModal();
+          await refresh(); // no keystore now → onboarding
+          toast('Sidecar reset', 'success');
+        } catch (e) {
+          err.textContent = e.message;
+          toast(e.message, 'error');
+        }
+      });
+      const cancel = h('button', { className: 'ghost', textContent: 'Cancel' });
+      cancel.addEventListener('click', closeModal);
+      modal.append(
+        h('h3', { textContent: 'Reset Sidecar?' }),
+        warn,
+        h('label', { textContent: 'Confirm' }),
+        confirmInput,
+        err,
+        h('div', { className: 'actions' }, [del, cancel])
+      );
+      setTimeout(() => confirmInput.focus(), 50);
+    });
   });
 
   $('change-pin-btn').addEventListener('click', () => {

--- a/styles.css
+++ b/styles.css
@@ -279,6 +279,11 @@ button { cursor: pointer; }
   color: #fff;
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2), 0 8px 20px rgba(196, 52, 74, 0.3);
 }
+
+/* settings danger zone — set apart with a red heading and a top divider */
+.setting.danger-zone { margin-top: 30px; padding-top: 22px; border-top: 1px solid rgba(240, 86, 107, 0.3); }
+.setting.danger-zone h3 { color: var(--red); }
+.setting.danger-zone .danger { margin-top: 8px; }
 button:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(203, 161, 78, 0.4); }
 
 .icon-btn {


### PR DESCRIPTION
## Summary

- **Danger zone** in Settings: a red **Reset Sidecar** button under a red "Danger zone" heading (top divider sets it apart). Clicking opens a confirmation modal that requires typing **RESET** before the destructive button enables. The confirm button is `.danger` (not `.primary`), so the modal's Enter-to-submit shortcut can't trigger it — a deliberate click is required.
- **`SIDECAR_RESET_ALL`** reuses `lockKeystore()` (wipes in-memory keys, signer cache, NWC client, auto-lock alarm) then `chrome.storage.local.clear()` to remove all persisted data (keystore, accounts, permissions, relays, settings, site bindings, activity, NWC connections, budgets). The panel then refreshes to onboarding.
- **Footer logo on every screen**: the Sidecar wordmark now sits at the bottom of all four main tabs (a shared element below the tabviews) and on Settings, each linking to the **About** card.

## Test plan
- [ ] Settings → Danger zone → Reset Sidecar → type RESET → confirm → lands on onboarding, all data gone.
- [ ] Confirm button stays disabled until "RESET" is typed; Enter doesn't fire it.
- [ ] Footer logo appears on Accounts/Activity/Profile/Wallet and Settings; clicking any opens the About card.

🍷 Generated with [Claude Code](https://claude.com/claude-code)