### PR TITLE
feat: contenteditable composer with @mention autocomplete and atomic pills (Phase 2)

### DIFF
--- a/sidepanel.js
+++ b/sidepanel.js
@@ -1373,6 +1373,54 @@
   const mentionNameCache = new Map(); // pubkey -> name|null
   const TOKEN_RE = /(https?:\/\/[^\s]+)|(?:nostr:)?((?:npub1|nprofile1)[0-9a-z]+)/gi;
 
+  // Follow list cache for @mention autocomplete (invalidated on account switch)
+  let followListCache = null;
+  let followListPubkey = null;
+
+  async function getFollowList() {
+    if (followListCache && followListPubkey === state.activePubkey) return followListCache;
+    followListPubkey = state.activePubkey;
+    if (!state.activePubkey) return (followListCache = []);
+    try {
+      const relays = await relayUrls(false);
+      const ev = await Promise.race([
+        poolGet(relays, { kinds: [3], authors: [state.activePubkey] }),
+        new Promise((r) => setTimeout(() => r(null), 5000)),
+      ]);
+      if (!ev) return (followListCache = []);
+      const pubkeys = (ev.tags || [])
+        .filter((t) => t[0] === 'p')
+        .map((t) => t[1])
+        .filter((pk) => pk && pk.length === 64);
+      if (!pubkeys.length) return (followListCache = []);
+      const profiles = await Promise.race([
+        getPool().querySync(relays, { kinds: [0], authors: pubkeys }),
+        new Promise((r) => setTimeout(() => r([]), 6000)),
+      ]);
+      const byPk = {};
+      (profiles || []).forEach((p) => {
+        if (!byPk[p.pubkey] || p.created_at > byPk[p.pubkey].created_at) byPk[p.pubkey] = p;
+      });
+      followListCache = pubkeys
+        .map((pk) => {
+          let name = null, picture = null;
+          const prof = byPk[pk];
+          if (prof) {
+            try {
+              const c = JSON.parse(prof.content);
+              name = c.display_name || c.name || null;
+              picture = c.picture || null;
+            } catch (_) {}
+          }
+          return { pubkey: pk, name, picture };
+        })
+        .filter((c) => c.name);
+      return followListCache;
+    } catch (_) {
+      return (followListCache = []);
+    }
+  }
+
   function npubChip(npub) {
     const el = h('div', { className: 'profile-npub', title: 'Copy npub' });
     el.append(icon('copy'), h('span', { textContent: shortNpub(npub) }));
@@ -1601,7 +1649,9 @@
   // Composer preview: inline media / links, profile mentions (@name), and nostr
   // event refs (note1/nevent/naddr) rendered as embed cards fetched from the
   // user's own relays.
-  const PREVIEW_RE = /(https?:\/\/[^\s]+)|(?:nostr:)?(npub1[0-9a-z]+|nprofile1[0-9a-z]+|note1[0-9a-z]+|nevent1[0-9a-z]+|naddr1[0-9a-z]+)/gi;
+  // npub1/note1 are always exactly 63 chars (5+58); use {58} to prevent the regex
+  // from greedily consuming adjacent lowercase words as bech32 characters.
+  const PREVIEW_RE = /(https?:\/\/[^\s]+)|(?:nostr:)?(npub1[0-9a-z]{58}|nprofile1[0-9a-z]{50,}|note1[0-9a-z]{58}|nevent1[0-9a-z]{50,}|naddr1[0-9a-z]{50,})/gi;
   function renderNotePreview(container, text) {
     const mentions = [];
     const embeds = [];
@@ -1709,6 +1759,28 @@
     });
   }
 
