### PR TITLE
feat: OG link preview cards in composer + README refresh (Phase 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,16 @@ A NIP-07 nostr signing extension that lives in your browser's side panel. Sideca
 holds your keys locally — encrypted behind a PIN — and provides `window.nostr` to the
 web apps you use, so you can sign in and sign events across nostr clients without
 pasting your nsec anywhere. It also has a built-in Lightning wallet (Nostr Wallet
-Connect) for sending and receiving sats.
+Connect) and a composer for posting notes directly from the panel.
 
 <img width="2816" height="1566" alt="Sidecar" src="https://i.nostr.build/Sr11DBpz7pVITHoS.png" />
+
+## Install
+
+**[Get Sidecar on the Chrome Web Store](https://chromewebstore.google.com/detail/sidecar-a-classy-nostr-si/moimlikilhheabdafocpmneehpblhiln)**
+— works in Chrome, Brave, Edge, and other Chromium browsers.
+
+Or run from source (no build step required — see below).
 
 ## Features
 
@@ -19,6 +26,11 @@ Connect) for sending and receiving sats.
 - **Per-site account binding** — each site stays pinned to the account it logged in with (no NIP-07 desync). Switch a site to another account from **Connected Sites**.
 - **Identity from your profile** — account names and avatars are imported from your kind 0 metadata; view and edit your profile and publish kind 0.
 - **Backups** — encrypt your profile, follows, and mute list to your own key and store them on your relays (NIP-78), or export a signed JSON bundle.
+- **Note composer** — post kind:1 notes directly from the panel with a 15-second undo window. Features include:
+  - **@mention autocomplete** — type `@` to search your follow list; selecting inserts an atomic pill that serializes to `nostr:npub1…` and adds a `p` tag automatically.
+  - **Nostr event embeds** — paste a `note1`, `nevent1`, or `naddr1` entity and the preview renders a fetched embed card (author, timestamp, content excerpt).
+  - **Link previews** — plain URLs show an OG meta card (title, description, thumbnail) fetched through the extension with no third-party service.
+  - **Media upload** — attach images and video; files are uploaded and appended as URLs.
 - **Lightning wallet (NWC)** — connect any Nostr Wallet Connect wallet (Alby Hub, Rizful, YakiHonne, …). Send (BOLT11 or lightning address via LNURL-pay), receive (invoice or your lightning address QR), view paginated history, and back up the connection to your relays. Sidecar never holds your funds.
 - **WebLN provider** — web apps can pay and make invoices through your connected wallet (`window.webln`), gated by an approval prompt with an optional per-site daily budget you can edit or revoke any time.
 - **Pay invoices from any page** — when a nostr client you're signed into shows a Lightning invoice, a **Pay with Sidecar** card appears so you can pay in a tap. You can also right-click a `lightning:` link, a selected BOLT11 invoice, or a QR image.

