### PR TITLE
Onboarding: welcome page, composer paste, relay fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,16 @@ A NIP-07 nostr signing extension that lives in your browser's side panel. Sideca
 holds your keys locally — encrypted behind a PIN — and provides `window.nostr` to the
 web apps you use, so you can sign in and sign events across nostr clients without
 pasting your nsec anywhere. It also has a built-in Lightning wallet (Nostr Wallet
-Connect) for sending and receiving sats.
+Connect) and a composer for posting notes directly from the panel.
 
 <img width="2816" height="1566" alt="Sidecar" src="https://i.nostr.build/Sr11DBpz7pVITHoS.png" />
 
+## Install
+
 **[Install from the Chrome Web Store →](https://chromewebstore.google.com/detail/sidecar-a-classy-nostr-si/moimlikilhheabdafocpmneehpblhiln)**
+— works in Chrome, Brave, Edge, and other Chromium browsers.
+
+Or run from source (no build step required — see below).
 
 ## Features
 
@@ -21,6 +26,11 @@ Connect) for sending and receiving sats.
 - **Per-site account binding** — each site stays pinned to the account it logged in with (no NIP-07 desync). Switch a site to another account from **Connected Sites**.
 - **Identity from your profile** — account names and avatars are imported from your kind 0 metadata; view and edit your profile and publish kind 0.
 - **Backups** — encrypt your profile, follows, and mute list to your own key and store them on your relays (NIP-78), or export a signed JSON bundle.
+- **Note composer** — post kind:1 notes directly from the panel with a 15-second undo window. Features include:
+  - **@mention autocomplete** — type `@` to search your follow list; selecting inserts an atomic pill that serializes to `nostr:npub1…` and adds a `p` tag automatically.
+  - **Nostr event embeds** — paste a `note1`, `nevent1`, or `naddr1` entity and the preview renders a fetched embed card (author, timestamp, content excerpt).
+  - **Link previews** — plain URLs show an OG meta card (title, description, thumbnail) fetched through the extension with no third-party service.
+  - **Media upload** — attach images and video; files are uploaded and appended as URLs.
 - **Lightning wallet (NWC)** — connect any Nostr Wallet Connect wallet (Alby Hub, Rizful, YakiHonne, …). Send (BOLT11 or lightning address via LNURL-pay), receive (invoice or your lightning address QR), view paginated history, and back up the connection to your relays. Sidecar never holds your funds.
 - **WebLN provider** — web apps can pay and make invoices through your connected wallet (`window.webln`), gated by an approval prompt with an optional per-site daily budget you can edit or revoke any time.
 - **Pay invoices from any page** — when a nostr client you're signed into shows a Lightning invoice, a **Pay with Sidecar** card appears so you can pay in a tap. You can also right-click a `lightning:` link, a selected BOLT11 invoice, or a QR image.