+  // Serialize a contenteditable editor div to plain nostr text.
+  // Text nodes → text, BR → \n, block divs → \n prefix, pill spans → their data-bech32.
+  //   (NBSP used after pills to prevent browser whitespace collapse) → regular space.
+  function serializeEditor(el) {
+    let out = '';
+    const walk = (node) => {
+      if (node.nodeType === Node.TEXT_NODE) {
+        out += node.textContent.replace(/ /g, ' ');
+      } else if (node.nodeName === 'BR') {
+        out += '\n';
+      } else if (node.dataset && node.dataset.bech32) {
+        out += node.dataset.bech32;
+      } else {
+        const isBlock = node.nodeName === 'DIV' || node.nodeName === 'P';
+        if (isBlock && out && !out.endsWith('\n')) out += '\n';
+        node.childNodes.forEach(walk);
+      }
+    };
+    el.childNodes.forEach(walk);
+    return out;
+  }
+
   function openComposer() {
     if (!state.activePubkey) {
       toast('Add an account first', 'error');
@@ -1720,10 +1792,21 @@
 
     async function doPublish() {
       const content = draft.text.trim();
+      const pTags = [];
+      const seenPks = new Set();
+      const mentionRe = /nostr:(npub1[0-9a-z]+|nprofile1[0-9a-z]+)/g;
+      let mm;
+      while ((mm = mentionRe.exec(content)) !== null) {
+        try {
+          const d = NT.nip19.decode(mm[1]);
+          const pk = d.type === 'npub' ? d.data : d.data.pubkey;
+          if (pk && !seenPks.has(pk)) { seenPks.add(pk); pTags.push(['p', pk]); }
+        } catch (_) {}
+      }
       const event = {
         kind: 1,
         created_at: Math.floor(Date.now() / 1000),
-        tags: [CLIENT_TAG.slice()],
+        tags: [CLIENT_TAG.slice(), ...pTags],
         content,
       };
       const signed = await call({ type: 'SIDECAR_OWNER_SIGN', event });
@@ -1741,9 +1824,123 @@
       const tabPreview = h('button', { className: 'compose-tab', textContent: 'Preview' });
       const tabBar = h('div', { className: 'compose-tabs' }, [tabWrite, tabPreview]);
 
-      const ta = h('textarea', { className: 'compose-text', placeholder: 'What’s on your mind?' });
-      ta.value = draft.text;
-      ta.addEventListener('input', () => { draft.text = ta.value; updatePostState(); });
+      const editor = h('div', { className: 'compose-text compose-editor is-empty', contentEditable: 'true' });
+      editor.dataset.placeholder = "What’s on your mind?";
+      if (draft.text) { editor.textContent = draft.text; editor.classList.remove('is-empty'); }
+
+      const editorWrap = h('div', { className: 'compose-editor-wrap' });
+      editorWrap.append(editor);
+
+      // ---- @mention autocomplete ----
+      let acDropdown = null, acResults = [], acIndex = 0;
+
+      function getCaretContext() {
+        const sel = window.getSelection();
+        if (!sel.rangeCount) return null;
+        const range = sel.getRangeAt(0);
+        if (!range.collapsed) return null;
+        const node = range.startContainer;
+        if (node.nodeType !== Node.TEXT_NODE || !editor.contains(node)) return null;
+        const before = node.textContent.slice(0, range.startOffset);
+        const match = before.match(/@([^\s@]*)$/);
+        if (!match) return null;
+        return { node, query: match[1] };
+      }
+
+      function closeAcDropdown() {
+        if (acDropdown) { acDropdown.remove(); acDropdown = null; }
+        acResults = []; acIndex = 0;
+      }
+
+      function updateAcActiveItem() {
+        if (!acDropdown) return;
+        acDropdown.querySelectorAll('.ac-item').forEach((el, i) => el.classList.toggle('active', i === acIndex));
+      }
+
+      function selectAcItem(contact, query) {
+        const sel = window.getSelection();
+        if (!sel.rangeCount) return;
+        const range = sel.getRangeAt(0);
+        const node = range.startContainer;
+        if (node.nodeType !== Node.TEXT_NODE) return;
+        const offset = range.startOffset;
+        const atStart = Math.max(0, offset - (query.length + 1));
+        // Auto-insert a leading space when @ immediately follows a non-whitespace char.
+        const charBeforeAt = atStart > 0 ? node.textContent[atStart - 1] : '';
+        const needsLeadingSpace = charBeforeAt && !/\s/.test(charBeforeAt);
+        range.setStart(node, atStart);
+        range.setEnd(node, offset);
+        range.deleteContents();
+        const pill = document.createElement('span');
+        pill.className = 'mention-pill';
+        pill.contentEditable = 'false';
+        pill.dataset.bech32 = 'nostr:' + NT.nip19.npubEncode(contact.pubkey);
+        pill.textContent = '@' + contact.name;
+        if (needsLeadingSpace) range.insertNode(document.createTextNode(' '));
+        range.collapse(false);
+        range.insertNode(pill);
+        // NBSP after pill: never collapsed by the browser, normalized to space by serializer.
+        const trailingSpace = document.createTextNode(' ');
+        range.setStartAfter(pill);
+        range.insertNode(trailingSpace);
+        range.setStartAfter(trailingSpace);
+        range.collapse(true);
+        sel.removeAllRanges();
+        sel.addRange(range);
+        closeAcDropdown();
+        draft.text = serializeEditor(editor);
+        syncEmptyClass();
+        updatePostState();
+      }
+
+      async function updateAcDropdown() {
+        const ctx = getCaretContext();
+        if (!ctx || ctx.query.length === 0) { closeAcDropdown(); return; }
+        const follows = await getFollowList();
+        const q = ctx.query.toLowerCase();
+        acResults = follows.filter((c) => c.name && c.name.toLowerCase().includes(q)).slice(0, 8);
+        if (!acResults.length) { closeAcDropdown(); return; }
+        acIndex = Math.min(acIndex, acResults.length - 1);
+        if (!acDropdown) {
+          acDropdown = h('div', { className: 'ac-dropdown' });
+          editorWrap.append(acDropdown);
+        }
+        acDropdown.innerHTML = '';
+        acResults.forEach((c, i) => {
+          const item = h('div', { className: 'ac-item' + (i === acIndex ? ' active' : '') });
+          const av = h('span', { className: 'ac-item-av' });
+          applyAvatar(av, c.picture ? { picture: c.picture } : {});
+          item.append(av, h('span', { className: 'ac-item-name', textContent: '@' + c.name }));
+          item.addEventListener('mousedown', (e) => {
+            e.preventDefault();
+            const fresh = getCaretContext();
+            selectAcItem(c, fresh ? fresh.query : ctx.query);
+          });
+          acDropdown.append(item);
+        });
+      }
+
+      function syncEmptyClass() {
+        editor.classList.toggle('is-empty', !editor.textContent.trim() && !editor.querySelector('[data-bech32]'));
+      }
+
+      editor.addEventListener('input', () => {
+        draft.text = serializeEditor(editor);
+        syncEmptyClass();
+        updatePostState();
+        updateAcDropdown();
+      });
+
+      editor.addEventListener('keydown', (e) => {
+        if (!acDropdown) return;
+        if (e.key === 'ArrowDown') { e.preventDefault(); acIndex = Math.min(acIndex + 1, acResults.length - 1); updateAcActiveItem(); }
+        else if (e.key === 'ArrowUp') { e.preventDefault(); acIndex = Math.max(acIndex - 1, 0); updateAcActiveItem(); }
+        else if (e.key === 'Enter' || e.key === 'Tab') {
+          if (acResults[acIndex]) { e.preventDefault(); const ctx = getCaretContext(); selectAcItem(acResults[acIndex], ctx ? ctx.query : ''); }
+        } else if (e.key === 'Escape') { e.preventDefault(); closeAcDropdown(); }
+      });
+
+      editor.addEventListener('blur', () => setTimeout(closeAcDropdown, 150));
 
       const previewPane = h('div', { className: 'compose-preview hidden' });
       function renderPreview() {
@@ -1761,11 +1958,11 @@
         preview = p;
         tabWrite.classList.toggle('active', !p);
         tabPreview.classList.toggle('active', p);
-        ta.classList.toggle('hidden', p);
+        editorWrap.classList.toggle('hidden', p);
         thumbs.classList.toggle('hidden', p);
         addBtn.classList.toggle('hidden', p);
         previewPane.classList.toggle('hidden', !p);
-        if (p) renderPreview();
+        if (p) { closeAcDropdown(); renderPreview(); }
       }
       tabWrite.addEventListener('click', () => setMode(false));
       tabPreview.addEventListener('click', () => setMode(true));
@@ -1782,9 +1979,17 @@
           const rm = h('button', { className: 'compose-thumb-x', title: 'Remove' });
           rm.append(icon('trash'));
           rm.addEventListener('click', () => {
-            draft.text = draft.text.replace('\n' + m.url, '').replace(m.url, '').trimEnd();
-            ta.value = draft.text;
+            const walker = document.createTreeWalker(editor, NodeFilter.SHOW_TEXT);
+            let wn;
+            while ((wn = walker.nextNode())) {
+              if (wn.textContent.includes(m.url)) {
+                wn.textContent = wn.textContent.replace('\n' + m.url, '').replace(m.url, '');
+                break;
+              }
+            }
             draft.media.splice(i, 1);
+            draft.text = serializeEditor(editor);
+            syncEmptyClass();
             renderThumbs();
             updatePostState();
           });
@@ -1812,8 +2017,10 @@
         try {
           const url = await uploadMedia(file);
           draft.media.push({ url, isVideo: file.type.startsWith('video/') });
-          draft.text = (draft.text ? draft.text.trimEnd() + '\n' : '') + url;
-          ta.value = draft.text;
+          const urlNode = document.createTextNode((editor.textContent.trim() ? '\n' : '') + url);
+          editor.append(urlNode);
+          draft.text = serializeEditor(editor);
+          syncEmptyClass();
           renderThumbs();
           updatePostState();
         } catch (e) {
@@ -1850,7 +2057,7 @@
         h('h3', { textContent: 'New note' }),
         author,
         tabBar,
-        ta,
+        editorWrap,
         previewPane,
         thumbs,
         addBtn,
@@ -1859,7 +2066,7 @@
         h('div', { className: 'actions' }, [post, cancel])
       );
       updatePostState();
-      ta.focus();
+      editor.focus();
     }
 
     function showCountdown() {
@@ -2483,7 +2690,7 @@
     connect.addEventListener('click', async () => {
       const conn = input.value.trim();
       if (!conn) return (err.textContent = 'Paste a connection string.');
-      if (!conn.startsWith('nostr+walletconnect://')) return (err.textContent = 'That doesn’t look like an NWC string.');
+      if (!conn.startsWith('nostr+walletconnect://')) return (err.textContent = "That doesn't look like an NWC string.");
       err.textContent = '';
       connect.disabled = true;
       connect.textContent = 'Connecting…';
@@ -3150,7 +3357,7 @@
       });
       modal.append(
         h('h3', { textContent: 'Disconnect wallet?' }),
-        h('p', { className: 'hint', textContent: 'Removes this account’s saved NWC connection from Sidecar. Your wallet and funds are unaffected.' }),
+        h('p', { className: 'hint', textContent: "Removes this account's saved NWC connection from Sidecar. Your wallet and funds are unaffected." }),
         h('div', { className: 'actions' }, [go, cancel])
       );
     });

--- a/styles.css
+++ b/styles.css
@@ -746,6 +746,32 @@ button:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(203, 161, 78, 0
   width: 100%; min-height: 120px; resize: vertical; box-sizing: border-box;
   font-family: var(--font-ui); font-size: 15px; line-height: 1.5;
 }
+/* contenteditable composer */
+.compose-editor-wrap { position: relative; }
+.compose-editor {
+  min-height: 120px; max-height: 240px; overflow-y: auto; resize: none;
+  outline: none; cursor: text; white-space: pre-wrap; word-break: break-word;
+}
+.compose-editor.is-empty::before {
+  content: attr(data-placeholder); color: var(--muted); pointer-events: none; display: block;
+}
+/* @mention atomic pill */
+.mention-pill {
+  display: inline-block; background: rgba(167, 139, 250, 0.18); color: var(--lav);
+  border-radius: 10px; padding: 1px 7px; font-size: 13.5px; font-weight: 600;
+  cursor: default; white-space: nowrap; line-height: 1.5; user-select: all;
+}
+/* @mention autocomplete dropdown */
+.ac-dropdown {
+  position: absolute; top: calc(100% + 4px); left: 0; right: 0; z-index: 50;
+  background: var(--bg-2); border: 1px solid var(--border-strong); border-radius: 10px;
+  box-shadow: var(--shadow); max-height: 200px; overflow-y: auto;
+}
+.ac-item { display: flex; align-items: center; gap: 9px; padding: 8px 12px; cursor: pointer; font-size: 13px; }
+.ac-item:hover, .ac-item.active { background: rgba(167, 139, 250, 0.1); }
+.ac-item-av { width: 26px; height: 26px; border-radius: 50%; overflow: hidden; flex-shrink: 0; background: var(--velvet-1); border: 1px solid var(--border); }
+.ac-item-av img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.ac-item-name { font-weight: 600; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .compose-preview {
   min-height: 120px; max-height: 46vh; overflow-y: auto;
   border: 1px solid var(--border); border-radius: 10px; padding: 12px;


### PR DESCRIPTION
## Summary

- Replaces the compose textarea with a `contenteditable` div, enabling rich inline content
- Typing `@` triggers an autocomplete dropdown populated from the active account's follow list (kind:3 → bulk kind:0 profile fetch, cached per account)
- Selecting a contact inserts an atomic pill (`contenteditable="false"` span) that deletes as a unit and serializes to `nostr:npub1…` in the event content
- Each `@mention` pill automatically adds a `["p", pubkey]` tag to the published event
- NBSP used as the post-pill separator to prevent browser whitespace collapse; normalized to a regular space by the serializer
- Auto-inserts a leading space when `@` immediately follows a non-whitespace character (`word@name` → `word @name`)
- `PREVIEW_RE` now uses exact lengths for `npub1`/`note1` (`{58}`) and minimums for TLV types, preventing the regex from greedily consuming adjacent lowercase words as bech32 characters
- Arrow keys, Enter/Tab, and Escape navigate and dismiss the dropdown; clicking an item works without stealing focus from the editor

## Test plan

- [ ] Open composer, type `@` + a letter from someone you follow — dropdown appears with avatar and name
- [ ] Arrow keys and Enter select; Escape dismisses without inserting
- [ ] Clicking an item inserts the pill without losing editor focus
- [ ] The pill deletes atomically (Backspace removes the whole chip, not char by char)
- [ ] `word@name` auto-inserts a space before the pill
- [ ] Preview tab renders inserted pills as orange `@name` mentions
- [ ] Published event content has `nostr:npub1…` for each pill, with correct `["p", pubkey]` tags
- [ ] Media upload and remove still work correctly with the contenteditable editor
- [ ] Countdown/cancel flow returns to editor with draft text preserved

🍹 Shaken with [Claude Code](https://claude.com/claude-code)