--- a/background.js
+++ b/background.js
@@ -687,6 +687,41 @@ async function handleControl(message, sendResponse) {
         await lockKeystore();
         result = await KS.getState();
         break;
+      case 'SIDECAR_FETCH_OG': {
+        // Fetch a URL from the SW (no CORS restriction) and parse OG/meta tags.
+        // Returns { title, description, image, site } or null on failure.
+        const ogUrl = message.url;
+        try {
+          const resp = await fetch(ogUrl, { signal: AbortSignal.timeout(8000) });
+          if (!resp.ok) { result = null; break; }
+          const ct = resp.headers.get('content-type') || '';
+          if (!ct.includes('text/html')) { result = null; break; }
+          const html = await resp.text();
+          const pick = (html, ...patterns) => {
+            for (const p of patterns) { const m = html.match(p); if (m) return m[1].trim(); }
+            return null;
+          };
+          result = {
+            title: pick(html,
+              /<meta[^>]+property=["']og:title["'][^>]+content=["']([^"'<>]+)["']/i,
+              /<meta[^>]+content=["']([^"'<>]+)["'][^>]+property=["']og:title["']/i,
+              /<title[^>]*>([^<]{1,200})<\/title>/i),
+            description: pick(html,
+              /<meta[^>]+property=["']og:description["'][^>]+content=["']([^"'<>]+)["']/i,
+              /<meta[^>]+content=["']([^"'<>]+)["'][^>]+property=["']og:description["']/i,
+              /<meta[^>]+name=["']description["'][^>]+content=["']([^"'<>]+)["']/i,
+              /<meta[^>]+content=["']([^"'<>]+)["'][^>]+name=["']description["']/i),
+            image: pick(html,
+              /<meta[^>]+property=["']og:image["'][^>]+content=["']([^"'<>]+)["']/i,
+              /<meta[^>]+content=["']([^"'<>]+)["'][^>]+property=["']og:image["']/i),
+            site: pick(html,
+              /<meta[^>]+property=["']og:site_name["'][^>]+content=["']([^"'<>]+)["']/i,
+              /<meta[^>]+content=["']([^"'<>]+)["'][^>]+property=["']og:site_name["']/i),
+          };
+          if (!result.title && !result.description) result = null;
+        } catch (_) { result = null; }
+        break;
+      }
       case 'SIDECAR_RESET_ALL':
         // Wipe everything: in-memory keys/session/wallet (lockKeystore) plus all
         // persisted data (keystore, accounts, permissions, relays, settings, site

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -1680,6 +1680,13 @@
           a.href = url; a.target = '_blank'; a.rel = 'noreferrer noopener';
           a.textContent = url;
           container.append(a);
+          if (url.startsWith('https://')) {
+            const card = document.createElement('a');
+            card.className = 'link-card loading';
+            card.textContent = 'Loading preview…';
+            container.append(card);
+            fetchOgMeta(url).then((meta) => renderLinkCard(card, url, meta));
+          }
         }
       } else if (m[2]) {
         const bech = m[2];
@@ -1757,6 +1764,42 @@
       if (p.picture) applyAvatar(av, { picture: p.picture });
       if (p.name) name.textContent = '@' + p.name;
     });
+  }
+
+  // ---- OG / link preview cards ----
+  const ogCache = new Map(); // url → { title, description, image, site } | null
+
+  async function fetchOgMeta(url) {
+    if (ogCache.has(url)) return ogCache.get(url);
+    ogCache.set(url, null); // mark in-flight so parallel calls don't double-fetch
+    try {
+      const meta = await call({ type: 'SIDECAR_FETCH_OG', url });
+      ogCache.set(url, meta);
+      return meta;
+    } catch (_) { return null; }
+  }
+
+  function renderLinkCard(container, url, meta) {
+    container.classList.remove('loading');
+    if (!meta) { container.remove(); return; }
+    container.innerHTML = '';
+    const body = h('div', { className: 'link-card-body' });
+    if (meta.site) body.append(h('div', { className: 'link-card-site', textContent: meta.site }));
+    if (meta.title) body.append(h('div', { className: 'link-card-title', textContent: meta.title }));
+    if (meta.description) body.append(h('div', { className: 'link-card-desc', textContent: meta.description }));
+    const isHttps = (s) => typeof s === 'string' && s.startsWith('https://');
+    if (isHttps(meta.image)) {
+      const img = document.createElement('img');
+      img.className = 'link-card-img';
+      img.referrerPolicy = 'no-referrer';
+      img.src = meta.image;
+      img.onerror = () => img.remove();
+      container.append(img);
+    }
+    container.append(body);
+    container.href = url;
+    container.target = '_blank';
+    container.rel = 'noreferrer noopener';
   }
 
   // Serialize a contenteditable editor div to plain nostr text.

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -1779,14 +1779,21 @@
     } catch (_) { return null; }
   }
 
+  function decodeHtml(s) {
+    if (!s) return s;
+    const t = document.createElement('textarea');
+    t.innerHTML = s;
+    return t.value;
+  }
+
   function renderLinkCard(container, url, meta) {
     container.classList.remove('loading');
     if (!meta) { container.remove(); return; }
     container.innerHTML = '';
     const body = h('div', { className: 'link-card-body' });
-    if (meta.site) body.append(h('div', { className: 'link-card-site', textContent: meta.site }));
-    if (meta.title) body.append(h('div', { className: 'link-card-title', textContent: meta.title }));
-    if (meta.description) body.append(h('div', { className: 'link-card-desc', textContent: meta.description }));
+    if (meta.site) body.append(h('div', { className: 'link-card-site', textContent: decodeHtml(meta.site) }));
+    if (meta.title) body.append(h('div', { className: 'link-card-title', textContent: decodeHtml(meta.title) }));
+    if (meta.description) body.append(h('div', { className: 'link-card-desc', textContent: decodeHtml(meta.description) }));
     const isHttps = (s) => typeof s === 'string' && s.startsWith('https://');
     if (isHttps(meta.image)) {
       const img = document.createElement('img');

--- a/styles.css
+++ b/styles.css
@@ -806,6 +806,21 @@ button:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(203, 161, 78, 0
 .compose-add { display: inline-flex; align-items: center; gap: 7px; margin: 6px 0 2px; }
 .compose-add svg { width: 15px; height: 15px; }
 
+/* link / OG preview card in note preview */
+.link-card {
+  display: block; margin: 8px 0; border: 1px solid var(--border); border-radius: 12px;
+  overflow: hidden; text-decoration: none; color: inherit;
+  background: linear-gradient(150deg, var(--velvet-1), var(--velvet-2));
+  transition: border-color 0.15s;
+}
+.link-card:hover { border-color: var(--border-strong); }
+.link-card.loading { padding: 10px 12px; color: var(--faint); font-size: 12px; }
+.link-card-img { width: 100%; max-height: 140px; object-fit: cover; display: block; }
+.link-card-body { padding: 10px 12px; }
+.link-card-site { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 3px; }
+.link-card-title { font-weight: 600; font-size: 13px; color: var(--text); margin-bottom: 4px; line-height: 1.35; }
+.link-card-desc { font-size: 12px; color: var(--text-2); line-height: 1.45; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
+
 /* send countdown ring */
 .countdown-wrap { position: relative; width: 92px; height: 92px; margin: 14px auto 6px; }
 .countdown-ring { width: 92px; height: 92px; transform: rotate(0deg); }


### PR DESCRIPTION
## Summary

- URLs in the composer preview now render a fetched link card below the raw link: site name, title, description, and thumbnail image
- Fetch runs in the service worker (no CORS restriction, no third-party service) and results are cached per panel session
- OG tags parsed via regex from the SW-fetched HTML; cards only render when at least a title or description is found; HTTPS-only images loaded with `referrerpolicy="no-referrer"`
- HTML entities in OG metadata are decoded before display (`&#039;` → `'` etc.)
- Updates the README to reflect the full current feature set: composer with `@mention` autocomplete, nostr event embeds, and link previews; adds a prominent Chrome Web Store install link at the top

## Test plan

- [ ] Paste `https://github.com/dmnyc/sidecar` into the composer — preview tab shows the repo OG card with image, title, and description
- [ ] Paste a Wikipedia URL — title and description render with correct punctuation (no raw HTML entities)
- [ ] Paste a URL with no OG tags — no card rendered, just the raw link
- [ ] Paste a non-HTTPS URL — no card attempt
- [ ] Paste an image or video URL — renders as inline media, no OG card
- [ ] README renders correctly on GitHub with the store link prominent at the top

🍷 Poured with [Claude Code](https://claude.com/claude-code)