--- a/background.js
+++ b/background.js
@@ -687,6 +687,41 @@ async function handleControl(message, sendResponse) {
         await lockKeystore();
         result = await KS.getState();
         break;
+      case 'SIDECAR_FETCH_OG': {
+        // Fetch a URL from the SW (no CORS restriction) and parse OG/meta tags.
+        // Returns { title, description, image, site } or null on failure.
+        const ogUrl = message.url;
+        try {
+          const resp = await fetch(ogUrl, { signal: AbortSignal.timeout(8000) });
+          if (!resp.ok) { result = null; break; }
+          const ct = resp.headers.get('content-type') || '';
+          if (!ct.includes('text/html')) { result = null; break; }
+          const html = await resp.text();
+          const pick = (html, ...patterns) => {
+            for (const p of patterns) { const m = html.match(p); if (m) return m[1].trim(); }
+            return null;
+          };
+          result = {
+            title: pick(html,
+              /<meta[^>]+property=["']og:title["'][^>]+content=["']([^"'<>]+)["']/i,
+              /<meta[^>]+content=["']([^"'<>]+)["'][^>]+property=["']og:title["']/i,
+              /<title[^>]*>([^<]{1,200})<\/title>/i),
+            description: pick(html,
+              /<meta[^>]+property=["']og:description["'][^>]+content=["']([^"'<>]+)["']/i,
+              /<meta[^>]+content=["']([^"'<>]+)["'][^>]+property=["']og:description["']/i,
+              /<meta[^>]+name=["']description["'][^>]+content=["']([^"'<>]+)["']/i,
+              /<meta[^>]+content=["']([^"'<>]+)["'][^>]+name=["']description["']/i),
+            image: pick(html,
+              /<meta[^>]+property=["']og:image["'][^>]+content=["']([^"'<>]+)["']/i,
+              /<meta[^>]+content=["']([^"'<>]+)["'][^>]+property=["']og:image["']/i),
+            site: pick(html,
+              /<meta[^>]+property=["']og:site_name["'][^>]+content=["']([^"'<>]+)["']/i,
+              /<meta[^>]+content=["']([^"'<>]+)["'][^>]+property=["']og:site_name["']/i),
+          };
+          if (!result.title && !result.description) result = null;
+        } catch (_) { result = null; }
+        break;
+      }
       case 'SIDECAR_RESET_ALL':
         // Wipe everything: in-memory keys/session/wallet (lockKeystore) plus all
         // persisted data (keystore, accounts, permissions, relays, settings, site

--- a/background.js
+++ b/background.js
@@ -19,7 +19,8 @@ const NWC = self.SidecarNWC;
 const DEFAULT_RELAYS = {
   'wss://relay.damus.io': { read: true, write: true },
   'wss://nos.lol': { read: true, write: true },
-  'wss://relay.primal.net': { read: true, write: true },
+  'wss://relay.snort.social': { read: true, write: true },
+  'wss://relay.primal.net': { read: true, write: false },
 };
 
 const AUTO_LOCK_ALARM = 'sidecar-auto-lock';

--- a/background.js
+++ b/background.js
@@ -87,9 +87,13 @@ async function logActivity(entry) {
 }
 
 // ---- side panel open on toolbar click ----
-chrome.runtime.onInstalled.addListener(() => {
+chrome.runtime.onInstalled.addListener((details) => {
   chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true }).catch(() => {});
   createPayMenu();
+  if (details.reason === 'install') {
+    chrome.storage.local.remove('firstPostTipDismissed');
+    chrome.tabs.create({ url: chrome.runtime.getURL('welcome.html') });
+  }
 });
 chrome.action.onClicked.addListener((tab) => {
   chrome.sidePanel.open({ tabId: tab.id }).catch(() => {});

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -79,6 +79,9 @@
           <button class="secondary" id="add-generate">Generate new</button>
           <button class="secondary" id="add-import">Import nsec</button>
         </div>
+        <div class="explore-link-wrap">
+          <a class="explore-link" id="explore-apps-link" href="#">Explore nostr apps →</a>
+        </div>
       </div>
 
       <!-- Activity: signing history + per-site permission tiers -->
@@ -113,6 +116,7 @@
       </div>
     </main>
 
+    <div id="first-post-balloon" class="first-post-balloon hidden">Try the composer →</div>
     <button id="compose-fab" class="fab" title="Post a note">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20.24 12.24a6 6 0 0 0-8.49-8.49L5 10.5V19h8.5z"></path><line x1="16" y1="8" x2="2" y2="22"></line><line x1="17.5" y1="15" x2="9" y2="15"></line></svg>
     </button>

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -1680,6 +1680,13 @@
           a.href = url; a.target = '_blank'; a.rel = 'noreferrer noopener';
           a.textContent = url;
           container.append(a);
+          if (url.startsWith('https://')) {
+            const card = document.createElement('a');
+            card.className = 'link-card loading';
+            card.textContent = 'Loading preview…';
+            container.append(card);
+            fetchOgMeta(url).then((meta) => renderLinkCard(card, url, meta));
+          }
         }
       } else if (m[2]) {
         const bech = m[2];
@@ -1757,6 +1764,42 @@
       if (p.picture) applyAvatar(av, { picture: p.picture });
       if (p.name) name.textContent = '@' + p.name;
     });
+  }
+
+  // ---- OG / link preview cards ----
+  const ogCache = new Map(); // url → { title, description, image, site } | null
+
+  async function fetchOgMeta(url) {
+    if (ogCache.has(url)) return ogCache.get(url);
+    ogCache.set(url, null); // mark in-flight so parallel calls don't double-fetch
+    try {
+      const meta = await call({ type: 'SIDECAR_FETCH_OG', url });
+      ogCache.set(url, meta);
+      return meta;
+    } catch (_) { return null; }
+  }
+
+  function renderLinkCard(container, url, meta) {
+    container.classList.remove('loading');
+    if (!meta) { container.remove(); return; }
+    container.innerHTML = '';
+    const body = h('div', { className: 'link-card-body' });
+    if (meta.site) body.append(h('div', { className: 'link-card-site', textContent: meta.site }));
+    if (meta.title) body.append(h('div', { className: 'link-card-title', textContent: meta.title }));
+    if (meta.description) body.append(h('div', { className: 'link-card-desc', textContent: meta.description }));
+    const isHttps = (s) => typeof s === 'string' && s.startsWith('https://');
+    if (isHttps(meta.image)) {
+      const img = document.createElement('img');
+      img.className = 'link-card-img';
+      img.referrerPolicy = 'no-referrer';
+      img.src = meta.image;
+      img.onerror = () => img.remove();
+      container.append(img);
+    }
+    container.append(body);
+    container.href = url;
+    container.target = '_blank';
+    container.rel = 'noreferrer noopener';
   }
 
   // Serialize a contenteditable editor div to plain nostr text.

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -112,7 +112,8 @@
   );
 
   let state = null;
-  let hideBalances = false; // privacy toggle (persisted in settings)
+  let hideBalances = false;
+  let _firstPostSeenPubkeys = null;
   let balanceCache = { pubkey: null, sats: null }; // last known balance for instant display
 
   // Privacy masking is done in CSS (-webkit-text-security on `.balances-hidden`),
@@ -237,7 +238,19 @@
     toast('Locked', 'success');
   });
 
-  $('compose-fab').addEventListener('click', () => openComposer());
+  $('compose-fab').addEventListener('click', () => {
+    const balloon = $('first-post-balloon');
+    const isFirstTime = balloon && !balloon.classList.contains('hidden') && state?.activePubkey;
+    if (isFirstTime) {
+      _firstPostSeenPubkeys = _firstPostSeenPubkeys || new Set();
+      _firstPostSeenPubkeys.add(state.activePubkey);
+      chrome.storage.local.set({ firstPostTipSeenPubkeys: [..._firstPostSeenPubkeys] });
+      balloon.classList.add('hidden');
+      openComposer('Just setting up my #Sidecar 🍸');
+    } else {
+      openComposer();
+    }
+  });
 
   // Dim the FAB while the content is actively scrolling so it doesn't distract;
   // snap back ~160ms after scrolling stops (mirrors zap.cooking's create FAB).
@@ -590,6 +603,14 @@
       if (t) t.disabled = !hasAccounts;
     });
     $('compose-fab').disabled = !hasAccounts;
+    const balloon = $('first-post-balloon');
+    if (balloon) {
+      const showBalloon = hasAccounts &&
+        !!state.activePubkey &&
+        _firstPostSeenPubkeys !== null &&
+        !_firstPostSeenPubkeys.has(state.activePubkey);
+      balloon.classList.toggle('hidden', !showBalloon);
+    }
     if (!hasAccounts) {
       document.querySelectorAll('.tab').forEach((t) => t.classList.remove('active'));
       const acc = document.querySelector('.tab[data-tab="accounts"]');
@@ -746,6 +767,29 @@
   labelButton('add-import', 'download', 'Import nsec');
   $('add-generate').addEventListener('click', () => generateAccount());
   $('add-import').addEventListener('click', () => importAccountModal());
+  $('explore-apps-link').addEventListener('click', (e) => {
+    e.preventDefault();
+    chrome.tabs.create({ url: chrome.runtime.getURL('welcome.html') });
+  });
+
+  // ---- first-post tip balloon (once per imported nsec) ----
+  (function initFirstPostBalloon() {
+    const balloon = $('first-post-balloon');
+    if (!balloon) return;
+    chrome.storage.local.get('firstPostTipSeenPubkeys', ({ firstPostTipSeenPubkeys }) => {
+      _firstPostSeenPubkeys = new Set(Array.isArray(firstPostTipSeenPubkeys) ? firstPostTipSeenPubkeys : []);
+      if (state?.accounts) renderMain();
+    });
+    balloon.addEventListener('click', () => {
+      if (state?.activePubkey) {
+        _firstPostSeenPubkeys = _firstPostSeenPubkeys || new Set();
+        _firstPostSeenPubkeys.add(state.activePubkey);
+        chrome.storage.local.set({ firstPostTipSeenPubkeys: [..._firstPostSeenPubkeys] });
+      }
+      balloon.classList.add('hidden');
+      openComposer('Just setting up my #Sidecar 🍸');
+    });
+  })();
 
   // ---- modals ----
   let modalCleanup = null;
@@ -1831,12 +1875,12 @@
     return out;
   }
 
-  function openComposer() {
+  function openComposer(initialText) {
     if (!state.activePubkey) {
       toast('Add an account first', 'error');
       return;
     }
-    const draft = { text: '', media: [] };
+    const draft = { text: initialText || '', media: [] };
     const modal = $('modal');
     let timer = null;
 

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -1779,14 +1779,21 @@
     } catch (_) { return null; }
   }
 
+  function decodeHtml(s) {
+    if (!s) return s;
+    const t = document.createElement('textarea');
+    t.innerHTML = s;
+    return t.value;
+  }
+
   function renderLinkCard(container, url, meta) {
     container.classList.remove('loading');
     if (!meta) { container.remove(); return; }
     container.innerHTML = '';
     const body = h('div', { className: 'link-card-body' });
-    if (meta.site) body.append(h('div', { className: 'link-card-site', textContent: meta.site }));
-    if (meta.title) body.append(h('div', { className: 'link-card-title', textContent: meta.title }));
-    if (meta.description) body.append(h('div', { className: 'link-card-desc', textContent: meta.description }));
+    if (meta.site) body.append(h('div', { className: 'link-card-site', textContent: decodeHtml(meta.site) }));
+    if (meta.title) body.append(h('div', { className: 'link-card-title', textContent: decodeHtml(meta.title) }));
+    if (meta.description) body.append(h('div', { className: 'link-card-desc', textContent: decodeHtml(meta.description) }));
     const isHttps = (s) => typeof s === 'string' && s.startsWith('https://');
     if (isHttps(meta.image)) {
       const img = document.createElement('img');

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -2015,7 +2015,9 @@
       }
 
       function syncEmptyClass() {
-        editor.classList.toggle('is-empty', !editor.textContent.trim() && !editor.querySelector('[data-bech32]'));
+        const isEmpty = !editor.textContent.trim() && !editor.querySelector('[data-bech32]');
+        editor.classList.toggle('is-empty', isEmpty);
+        if (isEmpty) editor.innerHTML = '';
       }
 
       editor.addEventListener('input', () => {
@@ -2111,7 +2113,8 @@
         try {
           const url = await uploadMedia(file);
           draft.media.push({ url, isVideo: file.type.startsWith('video/') });
-          const urlNode = document.createTextNode((editor.textContent.trim() ? '\n' : '') + url);
+          const t = editor.textContent;
+          const urlNode = document.createTextNode((t.length && !/\s$/.test(t) ? '\n' : '') + url);
           editor.append(urlNode);
           draft.text = serializeEditor(editor);
           syncEmptyClass();
@@ -2124,6 +2127,42 @@
         addBtn.disabled = false;
         lbl.textContent = prev;
         fileInput.value = '';
+      });
+
+      editor.addEventListener('paste', async (e) => {
+        const imageFiles = Array.from(e.clipboardData?.items ?? [])
+          .filter((item) => item.kind === 'file' && item.type.startsWith('image/'))
+          .map((item) => item.getAsFile())
+          .filter((f) => f !== null);
+        if (imageFiles.length === 0) {
+          e.preventDefault();
+          const plain = e.clipboardData.getData('text/plain');
+          if (plain) document.execCommand('insertText', false, plain);
+          return;
+        }
+        e.preventDefault();
+        addBtn.disabled = true;
+        const lbl = addBtn.querySelector('span');
+        const prev = lbl.textContent;
+        lbl.textContent = 'Uploading…';
+        try {
+          for (const file of imageFiles) {
+            const url = await uploadMedia(file);
+            draft.media.push({ url, isVideo: false });
+            const t = editor.textContent;
+            const urlNode = document.createTextNode((t.length && !/\s$/.test(t) ? '\n' : '') + url);
+            editor.append(urlNode);
+          }
+          draft.text = serializeEditor(editor);
+          syncEmptyClass();
+          renderThumbs();
+          updatePostState();
+        } catch (e) {
+          err.textContent = e.message;
+          toast(e.message, 'error');
+        }
+        addBtn.disabled = false;
+        lbl.textContent = prev;
       });
 
       const err = h('div', { className: 'error' });

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -1373,6 +1373,54 @@
   const mentionNameCache = new Map(); // pubkey -> name|null
   const TOKEN_RE = /(https?:\/\/[^\s]+)|(?:nostr:)?((?:npub1|nprofile1)[0-9a-z]+)/gi;
 
+  // Follow list cache for @mention autocomplete (invalidated on account switch)
+  let followListCache = null;
+  let followListPubkey = null;
+
+  async function getFollowList() {
+    if (followListCache && followListPubkey === state.activePubkey) return followListCache;
+    followListPubkey = state.activePubkey;
+    if (!state.activePubkey) return (followListCache = []);
+    try {
+      const relays = await relayUrls(false);
+      const ev = await Promise.race([
+        poolGet(relays, { kinds: [3], authors: [state.activePubkey] }),
+        new Promise((r) => setTimeout(() => r(null), 5000)),
+      ]);
+      if (!ev) return (followListCache = []);
+      const pubkeys = (ev.tags || [])
+        .filter((t) => t[0] === 'p')
+        .map((t) => t[1])
+        .filter((pk) => pk && pk.length === 64);
+      if (!pubkeys.length) return (followListCache = []);
+      const profiles = await Promise.race([
+        getPool().querySync(relays, { kinds: [0], authors: pubkeys }),
+        new Promise((r) => setTimeout(() => r([]), 6000)),
+      ]);
+      const byPk = {};
+      (profiles || []).forEach((p) => {
+        if (!byPk[p.pubkey] || p.created_at > byPk[p.pubkey].created_at) byPk[p.pubkey] = p;
+      });
+      followListCache = pubkeys
+        .map((pk) => {
+          let name = null, picture = null;
+          const prof = byPk[pk];
+          if (prof) {
+            try {
+              const c = JSON.parse(prof.content);
+              name = c.display_name || c.name || null;
+              picture = c.picture || null;
+            } catch (_) {}
+          }
+          return { pubkey: pk, name, picture };
+        })
+        .filter((c) => c.name);
+      return followListCache;
+    } catch (_) {
+      return (followListCache = []);
+    }
+  }
+
   function npubChip(npub) {
     const el = h('div', { className: 'profile-npub', title: 'Copy npub' });
     el.append(icon('copy'), h('span', { textContent: shortNpub(npub) }));
@@ -1601,7 +1649,9 @@
   // Composer preview: inline media / links, profile mentions (@name), and nostr
   // event refs (note1/nevent/naddr) rendered as embed cards fetched from the
   // user's own relays.
-  const PREVIEW_RE = /(https?:\/\/[^\s]+)|(?:nostr:)?(npub1[0-9a-z]+|nprofile1[0-9a-z]+|note1[0-9a-z]+|nevent1[0-9a-z]+|naddr1[0-9a-z]+)/gi;
+  // npub1/note1 are always exactly 63 chars (5+58); use {58} to prevent the regex
+  // from greedily consuming adjacent lowercase words as bech32 characters.
+  const PREVIEW_RE = /(https?:\/\/[^\s]+)|(?:nostr:)?(npub1[0-9a-z]{58}|nprofile1[0-9a-z]{50,}|note1[0-9a-z]{58}|nevent1[0-9a-z]{50,}|naddr1[0-9a-z]{50,})/gi;
   function renderNotePreview(container, text) {
     const mentions = [];
     const embeds = [];
@@ -1709,6 +1759,28 @@
     });
   }
 
+  // Serialize a contenteditable editor div to plain nostr text.
+  // Text nodes → text, BR → \n, block divs → \n prefix, pill spans → their data-bech32.
+  //   (NBSP used after pills to prevent browser whitespace collapse) → regular space.
+  function serializeEditor(el) {
+    let out = '';
+    const walk = (node) => {
+      if (node.nodeType === Node.TEXT_NODE) {
+        out += node.textContent.replace(/ /g, ' ');
+      } else if (node.nodeName === 'BR') {
+        out += '\n';
+      } else if (node.dataset && node.dataset.bech32) {
+        out += node.dataset.bech32;
+      } else {
+        const isBlock = node.nodeName === 'DIV' || node.nodeName === 'P';
+        if (isBlock && out && !out.endsWith('\n')) out += '\n';
+        node.childNodes.forEach(walk);
+      }
+    };
+    el.childNodes.forEach(walk);
+    return out;
+  }
+
   function openComposer() {
     if (!state.activePubkey) {
       toast('Add an account first', 'error');
@@ -1720,10 +1792,21 @@
 
     async function doPublish() {
       const content = draft.text.trim();
+      const pTags = [];
+      const seenPks = new Set();
+      const mentionRe = /nostr:(npub1[0-9a-z]+|nprofile1[0-9a-z]+)/g;
+      let mm;
+      while ((mm = mentionRe.exec(content)) !== null) {
+        try {
+          const d = NT.nip19.decode(mm[1]);
+          const pk = d.type === 'npub' ? d.data : d.data.pubkey;
+          if (pk && !seenPks.has(pk)) { seenPks.add(pk); pTags.push(['p', pk]); }
+        } catch (_) {}
+      }
       const event = {
         kind: 1,
         created_at: Math.floor(Date.now() / 1000),
-        tags: [CLIENT_TAG.slice()],
+        tags: [CLIENT_TAG.slice(), ...pTags],
         content,
       };
       const signed = await call({ type: 'SIDECAR_OWNER_SIGN', event });
@@ -1741,9 +1824,123 @@
       const tabPreview = h('button', { className: 'compose-tab', textContent: 'Preview' });
       const tabBar = h('div', { className: 'compose-tabs' }, [tabWrite, tabPreview]);
 
-      const ta = h('textarea', { className: 'compose-text', placeholder: 'What’s on your mind?' });
-      ta.value = draft.text;
-      ta.addEventListener('input', () => { draft.text = ta.value; updatePostState(); });
+      const editor = h('div', { className: 'compose-text compose-editor is-empty', contentEditable: 'true' });
+      editor.dataset.placeholder = "What’s on your mind?";
+      if (draft.text) { editor.textContent = draft.text; editor.classList.remove('is-empty'); }
+
+      const editorWrap = h('div', { className: 'compose-editor-wrap' });
+      editorWrap.append(editor);
+
+      // ---- @mention autocomplete ----
+      let acDropdown = null, acResults = [], acIndex = 0;
+
+      function getCaretContext() {
+        const sel = window.getSelection();
+        if (!sel.rangeCount) return null;
+        const range = sel.getRangeAt(0);
+        if (!range.collapsed) return null;
+        const node = range.startContainer;
+        if (node.nodeType !== Node.TEXT_NODE || !editor.contains(node)) return null;
+        const before = node.textContent.slice(0, range.startOffset);
+        const match = before.match(/@([^\s@]*)$/);
+        if (!match) return null;
+        return { node, query: match[1] };
+      }
+
+      function closeAcDropdown() {
+        if (acDropdown) { acDropdown.remove(); acDropdown = null; }
+        acResults = []; acIndex = 0;
+      }
+
+      function updateAcActiveItem() {
+        if (!acDropdown) return;
+        acDropdown.querySelectorAll('.ac-item').forEach((el, i) => el.classList.toggle('active', i === acIndex));
+      }
+
+      function selectAcItem(contact, query) {
+        const sel = window.getSelection();
+        if (!sel.rangeCount) return;
+        const range = sel.getRangeAt(0);
+        const node = range.startContainer;
+        if (node.nodeType !== Node.TEXT_NODE) return;
+        const offset = range.startOffset;
+        const atStart = Math.max(0, offset - (query.length + 1));
+        // Auto-insert a leading space when @ immediately follows a non-whitespace char.
+        const charBeforeAt = atStart > 0 ? node.textContent[atStart - 1] : '';
+        const needsLeadingSpace = charBeforeAt && !/\s/.test(charBeforeAt);
+        range.setStart(node, atStart);
+        range.setEnd(node, offset);
+        range.deleteContents();
+        const pill = document.createElement('span');
+        pill.className = 'mention-pill';
+        pill.contentEditable = 'false';
+        pill.dataset.bech32 = 'nostr:' + NT.nip19.npubEncode(contact.pubkey);
+        pill.textContent = '@' + contact.name;
+        if (needsLeadingSpace) range.insertNode(document.createTextNode(' '));
+        range.collapse(false);
+        range.insertNode(pill);
+        // NBSP after pill: never collapsed by the browser, normalized to space by serializer.
+        const trailingSpace = document.createTextNode(' ');
+        range.setStartAfter(pill);
+        range.insertNode(trailingSpace);
+        range.setStartAfter(trailingSpace);
+        range.collapse(true);
+        sel.removeAllRanges();
+        sel.addRange(range);
+        closeAcDropdown();
+        draft.text = serializeEditor(editor);
+        syncEmptyClass();
+        updatePostState();
+      }
+
+      async function updateAcDropdown() {
+        const ctx = getCaretContext();
+        if (!ctx || ctx.query.length === 0) { closeAcDropdown(); return; }
+        const follows = await getFollowList();
+        const q = ctx.query.toLowerCase();
+        acResults = follows.filter((c) => c.name && c.name.toLowerCase().includes(q)).slice(0, 8);
+        if (!acResults.length) { closeAcDropdown(); return; }
+        acIndex = Math.min(acIndex, acResults.length - 1);
+        if (!acDropdown) {
+          acDropdown = h('div', { className: 'ac-dropdown' });
+          editorWrap.append(acDropdown);
+        }
+        acDropdown.innerHTML = '';
+        acResults.forEach((c, i) => {
+          const item = h('div', { className: 'ac-item' + (i === acIndex ? ' active' : '') });
+          const av = h('span', { className: 'ac-item-av' });
+          applyAvatar(av, c.picture ? { picture: c.picture } : {});
+          item.append(av, h('span', { className: 'ac-item-name', textContent: '@' + c.name }));
+          item.addEventListener('mousedown', (e) => {
+            e.preventDefault();
+            const fresh = getCaretContext();
+            selectAcItem(c, fresh ? fresh.query : ctx.query);
+          });
+          acDropdown.append(item);
+        });
+      }
+
+      function syncEmptyClass() {
+        editor.classList.toggle('is-empty', !editor.textContent.trim() && !editor.querySelector('[data-bech32]'));
+      }
+
+      editor.addEventListener('input', () => {
+        draft.text = serializeEditor(editor);
+        syncEmptyClass();
+        updatePostState();
+        updateAcDropdown();
+      });
+
+      editor.addEventListener('keydown', (e) => {
+        if (!acDropdown) return;
+        if (e.key === 'ArrowDown') { e.preventDefault(); acIndex = Math.min(acIndex + 1, acResults.length - 1); updateAcActiveItem(); }
+        else if (e.key === 'ArrowUp') { e.preventDefault(); acIndex = Math.max(acIndex - 1, 0); updateAcActiveItem(); }
+        else if (e.key === 'Enter' || e.key === 'Tab') {
+          if (acResults[acIndex]) { e.preventDefault(); const ctx = getCaretContext(); selectAcItem(acResults[acIndex], ctx ? ctx.query : ''); }
+        } else if (e.key === 'Escape') { e.preventDefault(); closeAcDropdown(); }
+      });
+
+      editor.addEventListener('blur', () => setTimeout(closeAcDropdown, 150));
 
       const previewPane = h('div', { className: 'compose-preview hidden' });
       function renderPreview() {
@@ -1761,11 +1958,11 @@
         preview = p;
         tabWrite.classList.toggle('active', !p);
         tabPreview.classList.toggle('active', p);
-        ta.classList.toggle('hidden', p);
+        editorWrap.classList.toggle('hidden', p);
         thumbs.classList.toggle('hidden', p);
         addBtn.classList.toggle('hidden', p);
         previewPane.classList.toggle('hidden', !p);
-        if (p) renderPreview();
+        if (p) { closeAcDropdown(); renderPreview(); }
       }
       tabWrite.addEventListener('click', () => setMode(false));
       tabPreview.addEventListener('click', () => setMode(true));
@@ -1782,9 +1979,17 @@
           const rm = h('button', { className: 'compose-thumb-x', title: 'Remove' });
           rm.append(icon('trash'));
           rm.addEventListener('click', () => {
-            draft.text = draft.text.replace('\n' + m.url, '').replace(m.url, '').trimEnd();
-            ta.value = draft.text;
+            const walker = document.createTreeWalker(editor, NodeFilter.SHOW_TEXT);
+            let wn;
+            while ((wn = walker.nextNode())) {
+              if (wn.textContent.includes(m.url)) {
+                wn.textContent = wn.textContent.replace('\n' + m.url, '').replace(m.url, '');
+                break;
+              }
+            }
             draft.media.splice(i, 1);
+            draft.text = serializeEditor(editor);
+            syncEmptyClass();
             renderThumbs();
             updatePostState();
           });
@@ -1812,8 +2017,10 @@
         try {
           const url = await uploadMedia(file);
           draft.media.push({ url, isVideo: file.type.startsWith('video/') });
-          draft.text = (draft.text ? draft.text.trimEnd() + '\n' : '') + url;
-          ta.value = draft.text;
+          const urlNode = document.createTextNode((editor.textContent.trim() ? '\n' : '') + url);
+          editor.append(urlNode);
+          draft.text = serializeEditor(editor);
+          syncEmptyClass();
           renderThumbs();
           updatePostState();
         } catch (e) {
@@ -1850,7 +2057,7 @@
         h('h3', { textContent: 'New note' }),
         author,
         tabBar,
-        ta,
+        editorWrap,
         previewPane,
         thumbs,
         addBtn,
@@ -1859,7 +2066,7 @@
         h('div', { className: 'actions' }, [post, cancel])
       );
       updatePostState();
-      ta.focus();
+      editor.focus();
     }
 
     function showCountdown() {
@@ -2483,7 +2690,7 @@
     connect.addEventListener('click', async () => {
       const conn = input.value.trim();
       if (!conn) return (err.textContent = 'Paste a connection string.');
-      if (!conn.startsWith('nostr+walletconnect://')) return (err.textContent = 'That doesn’t look like an NWC string.');
+      if (!conn.startsWith('nostr+walletconnect://')) return (err.textContent = "That doesn't look like an NWC string.");
       err.textContent = '';
       connect.disabled = true;
       connect.textContent = 'Connecting…';
@@ -3150,7 +3357,7 @@
       });
       modal.append(
         h('h3', { textContent: 'Disconnect wallet?' }),
-        h('p', { className: 'hint', textContent: 'Removes this account’s saved NWC connection from Sidecar. Your wallet and funds are unaffected.' }),
+        h('p', { className: 'hint', textContent: "Removes this account's saved NWC connection from Sidecar. Your wallet and funds are unaffected." }),
         h('div', { className: 'actions' }, [go, cancel])
       );
     });

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -503,7 +503,10 @@
     if (!relays.length) throw new Error('No relays configured (add some in Settings)');
     const results = await Promise.allSettled(getPool().publish(relays, signed));
     const ok = results.filter((r) => r.status === 'fulfilled').length;
-    if (!ok) throw new Error('Could not publish to any relay');
+    if (!ok) {
+      const detail = results.map((r, i) => `${relays[i]}: ${r.reason?.message || r.reason || 'rejected'}`).join(' | ');
+      throw new Error(`Could not publish to any relay — ${detail}`);
+    }
     return ok;
   }
 

--- a/styles.css
+++ b/styles.css
@@ -806,6 +806,21 @@ button:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(203, 161, 78, 0
 .compose-add { display: inline-flex; align-items: center; gap: 7px; margin: 6px 0 2px; }
 .compose-add svg { width: 15px; height: 15px; }
 
+/* link / OG preview card in note preview */
+.link-card {
+  display: block; margin: 8px 0; border: 1px solid var(--border); border-radius: 12px;
+  overflow: hidden; text-decoration: none; color: inherit;
+  background: linear-gradient(150deg, var(--velvet-1), var(--velvet-2));
+  transition: border-color 0.15s;
+}
+.link-card:hover { border-color: var(--border-strong); }
+.link-card.loading { padding: 10px 12px; color: var(--faint); font-size: 12px; }
+.link-card-img { width: 100%; max-height: 140px; object-fit: cover; display: block; }
+.link-card-body { padding: 10px 12px; }
+.link-card-site { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 3px; }
+.link-card-title { font-weight: 600; font-size: 13px; color: var(--text); margin-bottom: 4px; line-height: 1.35; }
+.link-card-desc { font-size: 12px; color: var(--text-2); line-height: 1.45; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
+
 /* send countdown ring */
 .countdown-wrap { position: relative; width: 92px; height: 92px; margin: 14px auto 6px; }
 .countdown-ring { width: 92px; height: 92px; transform: rotate(0deg); }

--- a/styles.css
+++ b/styles.css
@@ -366,6 +366,7 @@ button:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(203, 161, 78, 0
 .acct-row.foot { justify-content: center; color: var(--lav); border-top: 1px solid var(--border); border-radius: 0; margin-top: 4px; padding-top: 11px; }
 
 /* nsec import preview — confirm the account a pasted key belongs to */
+
 .import-preview {
   display: flex; align-items: center; gap: 11px; padding: 10px 12px; margin-top: 8px;
   border: 1px solid var(--gold-soft); border-radius: 12px;
@@ -575,6 +576,28 @@ button:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(203, 161, 78, 0
 
 /* full-width stacked account actions with breathing room above */
 .add-actions { display: flex; flex-direction: column; gap: 10px; margin-top: 30px; }
+.explore-link-wrap { display: flex; flex-direction: column; gap: 8px; margin-top: 24px; padding: 0 4px; }
+.explore-link { font-size: 13px; color: var(--muted); text-decoration: none; text-align: center; display: block; }
+.explore-link:hover { color: var(--lav); }
+.first-post-balloon {
+  position: absolute; bottom: 90px; right: 12px; z-index: 49;
+  background: var(--amber); color: #1a0e08;
+  font-size: 12px; font-weight: 600;
+  padding: 7px 13px; border-radius: 10px;
+  white-space: nowrap; cursor: pointer;
+  box-shadow: 0 4px 14px rgba(0,0,0,0.45);
+  transition: background 0.12s, opacity 0.15s;
+}
+.first-post-balloon::after {
+  content: ''; position: absolute;
+  bottom: -7px; right: 24px;
+  border-left: 7px solid transparent;
+  border-right: 7px solid transparent;
+  border-top: 7px solid var(--amber);
+  transition: border-top-color 0.12s;
+}
+.first-post-balloon:hover { background: var(--gold); }
+.first-post-balloon:hover::after { border-top-color: var(--gold); }
 .add-actions button { width: 100%; display: flex; align-items: center; justify-content: center; gap: 9px; }
 .add-actions button svg { width: 17px; height: 17px; }
 
@@ -727,6 +750,7 @@ button:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(203, 161, 78, 0
 .fab:hover { transform: translateY(-1px) scale(1.03); opacity: 1; }
 .fab:active { transform: scale(0.97); }
 .fab svg { width: 24px; height: 24px; }
+
 .compose-author { display: flex; align-items: center; gap: 10px; margin: 2px 0 12px; }
 .compose-author-av { width: 36px; height: 36px; border-radius: 50%; overflow: hidden; flex-shrink: 0;
   background: linear-gradient(180deg, #2a1257, #160a30); border: 1px solid var(--border); }

--- a/styles.css
+++ b/styles.css
@@ -746,6 +746,32 @@ button:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(203, 161, 78, 0
   width: 100%; min-height: 120px; resize: vertical; box-sizing: border-box;
   font-family: var(--font-ui); font-size: 15px; line-height: 1.5;
 }
+/* contenteditable composer */
+.compose-editor-wrap { position: relative; }
+.compose-editor {
+  min-height: 120px; max-height: 240px; overflow-y: auto; resize: none;
+  outline: none; cursor: text; white-space: pre-wrap; word-break: break-word;
+}
+.compose-editor.is-empty::before {
+  content: attr(data-placeholder); color: var(--muted); pointer-events: none; display: block;
+}
+/* @mention atomic pill */
+.mention-pill {
+  display: inline-block; background: rgba(167, 139, 250, 0.18); color: var(--lav);
+  border-radius: 10px; padding: 1px 7px; font-size: 13.5px; font-weight: 600;
+  cursor: default; white-space: nowrap; line-height: 1.5; user-select: all;
+}
+/* @mention autocomplete dropdown */
+.ac-dropdown {
+  position: absolute; top: calc(100% + 4px); left: 0; right: 0; z-index: 50;
+  background: var(--bg-2); border: 1px solid var(--border-strong); border-radius: 10px;
+  box-shadow: var(--shadow); max-height: 200px; overflow-y: auto;
+}
+.ac-item { display: flex; align-items: center; gap: 9px; padding: 8px 12px; cursor: pointer; font-size: 13px; }
+.ac-item:hover, .ac-item.active { background: rgba(167, 139, 250, 0.1); }
+.ac-item-av { width: 26px; height: 26px; border-radius: 50%; overflow: hidden; flex-shrink: 0; background: var(--velvet-1); border: 1px solid var(--border); }
+.ac-item-av img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.ac-item-name { font-weight: 600; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .compose-preview {
   min-height: 120px; max-height: 46vh; overflow-y: auto;
   border: 1px solid var(--border); border-radius: 10px; padding: 12px;

--- a/welcome.css
+++ b/welcome.css
@@ -1,0 +1,295 @@
+/* ============================================================
+   Sidecar — Welcome page
+   Same design tokens as the sidepanel. Standalone so we
+   re-declare the vars rather than import styles.css.
+   ============================================================ */
+
+:root {
+  --bg: #0a0118;
+  --bg-2: #140428;
+  --velvet-1: #23114a;
+  --velvet-2: #160a30;
+  --border: rgba(167, 139, 250, 0.16);
+  --border-strong: rgba(167, 139, 250, 0.30);
+  --orange: #ea772f;
+  --amber: #f4a64b;
+  --gold: #cba14e;
+  --gold-soft: rgba(203, 161, 78, 0.5);
+  --purple: #a78bfa;
+  --lav: #bda1ff;
+  --text: #f1e8f8;
+  --text-2: #e8d5f0;
+  --muted: #9a86c4;
+  --faint: #6f5fa0;
+  --red: #f0566b;
+  --font-display: 'Playfair Display', Georgia, 'Times New Roman', serif;
+  --font-ui: 'Manrope', system-ui, -apple-system, sans-serif;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+html, body {
+  min-height: 100%;
+  font-family: var(--font-ui);
+  font-size: 15px;
+  color: var(--text);
+  background-color: var(--bg);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+body {
+  background-image:
+    url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='38'%20height='38'%3E%3Cpath%20d='M0%2019%2019%200%2038%2019%2019%2038Z'%20fill='none'%20stroke='%23a78bfa'%20stroke-opacity='0.05'/%3E%3Ccircle%20cx='19'%20cy='19'%20r='1'%20fill='%23cba14e'%20fill-opacity='0.08'/%3E%3C/svg%3E"),
+    radial-gradient(1100px 480px at 50% -12%, rgba(167, 139, 250, 0.14), transparent 60%),
+    radial-gradient(820px 560px at 115% 112%, rgba(234, 119, 47, 0.12), transparent 55%),
+    linear-gradient(165deg, #170630 0%, var(--bg) 62%);
+  background-repeat: repeat, no-repeat, no-repeat, no-repeat;
+  background-attachment: fixed;
+}
+
+/* ===== Layout ===== */
+
+.page {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 64px 32px 96px;
+}
+
+/* ===== Header ===== */
+
+.header {
+  text-align: center;
+  margin-bottom: 52px;
+}
+
+.wordmark {
+  height: 40px;
+  width: auto;
+  margin-bottom: 20px;
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.header h1 {
+  font-family: var(--font-display);
+  font-size: 44px;
+  font-weight: 700;
+  line-height: 1.15;
+  color: var(--text);
+  margin-bottom: 14px;
+  letter-spacing: -0.01em;
+}
+
+.header p {
+  font-size: 16px;
+  color: var(--muted);
+  max-width: 480px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+/* ===== Category filters ===== */
+
+.filters {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-bottom: 40px;
+}
+
+.filter-btn {
+  padding: 7px 18px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--muted);
+  font-family: var(--font-ui);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s, background 0.15s;
+  white-space: nowrap;
+}
+
+.filter-btn:hover {
+  border-color: var(--border-strong);
+  color: var(--text-2);
+}
+
+.filter-btn.active {
+  background: rgba(167, 139, 250, 0.14);
+  border-color: rgba(167, 139, 250, 0.5);
+  color: var(--lav);
+}
+
+/* ===== App grid ===== */
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(236px, 1fr));
+  gap: 14px;
+}
+
+/* ===== App card ===== */
+
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 18px 18px 16px;
+  background: rgba(22, 10, 48, 0.7);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  text-decoration: none;
+  color: inherit;
+  cursor: pointer;
+  transition: border-color 0.15s, box-shadow 0.18s, transform 0.18s;
+  backdrop-filter: blur(4px);
+}
+
+.card:hover {
+  border-color: rgba(167, 139, 250, 0.35);
+  box-shadow: 0 0 0 1px rgba(167, 139, 250, 0.08), 0 10px 28px rgba(0, 0, 0, 0.45);
+  transform: translateY(-2px);
+}
+
+.card-top {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.favicon-wrap {
+  width: 46px;
+  height: 46px;
+  border-radius: 10px;
+  background: var(--velvet-1);
+  border: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.favicon-wrap img {
+  width: 32px;
+  height: 32px;
+  object-fit: contain;
+}
+
+.favicon-fallback {
+  font-family: var(--font-display);
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--purple);
+  line-height: 1;
+}
+
+.card-name {
+  font-family: var(--font-display);
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text);
+  line-height: 1.2;
+}
+
+.card-url {
+  font-size: 11px;
+  color: var(--faint);
+  margin-top: 1px;
+}
+
+.cat-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 9px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  width: fit-content;
+}
+
+.card-desc {
+  font-size: 13px;
+  color: var(--muted);
+  line-height: 1.55;
+  flex: 1;
+}
+
+.card-cta {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--purple);
+  letter-spacing: 0.03em;
+  margin-top: 2px;
+}
+
+/* Category badge palette */
+.cat-social   { background: rgba(167, 139, 250, 0.14); color: var(--lav); }
+.cat-longform { background: rgba(203, 161, 78,  0.14); color: var(--gold); }
+.cat-live     { background: rgba(234, 119, 47,  0.14); color: var(--orange); }
+.cat-audio    { background: rgba(244, 166, 75,  0.14); color: var(--amber); }
+.cat-food     { background: rgba(74,  222, 128, 0.14); color: #4ade80; }
+.cat-books    { background: rgba(56,  189, 248, 0.14); color: #38bdf8; }
+.cat-gaming   { background: rgba(52,  211, 153, 0.14); color: #34d399; }
+.cat-images   { background: rgba(248, 113, 113, 0.14); color: #f87171; }
+.cat-tools    { background: rgba(148, 163, 184, 0.12); color: #94a3b8; }
+
+/* ===== Footer ===== */
+
+.footer {
+  margin-top: 64px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.footer-tip {
+  font-size: 13px;
+  color: var(--faint);
+  line-height: 1.6;
+}
+
+.footer-tip a {
+  color: var(--muted);
+  text-decoration: underline;
+  text-decoration-color: rgba(154, 134, 196, 0.35);
+}
+
+.footer-tip a:hover {
+  color: var(--text);
+  text-decoration-color: var(--muted);
+}
+
+.footer-divider {
+  width: 48px;
+  height: 1px;
+  background: var(--border);
+  margin: 4px auto;
+}
+
+/* ===== Hidden cards (filtered out) ===== */
+
+.card.hidden-cat {
+  display: none;
+}
+
+/* ===== Responsive ===== */
+
+@media (max-width: 600px) {
+  .page { padding: 40px 16px 60px; }
+  .header h1 { font-size: 30px; }
+  .grid { grid-template-columns: 1fr 1fr; gap: 10px; }
+  .card { padding: 14px; }
+}
+
+@media (max-width: 400px) {
+  .grid { grid-template-columns: 1fr; }
+}

--- a/welcome.html
+++ b/welcome.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Welcome to Sidecar</title>
+  <link rel="stylesheet" href="fonts.css">
+  <link rel="stylesheet" href="welcome.css">
+</head>
+<body>
+  <div class="page">
+
+    <header class="header">
+      <img class="wordmark" src="icons/sidecar-logo.svg" alt="Sidecar">
+      <h1>Your nostr signer is ready.</h1>
+      <p>Sign in to any of these apps — no password, just your key. Click the Sidecar icon in your toolbar whenever a site asks.</p>
+    </header>
+
+    <div class="filters" id="filters">
+      <button class="filter-btn active" data-cat="all">All</button>
+      <button class="filter-btn" data-cat="social">Social</button>
+      <button class="filter-btn" data-cat="longform">Long-form</button>
+      <button class="filter-btn" data-cat="live">Live</button>
+      <button class="filter-btn" data-cat="audio">Audio</button>
+      <button class="filter-btn" data-cat="food">Food</button>
+      <button class="filter-btn" data-cat="books">Books</button>
+      <button class="filter-btn" data-cat="gaming">Gaming</button>
+      <button class="filter-btn" data-cat="images">Images</button>
+      <button class="filter-btn" data-cat="tools">Tools</button>
+    </div>
+
+    <div class="grid" id="grid"></div>
+
+    <footer class="footer">
+      <div class="footer-divider"></div>
+      <p class="footer-tip">New to nostr? <a href="https://nostr.how" target="_blank" rel="noopener">nostr.how</a> is a good place to start.</p>
+      <p class="footer-tip">Find more apps at <a href="https://nostrapps.com" target="_blank" rel="noopener">nostrapps.com</a> and <a href="https://nostr.net/" target="_blank" rel="noopener">nostr.net</a>.</p>
+      <p class="footer-tip"><a href="https://github.com/dmnyc/sidecar/issues" target="_blank" rel="noopener">Suggest an app to add →</a></p>
+    </footer>
+
+  </div>
+
+  <script src="welcome.js"></script>
+</body>
+</html>

--- a/welcome.js
+++ b/welcome.js
@@ -1,0 +1,242 @@
+const APPS = [
+  {
+    name: 'Jank',
+    url: 'https://jank.army',
+    domain: 'jank.army',
+    cat: 'social',
+    desc: 'A TweetDeck-style multi-column dashboard for nostr — follow lists, search, and notifications in one view.',
+    logo: `<svg viewBox="230 166 332 281" aria-hidden="true" style="width:32px;height:27px;color:var(--gold)"><path fill="currentColor" d="M554.5,269.9c-10.61-24.36-56.44-8.2-72.12-0.24c-15.68,7.96-45.35,29.91-54.27,20.02c-8.92-9.89,3.81-21.09,9.65-36.18c5.55-14.35,5.79-36.06,5.79-36.06c0-52.58-47.52-50.55-47.52-50.55s-47.52-2.04-47.52,50.55c0,0,0.24,21.71,5.79,36.06c5.83,15.09,18.57,26.29,9.65,36.18c-8.92,9.89-38.59-12.06-54.27-20.02s-61.51-24.12-72.12,0.24c-10.61,24.36-8.92,62.71,4.82,116.74c0,0,5.07,16.4,7.24,19.3c2.17,2.89,11.1,9.65,8.2-1.93c-2.89-11.58-16.76-101.55,10.01-107.34c0,0,2.53-0.42,4.7,1.09c0,0,7.6,2.41,7.24,15.92c-0.38,14.12-1.63,83.04,15.38,108.9c0,0,5.25,9.05,7.42-1.09c1.66-7.73-9.75-63.72,0.2-89.96c5.31-10.82,16.69-6.17,21-3.89l1.63,0.94c0.05,0.03,0.08,0.05,0.08,0.05l-0.01-0.01l0.02,0.01l-0.01,0c0,0,0.03,0.02,0.05,0.02l2.27,1.3c2.84,1.89,7.26,5.84,7.21,12.12c-1.51,33.64-2.45,95.9,10.98,99.32c0,0,4.7,4.34,3.98-13.39c-0.55-13.43-0.68-59.84,8.56-79.85l0,0.01c0,0,2.86-5.44,9.98-4.98l4.05,0.87l0.02,0.01c0,0,0.02,0,0.05,0.01l0.73,0.16c2.66,0.74,11.18,4.72,11.33,25.16c0.1,13.04,1.81,76.52,11.34,77.04c9.53-0.52,11.24-64,11.34-77.04c0.15-20.45,8.67-24.42,11.33-25.16l0.73-0.16c0.03,0,0.06-0.01,0.06-0.01l0.02-0.01l4.05-0.87c7.12-0.46,9.98,4.98,9.98,4.98l0-0.01c9.24,20.01,9.11,66.42,8.56,79.85c-0.72,17.73,3.98,13.39,3.98,13.39c13.43-3.42,12.49-65.68,10.98-99.32c-0.05-6.29,4.37-10.24,7.21-12.12l2.27-1.3c0.01-0.01,0.05-0.02,0.05-0.02l-0.01,0l0.02-0.01l-0.01,0.01c0,0,0.03-0.02,0.08-0.05l1.63-0.94c4.32-2.28,15.69-6.93,21,3.89c9.94,26.25-1.46,82.23,0.2,89.96c2.17,10.13,7.42,1.09,7.42,1.09c17.01-25.87,15.76-94.78,15.38-108.9c-0.36-13.51,7.24-15.92,7.24-15.92c2.17-1.51,4.7-1.09,4.7-1.09c26.77,5.79,12.9,95.76,10.01,107.34s6.03,4.82,8.2,1.93c2.17-2.89,7.24-19.3,7.24-19.3C563.43,332.61,565.12,294.26,554.5,269.9z"/></svg>`,
+  },
+  {
+    name: 'Jumble',
+    url: 'https://jumble.social',
+    domain: 'jumble.social',
+    cat: 'social',
+    desc: 'A clean relay-first feed — browse any relay like a channel, great for discovering new voices.',
+  },
+  {
+    name: 'Coracle',
+    url: 'https://coracle.social',
+    domain: 'coracle.social',
+    cat: 'social',
+    desc: 'Polished multi-protocol client with groups, DMs, and smart relay routing.',
+  },
+  {
+    name: 'Primal',
+    url: 'https://primal.net',
+    domain: 'primal.net',
+    cat: 'social',
+    desc: 'Fast, slick social feed with trending analytics, advanced search, and a built-in wallet.',
+  },
+  {
+    name: 'noStrudel',
+    url: 'https://nostrudel.ninja',
+    domain: 'nostrudel.ninja',
+    cat: 'social',
+    desc: 'Power-user toolkit: communities, streams, wikis, badges — nearly every NIP in one place.',
+  },
+  {
+    name: 'Habla',
+    url: 'https://habla.news',
+    domain: 'habla.news',
+    cat: 'longform',
+    desc: 'Write and publish long-form articles on nostr with a clean editor and monetization built in.',
+  },
+  {
+    name: 'YakiHonne',
+    url: 'https://yakihonne.com',
+    domain: 'yakihonne.com',
+    cat: 'longform',
+    desc: 'Articles, short notes, and curated content — a versatile client popular in the Global South.',
+  },
+  {
+    name: 'zap.stream',
+    url: 'https://zap.stream',
+    domain: 'zap.stream',
+    cat: 'live',
+    desc: 'Live streaming platform with real-time Lightning zaps from your audience.',
+  },
+  {
+    name: 'Nostr Nests',
+    url: 'https://nostrnests.com',
+    domain: 'nostrnests.com',
+    cat: 'audio',
+    desc: 'Audio rooms for chatting, debating, jamming, and micro-conferences over nostr.',
+  },
+  {
+    name: 'zap.cooking',
+    url: 'https://zap.cooking',
+    domain: 'zap.cooking',
+    cat: 'food',
+    desc: 'A recipe community built on nostr — share, discover, and zap great cooking.',
+  },
+  {
+    name: 'Bookstr',
+    url: 'https://bookstr.xyz',
+    domain: 'bookstr.xyz',
+    cat: 'books',
+    desc: 'Track your reading, write reviews, and share your shelves on a decentralized network.',
+  },
+  {
+    name: 'Slidestr',
+    url: 'https://slidestr.net',
+    domain: 'slidestr.net',
+    cat: 'images',
+    desc: 'A beautiful image viewer and slideshow browser for nostr photo content.',
+    icon: 'https://slidestr.net/slidestr.svg',
+  },
+  {
+    name: 'Fountain',
+    url: 'https://fountain.fm',
+    domain: 'fountain.fm',
+    cat: 'audio',
+    desc: 'Podcast player with Bitcoin streaming payments — earn sats while you listen, tip hosts with every second.',
+  },
+  {
+    name: 'Gamestr',
+    url: 'https://gamestr.io',
+    domain: 'gamestr.io',
+    cat: 'gaming',
+    desc: 'Decentralized gaming on nostr — play games, earn sats, and own your scores on a censorship-resistant network.',
+  },
+  {
+    name: 'Mutable',
+    url: 'https://mutable.top',
+    domain: 'mutable.top',
+    cat: 'tools',
+    desc: 'Manage your mute lists and check your privacy — see who is muting you and how exposed your DM metadata is.',
+  },
+  {
+    name: 'Plebs vs Zombies',
+    url: 'https://plebsvszombies.cc',
+    domain: 'plebsvszombies.cc',
+    cat: 'tools',
+    desc: 'A gamified nostr follow manager — cull your zombie followers and keep your network alive.',
+  },
+  {
+    name: 'Divine',
+    url: 'https://divine.video',
+    domain: 'divine.video',
+    cat: 'live',
+    desc: 'Short-form looping videos on nostr — discover and share clips with Lightning tipping built in.',
+    icon: 'https://divine.video/favicon.png',
+  },
+  {
+    name: 'Zapstore',
+    url: 'https://zapstore.dev',
+    domain: 'zapstore.dev',
+    cat: 'tools',
+    desc: 'An open app store where apps are published by developers and curated by communities.',
+  },
+];
+
+const CAT_LABELS = {
+  social:   'Social',
+  longform: 'Long-form',
+  live:     'Live',
+  audio:    'Audio',
+  food:     'Food',
+  books:    'Books',
+  gaming:   'Gaming',
+  images:   'Images',
+  tools:    'Tools',
+};
+
+function faviconUrl(domain) {
+  return `https://www.google.com/s2/favicons?domain=${domain}&sz=64`;
+}
+
+function renderCard(app) {
+  const a = document.createElement('a');
+  a.className = 'card';
+  a.href = app.url;
+  a.target = '_blank';
+  a.rel = 'noopener noreferrer';
+  a.dataset.cat = app.cat;
+
+  const faviconWrap = document.createElement('div');
+  faviconWrap.className = 'favicon-wrap';
+
+  if (app.logo) {
+    faviconWrap.innerHTML = app.logo;
+  } else {
+    const img = document.createElement('img');
+    img.src = app.icon || faviconUrl(app.domain);
+    img.alt = app.name;
+    img.width = 32;
+    img.height = 32;
+
+    const fallback = document.createElement('span');
+    fallback.className = 'favicon-fallback';
+    fallback.textContent = app.name[0];
+    fallback.style.display = 'none';
+
+    img.onerror = () => {
+      img.style.display = 'none';
+      fallback.style.display = '';
+    };
+
+    faviconWrap.appendChild(img);
+    faviconWrap.appendChild(fallback);
+  }
+
+  const nameEl = document.createElement('div');
+  nameEl.className = 'card-name';
+  nameEl.textContent = app.name;
+
+  const urlEl = document.createElement('div');
+  urlEl.className = 'card-url';
+  urlEl.textContent = app.domain;
+
+  const nameGroup = document.createElement('div');
+  nameGroup.appendChild(nameEl);
+  nameGroup.appendChild(urlEl);
+
+  const top = document.createElement('div');
+  top.className = 'card-top';
+  top.appendChild(faviconWrap);
+  top.appendChild(nameGroup);
+
+  const badge = document.createElement('span');
+  badge.className = `cat-badge cat-${app.cat}`;
+  badge.textContent = CAT_LABELS[app.cat];
+
+  const desc = document.createElement('p');
+  desc.className = 'card-desc';
+  desc.textContent = app.desc;
+
+  const cta = document.createElement('div');
+  cta.className = 'card-cta';
+  cta.textContent = 'Open →';
+
+  a.appendChild(top);
+  a.appendChild(badge);
+  a.appendChild(desc);
+  a.appendChild(cta);
+
+  return a;
+}
+
+const grid = document.getElementById('grid');
+const sorted = [...APPS].sort((a, b) =>
+  a.cat.localeCompare(b.cat) || a.name.localeCompare(b.name)
+);
+sorted.forEach(app => grid.appendChild(renderCard(app)));
+
+// Category filter
+document.getElementById('filters').addEventListener('click', e => {
+  const btn = e.target.closest('.filter-btn');
+  if (!btn) return;
+  const cat = btn.dataset.cat;
+
+  document.querySelectorAll('.filter-btn').forEach(b => b.classList.remove('active'));
+  btn.classList.add('active');
+
+  document.querySelectorAll('.card').forEach(card => {
+    if (cat === 'all' || card.dataset.cat === cat) {
+      card.classList.remove('hidden-cat');
+    } else {
+      card.classList.add('hidden-cat');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- **Welcome page** — branded start page opens on first install, listing NIP-07 nostr apps by category (Social, Long-form, Live, Audio, Gaming, Food, Books, Images, Tools) with favicon cards and category filters; linked from Accounts tab via "Explore nostr apps →"
- **First-post balloon** — amber speech bubble above the compose FAB appears once per imported nsec; clicking it or the FAB pre-fills the composer with "Just setting up my #Sidecar 🍸"
- **Composer paste-to-upload** — paste images directly into the composer; uploads via nostr.build NIP-98 and appends the URL with proper whitespace separation
- **Plain text paste** — strips rich-text formatting (color, font) when pasting from other apps
- **URL separator fix** — checks trailing whitespace rather than trim() to guarantee exactly one newline between note text and an appended image URL; clears stale DOM on empty to prevent cursor shifting down a line
- **Relay fixes** — `relay.primal.net` marked `write:false` (it rejects writes); `relay.snort.social` added as a third write relay; publish errors now include per-relay rejection reasons

## Test plan

- [ ] Fresh install opens welcome page; reloading extension does not
- [ ] Category filters on welcome page show/hide cards correctly
- [ ] "Explore nostr apps →" on Accounts tab opens welcome page
- [ ] Import an nsec → balloon appears above FAB; clicking balloon opens composer pre-filled
- [ ] Clicking FAB while balloon is visible also pre-fills; second open does not
- [ ] Balloon does not appear before any account is imported
- [ ] Paste an image into the composer → uploads and appends URL with newline separator
- [ ] Paste rich text from another app → plain text only, no color/formatting carried over
- [ ] Post a note → succeeds (no "could not post to any relay" error)

🥃 Generated with [Claude Code](https://claude.com/claude-code)