### PR TITLE
Auto-hide the revealed nsec after 30s

### DIFF
--- a/sidepanel.js
+++ b/sidepanel.js
@@ -908,27 +908,45 @@
   }
 
   // Show an nsec with copy + warning (used after generate, and from reveal).
+  // The key auto-hides after 30s so it can't be left exposed on screen; viewing
+  // it again goes back through the PIN-gated reveal.
+  const NSEC_REVEAL_TIMEOUT_S = 30;
   function nsecModal(opts) {
-    openModal((modal) => {
-      const box = h('div', { className: 'secret-box', textContent: opts.nsec });
-      const copy = h('button', { className: 'secondary', textContent: 'Copy nsec' });
-      copy.addEventListener('click', async () => {
-        try {
-          await navigator.clipboard.writeText(opts.nsec);
-          toast('nsec copied', 'success');
-        } catch (_) {}
-      });
-      const done = h('button', { className: 'primary', textContent: "I've saved it" });
-      done.addEventListener('click', closeModal);
-      modal.append(
-        h('h3', { textContent: opts.title }),
-        opts.intro ? h('p', { className: 'hint', textContent: opts.intro }) : document.createTextNode(''),
-        box,
-        copy,
-        h('p', { className: 'hint warn', textContent: 'Anyone with this key fully controls the account. Store it somewhere safe and never share it.' }),
-        h('div', { className: 'actions' }, [done])
-      );
-    });
+    let remaining = NSEC_REVEAL_TIMEOUT_S;
+    let timer = null;
+    openModal(
+      (modal) => {
+        const box = h('div', { className: 'secret-box', textContent: opts.nsec });
+        const copy = h('button', { className: 'secondary', textContent: 'Copy nsec' });
+        copy.addEventListener('click', async () => {
+          try {
+            await navigator.clipboard.writeText(opts.nsec);
+            toast('nsec copied', 'success');
+          } catch (_) {}
+        });
+        const done = h('button', { className: 'primary', textContent: "I've saved it" });
+        done.addEventListener('click', closeModal);
+        const countdown = h('p', {
+          className: 'hint',
+          textContent: 'Hiding in ' + remaining + 's. Reveal again with your PIN.',
+        });
+        timer = setInterval(() => {
+          remaining -= 1;
+          if (remaining <= 0) return closeModal(); // cleanup clears the timer
+          countdown.textContent = 'Hiding in ' + remaining + 's. Reveal again with your PIN.';
+        }, 1000);
+        modal.append(
+          h('h3', { textContent: opts.title }),
+          opts.intro ? h('p', { className: 'hint', textContent: opts.intro }) : document.createTextNode(''),
+          box,
+          copy,
+          h('p', { className: 'hint warn', textContent: 'Anyone with this key fully controls the account. Store it somewhere safe and never share it.' }),
+          countdown,
+          h('div', { className: 'actions' }, [done])
+        );
+      },
+      () => { if (timer) { clearInterval(timer); timer = null; } }
+    );
   }
 
   // Reveal an existing account's nsec — PIN-gated step-up.


### PR DESCRIPTION
## Summary

When the private key is displayed (after generating a key, or after a PIN-gated reveal), the modal now starts a **30-second countdown and auto-closes**, so an nsec can't be left exposed on screen. A visible "Hiding in Ns…" line makes the timeout obvious.

Re-viewing the key still requires the PIN (it routes through the existing `revealNsecModal` → `SIDECAR_REVEAL_NSEC`), so once it auto-hides, seeing it again costs a PIN entry. The timer is cleared on any manual close (Done / backdrop / Esc) so it can't fire against a later modal.

- 30s flat, no reset on interaction (hard cap).
- Applies to both the post-generate backup modal and the reveal modal (same `nsecModal`).

## Test plan
- [ ] Generate a new account → the backup modal counts down and auto-closes at 0.
- [ ] Accounts → Back up private key → enter PIN → revealed nsec counts down and auto-closes.
- [ ] Close early (Done/backdrop/Esc) → no stray close fires afterward.
- [ ] After auto-close, revealing again prompts for the PIN.

🍸 Generated with [Claude Code](https://claude.com/claude-code)