### PR TITLE
Clear stale PIN inputs when showing onboarding

### DIFF
--- a/sidepanel.js
+++ b/sidepanel.js
@@ -166,6 +166,11 @@
     closeAcctMenu();
     [$('view-onboarding'), $('view-lock'), $('view-main'), $('view-settings'), $('view-profile-edit'), $('view-approval')].forEach(hide);
     if (!state.initialized) {
+      // Clear any stale PIN left in the inputs (e.g. after a reset) — the panel is
+      // an SPA, so values would otherwise persist across the view switch.
+      $('ob-pin').value = '';
+      $('ob-pin2').value = '';
+      $('ob-error').textContent = '';
       show($('view-onboarding'));
       setTimeout(() => $('ob-pin').focus(), 50);
     } else if (state.locked) {


### PR DESCRIPTION
## Problem
After **Reset Sidecar**, the onboarding "Create keystore" screen showed a pre-filled PIN (dots in both fields). The panel is an SPA, so reset only swaps views — the PIN typed during the original onboarding stayed in the `#ob-pin`/`#ob-pin2` password inputs.

## Fix
`refresh()` now clears `#ob-pin`, `#ob-pin2`, and `#ob-error` whenever the onboarding view is shown, so the fields are always empty (after a reset or on first run).

## Test plan
- [ ] Set up an account, then Settings → Danger zone → Reset Sidecar → confirm.
- [ ] Onboarding appears with **empty** PIN fields.

🍸 Generated with [Claude Code](https://claude.com/claude-code)