### PR TITLE
Drop unnecessary wss://*/* host permission

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -11,8 +11,7 @@
     "notifications"
   ],
   "host_permissions": [
-    "https://*/*",
-    "wss://*/*"
+    "https://*/*"
   ],
   "background": {
     "service_worker": "background.js"


### PR DESCRIPTION
## Summary

Removes `"wss://*/*"` from `host_permissions`.

WebSocket connections (Nostr relays, NWC wallet) are not gated by `host_permissions` in MV3 — and `wss` isn't a valid host-permission match scheme, so Chrome effectively ignored the entry. It granted nothing Sidecar needs and only invited a Chrome Web Store review question.

`https://*/*` and the `<all_urls>` content script — which actually provide the all-sites access the NIP-07/WebLN provider needs — are unchanged.

## Test plan
- [ ] Load unpacked, connect an NWC wallet → balance/send/receive work (WebSocket to the wallet relay).
- [ ] Load a profile / publish kind 0 → relay reads/writes work (WebSocket to relays).

🍸 Generated with [Claude Code](https://claude.com/claude-code)