### PR TITLE
Wallet: edit a per-site budget in place

### DIFF
--- a/sidepanel.js
+++ b/sidepanel.js
@@ -2774,12 +2774,53 @@
       h('div', { className: 'item-label', textContent: host }),
       sub,
     ]);
+    const edit = iconButton('Edit budget', 'edit', () => editBudgetModal(host, b));
     const rm = iconButton('Revoke budget', 'trash', async () => {
       await call({ type: 'SIDECAR_REVOKE_BUDGET', host });
       renderWallet();
     });
-    row.append(main, rm);
+    row.append(main, h('div', { className: 'item-actions' }, [edit, rm]));
     return row;
+  }
+
+  function editBudgetModal(host, b) {
+    openModal((modal) => {
+      const err = h('div', { className: 'error' });
+      const input = h('input', { type: 'text', inputMode: 'numeric', value: String(b.budgetSats || 0) });
+      const save = h('button', { className: 'primary', textContent: 'Save budget' });
+      save.addEventListener('click', async () => {
+        err.textContent = '';
+        const budgetSats = parseInt(input.value, 10);
+        if (!budgetSats || budgetSats < 1) {
+          err.textContent = 'Enter a daily budget in sats.';
+          return;
+        }
+        try {
+          await call({ type: 'SIDECAR_SET_BUDGET', host, budgetSats, perPaymentSats: b.perPaymentSats || 0 });
+          closeModal();
+          renderWallet();
+          toast('Budget updated', 'success');
+        } catch (e) {
+          err.textContent = e.message;
+          toast(e.message, 'error');
+        }
+      });
+      const cancel = h('button', { className: 'ghost', textContent: 'Cancel' });
+      cancel.addEventListener('click', closeModal);
+      modal.append(
+        h('h3', { textContent: 'Edit budget' }),
+        h('p', {
+          className: 'hint',
+          textContent:
+            'Daily amount ' + host + ' can spend without a prompt. Saving resets the remaining amount for today.',
+        }),
+        h('label', { textContent: 'Daily budget (sats)' }),
+        input,
+        err,
+        h('div', { className: 'actions' }, [save, cancel])
+      );
+      setTimeout(() => input.focus(), 50);
+    });
   }
 
   function sendModal() {

--- a/styles.css
+++ b/styles.css
@@ -567,6 +567,8 @@ button:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(203, 161, 78, 0
 .item.item-pending { border-color: var(--gold-soft); box-shadow: var(--sheen), 0 0 0 1px var(--gold-soft); }
 .item.item-pending .item-label { color: var(--gold); }
 .item.item-pending .item-sub { color: var(--gold-soft); }
+/* budget rows: wrap the "X of Y sats left today" line at spaces, not mid-word */
+.wallet-budgets .item-sub { word-break: normal; overflow-wrap: anywhere; }
 
 .row-actions { display: flex; gap: 8px; align-items: center; }
 .row-actions input { flex: 1; }


### PR DESCRIPTION
## Summary

Per-site spending budgets could previously only be **revoked and recreated** (and recreation only happened through the payment approval prompt). This adds in-place editing.

- Each budget row now has a **pencil (edit)** action alongside revoke.
- It opens a small modal prefilled with the current daily amount; saving calls the existing `SIDECAR_SET_BUDGET` handler (`perPaymentSats` preserved).
- UI-only — no backend change; `setBudget` already overwrites.

Note: saving resets that day's **remaining** amount to the new total and restarts the 24h reset window (the modal states this).

## Test plan
- [ ] Set a budget via a payment prompt, then open Wallet → Site payments.
- [ ] Tap the pencil → change the amount → Save → row reflects the new "X of Y left today".
- [ ] Enter submits; invalid/empty shows an error.

🍸 Generated with [Claude Code](https://claude.com/claude-code)