### PR TITLE
Notification bell, approval popup consolidation, and composer draft autosave

### DIFF
--- a/background.js
+++ b/background.js
@@ -105,6 +105,8 @@ chrome.action.onClicked.addListener((tab) => {
 // ============================================================================
 const pendingPrompts = new Map(); // promptId -> { resolve, windowId, data, settled }
 let promptMutex = Promise.resolve(); // serialize prompts so only one window is open
+let popupWindowId = null;  // the reusable prompt popup window
+let popupPending = 0;      // count of unsettled popup-bound prompts
 
 // The side panel keeps a long-lived port open while it's visible. When it's open
 // we render approvals inline in the panel (it can't get lost behind a window);
@@ -176,32 +178,48 @@ function openPrompt(data) {
         }
       }
 
-      const W = 440;
-      const H = 600;
-      chrome.windows.getCurrent((cur) => {
-        const left =
-          cur && cur.left != null && cur.width != null
-            ? Math.round(cur.left + (cur.width - W) / 2)
-            : undefined;
-        const top =
-          cur && cur.top != null && cur.height != null
-            ? Math.round(cur.top + (cur.height - H) / 3)
-            : undefined;
-        chrome.windows.create(
-          {
-            url: chrome.runtime.getURL('prompt.html?id=' + promptId),
-            type: 'popup',
-            width: W,
-            height: H,
-            left,
-            top,
-            focused: true,
-          },
-          (win) => {
-            pendingPrompts.set(promptId, { resolve, windowId: win && win.id, data, settled: false });
+      const promptUrl = chrome.runtime.getURL('prompt.html?id=' + promptId);
+
+      function openInNewWindow() {
+        const W = 440, H = 600;
+        chrome.windows.getCurrent((cur) => {
+          const left =
+            cur && cur.left != null && cur.width != null
+              ? Math.round(cur.left + (cur.width - W) / 2)
+              : undefined;
+          const top =
+            cur && cur.top != null && cur.height != null
+              ? Math.round(cur.top + (cur.height - H) / 3)
+              : undefined;
+          chrome.windows.create(
+            { url: promptUrl, type: 'popup', width: W, height: H, left, top, focused: true },
+            (win) => {
+              popupWindowId = win ? win.id : null;
+              popupPending++;
+              pendingPrompts.set(promptId, { resolve, windowId: popupWindowId, data, settled: false });
+            }
+          );
+        });
+      }
+
+      // Reuse the existing popup window when possible — navigate its tab to the
+      // new prompt URL instead of spawning another window.
+      if (popupWindowId != null) {
+        chrome.windows.get(popupWindowId, { populate: true }, (win) => {
+          const tab = win && win.tabs && win.tabs[0];
+          if (!chrome.runtime.lastError && tab) {
+            popupPending++;
+            pendingPrompts.set(promptId, { resolve, windowId: popupWindowId, data, settled: false });
+            chrome.tabs.update(tab.id, { url: promptUrl });
+            chrome.windows.update(popupWindowId, { focused: true });
+          } else {
+            popupWindowId = null;
+            openInNewWindow();
           }
-        );
-      });
+        });
+      } else {
+        openInNewWindow();
+      }
     });
   const result = promptMutex.then(run, run);
   // Keep the chain alive regardless of outcome.
@@ -214,6 +232,10 @@ function openPrompt(data) {
 
 // If the user closes the popup without deciding, treat it as a cancel/reject.
 chrome.windows.onRemoved.addListener((windowId) => {
+  if (windowId === popupWindowId) {
+    popupWindowId = null;
+    popupPending = 0;
+  }
   for (const [id, p] of pendingPrompts) {
     if (p.windowId === windowId && !p.settled) {
       p.settled = true;
@@ -228,7 +250,15 @@ function settlePrompt(promptId, action, extra) {
   if (!p || p.settled) return;
   p.settled = true;
   pendingPrompts.delete(promptId);
-  if (p.windowId != null) chrome.windows.remove(p.windowId).catch(() => {});
+  if (p.windowId != null) {
+    popupPending--;
+    if (popupPending <= 0) {
+      popupPending = 0;
+      chrome.windows.remove(p.windowId).catch(() => {});
+      popupWindowId = null;
+    }
+    // else: leave window alive — run() for the next queued prompt will navigate it
+  }
   p.resolve(Object.assign({ action }, extra || {}));
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Sidecar | A Classy Nostr Signer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A multi-account NIP-07 nostr signer with a built-in Lightning wallet, in your browser sidebar.",
   "permissions": [
     "storage",

--- a/prompt.js
+++ b/prompt.js
@@ -196,8 +196,11 @@
       extra = { budgetSats, perPaymentSats: 0 };
     }
 
+    els.allow.disabled = true;
+    els.trust.disabled = true;
+    els.reject.disabled = true;
     await send({ type: 'SIDECAR_PROMPT_RESULT', id: promptId, action, extra });
-    window.close();
+    // Background either navigates this window to the next queued request or closes it.
   }
 
   els.allow.addEventListener('click', () => decide('once'));

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -49,6 +49,10 @@
         <svg class="chip-chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
       </button>
       <div class="topbar-actions">
+        <button id="notif-bell-btn" class="icon-btn notif-bell" title="Notifications">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"></path><path d="M13.73 21a2 2 0 0 1-3.46 0"></path></svg>
+          <span class="notif-badge hidden"></span>
+        </button>
         <button id="settings-btn" class="icon-btn" title="Settings">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"></circle><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path></svg>
         </button>

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -800,9 +800,22 @@
       const isNew = ev.created_at > seenAt;
       const { glyph, text } = notifLabel(ev);
 
+      // A reply/mention (kind 1) opens the event itself; a reaction/repost/zap
+      // (7/6/9735) should open the note it refers to — the `e` tag — not the
+      // meta-event, which renders as a lone heart/repost in the client.
       let linkTarget = '';
       try {
-        linkTarget = NT.nip19.neventEncode({ id: ev.id, author: ev.pubkey, relays: [] });
+        let targetId = ev.id;
+        let targetAuthor = ev.pubkey;
+        if (ev.kind !== 1) {
+          const eTags = ev.tags.filter((t) => t[0] === 'e' && t[1]);
+          if (eTags.length) {
+            targetId = eTags[eTags.length - 1][1];
+            const pTag = ev.tags.find((t) => t[0] === 'p' && t[1]);
+            targetAuthor = pTag ? pTag[1] : a.pubkey; // referenced note's author (usually you)
+          }
+        }
+        linkTarget = NT.nip19.neventEncode({ id: targetId, author: targetAuthor, relays: [] });
       } catch (_) {}
 
       // The whole card is the click target — open the note in the preferred client.

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -1175,6 +1175,7 @@
   function openModal(buildContent, onClose) {
     const modal = $('modal');
     modal.innerHTML = '';
+    modal.classList.remove('modal-sheet'); // reset full-height variant; opt back in per modal
     modalCleanup = onClose || null;
     buildContent(modal);
     show($('modal-overlay'));
@@ -2254,14 +2255,51 @@
     return out;
   }
 
-  function openComposer(initialText) {
+  // ---- composer draft autosave (per account, in chrome.storage.local) ----
+  function loadComposeDraft(pubkey) {
+    return new Promise((res) => {
+      chrome.storage.local.get('sidecar_compose_drafts', (r) => {
+        const all = (r && r.sidecar_compose_drafts) || {};
+        res(all[pubkey] || null);
+      });
+    });
+  }
+  function saveComposeDraft(pubkey, draft) {
+    const hasContent = !!((draft.text && draft.text.trim()) || (draft.media && draft.media.length));
+    chrome.storage.local.get('sidecar_compose_drafts', (r) => {
+      const all = (r && r.sidecar_compose_drafts) || {};
+      if (hasContent) all[pubkey] = { text: draft.text, media: draft.media, savedAt: Date.now() };
+      else delete all[pubkey];
+      chrome.storage.local.set({ sidecar_compose_drafts: all });
+    });
+  }
+  function clearComposeDraft(pubkey) {
+    chrome.storage.local.get('sidecar_compose_drafts', (r) => {
+      const all = (r && r.sidecar_compose_drafts) || {};
+      if (!all[pubkey]) return;
+      delete all[pubkey];
+      chrome.storage.local.set({ sidecar_compose_drafts: all });
+    });
+  }
+
+  async function openComposer(initialText) {
     if (!state.activePubkey) {
       toast('Add an account first', 'error');
       return;
     }
-    const draft = { text: initialText || '', media: [] };
+    const pubkey = state.activePubkey;
+    let draft = { text: initialText || '', media: [] };
     const modal = $('modal');
     let timer = null;
+    let saveTimer = null;
+    let published = false;
+    let enteredEditor = false;
+
+    function persistDraft() { saveComposeDraft(pubkey, draft); }
+    function scheduleSave() {
+      if (saveTimer) clearTimeout(saveTimer);
+      saveTimer = setTimeout(persistDraft, 400);
+    }
 
     async function doPublish() {
       const content = draft.text.trim();
@@ -2289,6 +2327,7 @@
 
     function showEditor() {
       if (timer) { clearInterval(timer); timer = null; }
+      enteredEditor = true;
       modal.innerHTML = '';
 
       // Write / Preview tab bar
@@ -2364,6 +2403,7 @@
         draft.text = serializeEditor(editor);
         syncEmptyClass();
         updatePostState();
+        scheduleSave();
       }
 
       async function updateAcDropdown() {
@@ -2404,6 +2444,7 @@
         syncEmptyClass();
         updatePostState();
         updateAcDropdown();
+        scheduleSave();
       });
 
       editor.addEventListener('keydown', (e) => {
@@ -2467,6 +2508,7 @@
             syncEmptyClass();
             renderThumbs();
             updatePostState();
+            scheduleSave();
           });
           cell.append(rm);
           thumbs.append(cell);
@@ -2499,6 +2541,7 @@
           syncEmptyClass();
           renderThumbs();
           updatePostState();
+          scheduleSave();
         } catch (e) {
           err.textContent = e.message;
           toast(e.message, 'error');
@@ -2536,6 +2579,7 @@
           syncEmptyClass();
           renderThumbs();
           updatePostState();
+          scheduleSave();
         } catch (e) {
           err.textContent = e.message;
           toast(e.message, 'error');
@@ -2605,6 +2649,8 @@
         now.textContent = 'Posting…';
         try {
           const signed = await doPublish();
+          published = true;
+          clearComposeDraft(pubkey);
           closeModal();
           toast('Note published', 'success');
           showPostBanner(signed);
@@ -2632,7 +2678,51 @@
       }, 1000);
     }
 
-    openModal(() => showEditor(), () => { if (timer) { clearInterval(timer); timer = null; } });
+    // Offer to resume a saved draft (or start fresh) before opening the editor.
+    function showDraftChooser(saved) {
+      modal.innerHTML = '';
+      const snippet = (saved.text || '').trim().replace(/\s+/g, ' ');
+      const preview = snippet.length > 160 ? snippet.slice(0, 160) + '…' : snippet;
+      const when = saved.savedAt ? ' from ' + relativeTime(Math.floor(saved.savedAt / 1000)) : '';
+      const mediaNote = saved.media && saved.media.length
+        ? saved.media.length + ' attachment' + (saved.media.length > 1 ? 's' : '')
+        : '';
+
+      const resume = h('button', { className: 'primary', textContent: 'Resume draft' });
+      resume.addEventListener('click', () => {
+        draft = { text: saved.text || '', media: (saved.media || []).slice() };
+        showEditor();
+      });
+      const fresh = h('button', { className: 'ghost', textContent: 'Start fresh' });
+      fresh.addEventListener('click', () => {
+        clearComposeDraft(pubkey);
+        draft = { text: initialText || '', media: [] };
+        showEditor();
+      });
+
+      const parts = [
+        h('h3', { textContent: 'Resume your draft?' }),
+        h('p', { className: 'hint', textContent: 'You have an unsaved draft' + when + '.' }),
+      ];
+      if (preview) parts.push(h('div', { className: 'draft-preview', textContent: preview }));
+      if (mediaNote) parts.push(h('p', { className: 'draft-preview-meta', textContent: mediaNote }));
+      parts.push(h('div', { className: 'actions' }, [resume, fresh]));
+      modal.append(...parts);
+    }
+
+    const saved = await loadComposeDraft(pubkey);
+    const hasSaved = !!(saved && ((saved.text && saved.text.trim()) || (saved.media && saved.media.length)));
+
+    openModal(
+      () => { if (hasSaved) showDraftChooser(saved); else showEditor(); },
+      () => {
+        if (timer) { clearInterval(timer); timer = null; }
+        if (saveTimer) { clearTimeout(saveTimer); saveTimer = null; }
+        // Persist on close only once the user has actually edited — closing the
+        // chooser without choosing must not overwrite the saved draft.
+        if (!published && enteredEditor) persistDraft();
+      }
+    );
   }
 
   // ---- edit profile (full-panel overlay) ----

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -117,6 +117,8 @@
   let _firstPostSeenPubkeys = null;
   let balanceCache = { pubkey: null, sats: null }; // last known balance for instant display
   const _notifCache = new Map(); // pubkey → { events: Event[], liveSub: Closeable|null }
+  const _notifProfiles = new Map(); // sender pubkey → display name string
+  const _muteLists = new Map(); // pubkey → Set<pubkey>
   let _notifSeenAt = {}; // pubkey → unix timestamp, persisted to chrome.storage.local
   let _notifSeenLoaded = false;
 
@@ -161,6 +163,7 @@
     // A pending signing approval is modal — it stays put until the user decides,
     // so don't let an incidental refresh navigate away from it.
     if (pendingApproval) {
+      closeModal();
       showApproval();
       return;
     }
@@ -274,6 +277,13 @@
       { passive: true }
     );
   })();
+
+  // ---- notification bell (topbar) ----
+  $('notif-bell-btn').addEventListener('click', () => {
+    if (!state?.activePubkey) return;
+    const a = state.accounts.find((acc) => acc.pubkey === state.activePubkey);
+    if (a) showNotifModal(a);
+  });
 
   // ---- settings (gear icon ↔ overlay view) ----
   $('settings-btn').addEventListener('click', () => {
@@ -573,10 +583,11 @@
     return cache.events.filter((ev) => ev.created_at > seenAt).length;
   }
 
-  function refreshBell(pubkey) {
-    const btn = document.querySelector('.notif-bell[data-pubkey="' + pubkey + '"]');
+  function refreshBell() {
+    const btn = $('notif-bell-btn');
     if (!btn) return;
-    const count = notifUnseenCount(pubkey);
+    const pubkey = state?.activePubkey;
+    const count = pubkey ? notifUnseenCount(pubkey) : 0;
     const badge = btn.querySelector('.notif-badge');
     if (!badge) return;
     badge.textContent = count > 99 ? '99+' : count > 0 ? String(count) : '';
@@ -618,6 +629,45 @@
       : { glyph: '@', text: 'mentioned you' };
   }
 
+  function notifAuthorName(pubkey) {
+    const cached = _notifProfiles.get(pubkey);
+    if (typeof cached === 'string' && cached) return cached;
+    try { return NT.nip19.npubEncode(pubkey).slice(0, 12) + '…'; } catch (_) { return pubkey.slice(0, 8) + '…'; }
+  }
+
+  function prefetchNotifProfile(pubkey, relays) {
+    if (_notifProfiles.has(pubkey)) return;
+    _notifProfiles.set(pubkey, ''); // mark as loading
+    poolGet(relays, { kinds: [0], authors: [pubkey] }).then((ev) => {
+      if (!ev) return;
+      const m = JSON.parse(ev.content) || {};
+      _notifProfiles.set(pubkey, m.display_name || m.displayName || m.name || '');
+    }).catch(() => {});
+  }
+
+  function cleanSnippet(content) {
+    return content
+      .replace(/nostr:(npub1\S+|nprofile1\S+)/g, (_, entity) => {
+        try {
+          const decoded = NT.nip19.decode(entity);
+          const pk = decoded.type === 'npub' ? decoded.data : decoded.data && decoded.data.pubkey;
+          if (pk) {
+            const name = _notifProfiles.get(pk);
+            if (name) return '@' + name;
+            return '@' + entity.slice(0, 12) + '…';
+          }
+        } catch (_) {}
+        return '@…';
+      })
+      .replace(/nostr:note1\S+/g, '[note]')
+      .replace(/nostr:nevent1\S+/g, '[note]')
+      .replace(/nostr:naddr1\S+/g, '[article]')
+      .replace(/https?:\/\/\S+\.(?:jpg|jpeg|png|gif|webp|avif|mp4|mov|mp3|wav|m3u8)(?:\?\S*)?/gi, '[media]')
+      .replace(/https?:\/\/([^\s/]+)\S*/g, '$1')
+      .replace(/\s+/g, ' ')
+      .trim();
+  }
+
   async function initNotifSubs() {
     if (!state || !state.accounts || state.accounts.length === 0) return;
     await loadNotifSeen();
@@ -626,17 +676,44 @@
     const since = Math.floor(Date.now() / 1000) - 7 * 24 * 3600;
 
     for (const a of state.accounts) {
+      // Fetch mute list (kind 10000) if not already loaded — includes both
+      // public p-tag mutes and private mutes encrypted in content (NIP-04 to self).
+      if (!_muteLists.has(a.pubkey)) {
+        (async () => {
+          try {
+            const ev = await poolGet(relays, { kinds: [10000], authors: [a.pubkey], limit: 1 });
+            if (!ev) { _muteLists.set(a.pubkey, new Set()); return; }
+            const muted = new Set(ev.tags.filter((t) => t[0] === 'p').map((t) => t[1]));
+            if (ev.content) {
+              try {
+                const plain = await call({ type: 'SIDECAR_OWNER_DECRYPT', ciphertext: ev.content, nip: 4 });
+                const privateTags = JSON.parse(plain);
+                if (Array.isArray(privateTags)) {
+                  privateTags.filter((t) => t[0] === 'p' && t[1]).forEach((t) => muted.add(t[1]));
+                }
+              } catch (_) {}
+            }
+            _muteLists.set(a.pubkey, muted);
+          } catch (_) {
+            _muteLists.set(a.pubkey, new Set());
+          }
+        })();
+      }
+
       if (_notifCache.has(a.pubkey)) continue;
       const cache = { events: [], liveSub: null };
       _notifCache.set(a.pubkey, cache);
 
       const addEvent = (ev) => {
         if (ev.pubkey === a.pubkey) return;
+        const muted = _muteLists.get(a.pubkey);
+        if (muted && muted.has(ev.pubkey)) return;
         if (cache.events.some((e) => e.id === ev.id)) return;
         cache.events.push(ev);
         cache.events.sort((x, y) => y.created_at - x.created_at);
         if (cache.events.length > 100) cache.events.length = 100;
-        refreshBell(a.pubkey);
+        prefetchNotifProfile(ev.pubkey, relays);
+        if (a.pubkey === state?.activePubkey) refreshBell();
       };
 
       const liveSince = Math.floor(Date.now() / 1000);
@@ -662,12 +739,63 @@
     const cache = _notifCache.get(a.pubkey) || { events: [] };
     const now = Math.floor(Date.now() / 1000);
     await saveNotifSeen(a.pubkey, now);
-    refreshBell(a.pubkey);
+    refreshBell();
 
     const client = await preferredClient();
-    const events = cache.events.slice(0, 30);
+    const events = cache.events;
+    const PAGE = 25;
+
+    // Kick off profile fetches for any senders not yet cached, then wait briefly
+    const relays = await relayUrls(false);
+    const uncached = [...new Set(events.map((e) => e.pubkey))].filter((pk) => !_notifProfiles.get(pk));
+    uncached.forEach((pk) => prefetchNotifProfile(pk, relays));
+    if (uncached.length) await new Promise((r) => setTimeout(r, 600));
+
+    function buildItem(ev) {
+      const isNew = ev.created_at > seenAt;
+      const item = h('div', { className: 'notif-item' + (isNew ? ' notif-new' : '') });
+      const { glyph, text } = notifLabel(ev);
+
+      let linkTarget = '';
+      try {
+        linkTarget = NT.nip19.neventEncode({ id: ev.id, author: ev.pubkey, relays: [] });
+      } catch (_) {}
+
+      // Top row: glyph · name (truncated) · time · arrow
+      const topRow = h('div', { className: 'notif-top' });
+      topRow.append(
+        h('span', { className: 'notif-glyph', textContent: glyph }),
+        h('span', { className: 'notif-author', textContent: notifAuthorName(ev.pubkey) }),
+        h('span', { className: 'notif-time', textContent: relativeTime(ev.created_at) })
+      );
+      if (linkTarget) {
+        const link = document.createElement('a');
+        link.className = 'notif-link';
+        link.href = client.url(linkTarget);
+        link.target = '_blank';
+        link.rel = 'noreferrer noopener';
+        link.title = 'Open in ' + client.label;
+        link.appendChild(icon('arrow-up-right'));
+        topRow.appendChild(link);
+      }
+      item.appendChild(topRow);
+
+      // Action row
+      item.appendChild(h('div', { className: 'notif-action', textContent: text }));
+
+      if (ev.kind === 1 && ev.content) {
+        const cleaned = cleanSnippet(ev.content);
+        if (cleaned) {
+          const snippet = cleaned.length > 140 ? cleaned.slice(0, 140) + '…' : cleaned;
+          item.appendChild(h('p', { className: 'notif-content', textContent: snippet }));
+        }
+      }
+      return item;
+    }
 
     openModal((modal) => {
+      modal.classList.add('modal-sheet');
+
       const xBtn = h('button', { className: 'modal-x', title: 'Close' });
       xBtn.appendChild(icon('x'));
       xBtn.addEventListener('click', closeModal);
@@ -688,45 +816,28 @@
         return;
       }
 
+      const scroll = h('div', { className: 'notif-scroll' });
       const list = h('div', { className: 'notif-list' });
-      events.forEach((ev) => {
-        const isNew = ev.created_at > seenAt;
-        const item = h('div', { className: 'notif-item' + (isNew ? ' notif-new' : '') });
-        const { glyph, text } = notifLabel(ev);
+      scroll.appendChild(list);
+      modal.appendChild(scroll);
 
-        const meta = h('div', { className: 'notif-meta' });
-        meta.append(
-          h('span', { className: 'notif-glyph', textContent: glyph }),
-          h('span', { className: 'notif-desc', textContent: text }),
-          h('span', { className: 'notif-time', textContent: relativeTime(ev.created_at) })
-        );
-        item.appendChild(meta);
+      let shown = 0;
+      let moreBtn = null;
 
-        const body = h('div', { className: 'notif-body' });
-        if (ev.kind === 1 && ev.content) {
-          const raw = ev.content.trim();
-          const snippet = raw.length > 120 ? raw.slice(0, 120) + '…' : raw;
-          body.appendChild(h('p', { className: 'notif-content', textContent: snippet }));
+      function loadMore() {
+        const next = events.slice(shown, shown + PAGE);
+        next.forEach((ev) => list.appendChild(buildItem(ev)));
+        shown += next.length;
+        if (shown >= events.length) {
+          if (moreBtn) { moreBtn.remove(); moreBtn = null; }
+        } else if (!moreBtn) {
+          moreBtn = h('button', { className: 'notif-load-more', textContent: 'Load more' });
+          moreBtn.addEventListener('click', loadMore);
+          scroll.appendChild(moreBtn);
         }
+      }
 
-        let linkTarget = '';
-        try {
-          linkTarget = NT.nip19.neventEncode({ id: ev.id, author: ev.pubkey, relays: [] });
-        } catch (_) {}
-        if (linkTarget) {
-          const link = document.createElement('a');
-          link.className = 'notif-link';
-          link.href = client.url(linkTarget);
-          link.target = '_blank';
-          link.rel = 'noreferrer noopener';
-          link.append(h('span', { textContent: 'Open in ' + client.label }), icon('arrow-up-right'));
-          body.appendChild(link);
-        }
-
-        item.appendChild(body);
-        list.appendChild(item);
-      });
-      modal.appendChild(list);
+      loadMore();
     });
   }
 
@@ -814,6 +925,7 @@
     // persistent header chip (current account)
     applyAvatar($('chip-av'), active || {});
     $('chip-name').textContent = active ? displayName(active) : 'No account';
+    refreshBell();
 
     // The active account already shows in the header chip and is marked (check +
     // highlight) in the list below, so the big "booth" card was a third copy.
@@ -930,21 +1042,6 @@
 
     const actions = document.createElement('div');
     actions.className = 'item-actions';
-
-    const bellBtn = document.createElement('button');
-    bellBtn.className = 'icon-btn sm notif-bell';
-    bellBtn.dataset.pubkey = a.pubkey;
-    bellBtn.title = 'Notifications';
-    bellBtn.appendChild(icon('bell'));
-    const badge = document.createElement('span');
-    badge.className = 'notif-badge hidden';
-    bellBtn.appendChild(badge);
-    bellBtn.addEventListener('click', (e) => {
-      e.stopPropagation();
-      showNotifModal(a);
-    });
-    actions.appendChild(bellBtn);
-    Promise.resolve().then(() => refreshBell(a.pubkey));
 
     if (isActive) {
       const check = icon('check');
@@ -4126,6 +4223,7 @@
     }
     port.onMessage.addListener((msg) => {
       if (msg && msg.type === 'SIDECAR_PANEL_APPROVAL') {
+        closeModal();
         pendingApproval = { id: msg.id, data: msg.data };
         showApproval();
       }

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -52,6 +52,7 @@
     eye: '<path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path><circle cx="12" cy="12" r="3"></circle>',
     'eye-off': '<path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"></path><line x1="1" y1="1" x2="23" y2="23"></line>',
     pin: '<path d="M12 17v5"></path><path d="M9 10.76V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v6.76a2 2 0 0 0 .59 1.42l1.12 1.12A2 2 0 0 1 18 14.59V16a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1v-1.41a2 2 0 0 1 .29-1.29l1.12-1.12A2 2 0 0 0 9 10.76Z"></path>',
+    bell: '<path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"></path><path d="M13.73 21a2 2 0 0 1-3.46 0"></path>',
   };
   function icon(name) {
     const wrap = document.createElement('span');
@@ -115,6 +116,9 @@
   let hideBalances = false;
   let _firstPostSeenPubkeys = null;
   let balanceCache = { pubkey: null, sats: null }; // last known balance for instant display
+  const _notifCache = new Map(); // pubkey → { events: Event[], liveSub: Closeable|null }
+  let _notifSeenAt = {}; // pubkey → unix timestamp, persisted to chrome.storage.local
+  let _notifSeenLoaded = false;
 
   // Privacy masking is done in CSS (-webkit-text-security on `.balances-hidden`),
   // which masks each glyph at its real width so toggling never reflows. We always
@@ -184,6 +188,7 @@
       const banner = $('post-banner');
       if (banner) hide(banner); // a note link is account-specific; clear on any state change
       renderMain();
+      initNotifSubs();
       // Re-render the visible tab so account-scoped views (Activity/Profile) follow the switch.
       const activeTab = document.querySelector('.tab.active');
       const name = activeTab && activeTab.dataset.tab;
@@ -541,6 +546,190 @@
     fetchAndStoreProfile(pubkey);
   }
 
+  // ---- notification bell ----
+
+  async function loadNotifSeen() {
+    if (_notifSeenLoaded) return;
+    _notifSeenLoaded = true;
+    try {
+      const r = await new Promise((res) => chrome.storage.local.get('sidecar_notif_seen', res));
+      _notifSeenAt = (r && r.sidecar_notif_seen) || {};
+    } catch (_) {}
+  }
+
+  async function saveNotifSeen(pubkey, ts) {
+    _notifSeenAt[pubkey] = ts;
+    try {
+      await new Promise((res) =>
+        chrome.storage.local.set({ sidecar_notif_seen: _notifSeenAt }, res)
+      );
+    } catch (_) {}
+  }
+
+  function notifUnseenCount(pubkey) {
+    const cache = _notifCache.get(pubkey);
+    if (!cache || !cache.events.length) return 0;
+    const seenAt = _notifSeenAt[pubkey] || 0;
+    return cache.events.filter((ev) => ev.created_at > seenAt).length;
+  }
+
+  function refreshBell(pubkey) {
+    const btn = document.querySelector('.notif-bell[data-pubkey="' + pubkey + '"]');
+    if (!btn) return;
+    const count = notifUnseenCount(pubkey);
+    const badge = btn.querySelector('.notif-badge');
+    if (!badge) return;
+    badge.textContent = count > 99 ? '99+' : count > 0 ? String(count) : '';
+    badge.classList.toggle('hidden', count === 0);
+  }
+
+  function relativeTime(ts) {
+    const diff = Math.floor(Date.now() / 1000) - ts;
+    if (diff < 60) return 'just now';
+    if (diff < 3600) return Math.floor(diff / 60) + 'm ago';
+    if (diff < 86400) return Math.floor(diff / 3600) + 'h ago';
+    if (diff < 7 * 86400) return Math.floor(diff / 86400) + 'd ago';
+    return new Date(ts * 1000).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  }
+
+  function notifLabel(ev) {
+    if (ev.kind === 9735) {
+      let sats = '';
+      try {
+        const descTag = ev.tags.find((t) => t[0] === 'description');
+        if (descTag) {
+          const inner = JSON.parse(descTag[1]);
+          const amtTag = inner.tags && inner.tags.find((t) => t[0] === 'amount');
+          if (amtTag) sats = Math.round(parseInt(amtTag[1], 10) / 1000) + ' sats';
+        }
+      } catch (_) {}
+      return { glyph: '⚡', text: sats ? 'zapped ' + sats : 'zapped you' };
+    }
+    if (ev.kind === 6) return { glyph: '🔁', text: 'reposted your note' };
+    if (ev.kind === 7) {
+      const r = (ev.content || '').trim();
+      const glyph = r === '+' ? '❤️' : r === '-' ? '👎' : r.length <= 4 && r ? r : '❤️';
+      return { glyph, text: 'reacted to your note' };
+    }
+    // kind 1
+    const hasE = ev.tags.some((t) => t[0] === 'e');
+    return hasE
+      ? { glyph: '💬', text: 'replied to your note' }
+      : { glyph: '@', text: 'mentioned you' };
+  }
+
+  async function initNotifSubs() {
+    if (!state || !state.accounts || state.accounts.length === 0) return;
+    await loadNotifSeen();
+    const relays = await relayUrls(false);
+    if (!relays.length) return;
+    const since = Math.floor(Date.now() / 1000) - 7 * 24 * 3600;
+
+    for (const a of state.accounts) {
+      if (_notifCache.has(a.pubkey)) continue;
+      const cache = { events: [], liveSub: null };
+      _notifCache.set(a.pubkey, cache);
+
+      const addEvent = (ev) => {
+        if (ev.pubkey === a.pubkey) return;
+        if (cache.events.some((e) => e.id === ev.id)) return;
+        cache.events.push(ev);
+        cache.events.sort((x, y) => y.created_at - x.created_at);
+        if (cache.events.length > 100) cache.events.length = 100;
+        refreshBell(a.pubkey);
+      };
+
+      const liveSince = Math.floor(Date.now() / 1000);
+      try {
+        getPool().subscribeManyEose(
+          relays,
+          [{ kinds: [1, 6, 7, 9735], '#p': [a.pubkey], since, limit: 50 }],
+          { onevent: addEvent }
+        );
+      } catch (_) {}
+      try {
+        cache.liveSub = getPool().subscribeMany(
+          relays,
+          [{ kinds: [1, 6, 7, 9735], '#p': [a.pubkey], since: liveSince }],
+          { onevent: addEvent }
+        );
+      } catch (_) {}
+    }
+  }
+
+  async function showNotifModal(a) {
+    const seenAt = _notifSeenAt[a.pubkey] || 0;
+    const cache = _notifCache.get(a.pubkey) || { events: [] };
+    const now = Math.floor(Date.now() / 1000);
+    await saveNotifSeen(a.pubkey, now);
+    refreshBell(a.pubkey);
+
+    const client = await preferredClient();
+    const events = cache.events.slice(0, 30);
+
+    openModal((modal) => {
+      const xBtn = h('button', { className: 'modal-x', title: 'Close' });
+      xBtn.appendChild(icon('x'));
+      xBtn.addEventListener('click', closeModal);
+      modal.appendChild(xBtn);
+
+      const heading = h('div', { className: 'notif-modal-head' });
+      heading.append(
+        avatarEl(a, 'notif-modal-av'),
+        h('div', {}, [
+          h('div', { className: 'notif-modal-title', textContent: 'Notifications' }),
+          h('div', { className: 'notif-modal-sub', textContent: displayName(a) }),
+        ])
+      );
+      modal.appendChild(heading);
+
+      if (!events.length) {
+        modal.appendChild(h('p', { className: 'hint', textContent: 'No recent notifications found.' }));
+        return;
+      }
+
+      const list = h('div', { className: 'notif-list' });
+      events.forEach((ev) => {
+        const isNew = ev.created_at > seenAt;
+        const item = h('div', { className: 'notif-item' + (isNew ? ' notif-new' : '') });
+        const { glyph, text } = notifLabel(ev);
+
+        const meta = h('div', { className: 'notif-meta' });
+        meta.append(
+          h('span', { className: 'notif-glyph', textContent: glyph }),
+          h('span', { className: 'notif-desc', textContent: text }),
+          h('span', { className: 'notif-time', textContent: relativeTime(ev.created_at) })
+        );
+        item.appendChild(meta);
+
+        const body = h('div', { className: 'notif-body' });
+        if (ev.kind === 1 && ev.content) {
+          const raw = ev.content.trim();
+          const snippet = raw.length > 120 ? raw.slice(0, 120) + '…' : raw;
+          body.appendChild(h('p', { className: 'notif-content', textContent: snippet }));
+        }
+
+        let linkTarget = '';
+        try {
+          linkTarget = NT.nip19.neventEncode({ id: ev.id, author: ev.pubkey, relays: [] });
+        } catch (_) {}
+        if (linkTarget) {
+          const link = document.createElement('a');
+          link.className = 'notif-link';
+          link.href = client.url(linkTarget);
+          link.target = '_blank';
+          link.rel = 'noreferrer noopener';
+          link.append(h('span', { textContent: 'Open in ' + client.label }), icon('arrow-up-right'));
+          body.appendChild(link);
+        }
+
+        item.appendChild(body);
+        list.appendChild(item);
+      });
+      modal.appendChild(list);
+    });
+  }
+
   // Sparkle hero shown in the empty (no-account) state — a classy welcome that
   // carries the brand and points at the add buttons below.
   const SPARK_SVG =
@@ -741,6 +930,22 @@
 
     const actions = document.createElement('div');
     actions.className = 'item-actions';
+
+    const bellBtn = document.createElement('button');
+    bellBtn.className = 'icon-btn sm notif-bell';
+    bellBtn.dataset.pubkey = a.pubkey;
+    bellBtn.title = 'Notifications';
+    bellBtn.appendChild(icon('bell'));
+    const badge = document.createElement('span');
+    badge.className = 'notif-badge hidden';
+    bellBtn.appendChild(badge);
+    bellBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      showNotifModal(a);
+    });
+    actions.appendChild(bellBtn);
+    Promise.resolve().then(() => refreshBell(a.pubkey));
+
     if (isActive) {
       const check = icon('check');
       check.classList.add('active-check');

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -646,6 +646,17 @@
     }).catch(() => {});
   }
 
+  const IMG_RE = /https?:\/\/\S+\.(?:jpg|jpeg|png|gif|webp|avif)(?:\?\S*)?/gi;
+  const AV_RE = /https?:\/\/\S+\.(?:mp4|mov|webm|m3u8|mp3|wav|m4a|ogg)(?:\?\S*)?/gi;
+
+  // Pull media URLs out of note content so they can render as previews instead
+  // of as raw links in the text snippet.
+  function extractMedia(content) {
+    const images = content.match(IMG_RE) || [];
+    const av = content.match(AV_RE) || [];
+    return { images, av };
+  }
+
   function cleanSnippet(content) {
     return content
       .replace(/nostr:(npub1\S+|nprofile1\S+)/g, (_, entity) => {
@@ -663,7 +674,8 @@
       .replace(/nostr:note1\S+/g, '[note]')
       .replace(/nostr:nevent1\S+/g, '[note]')
       .replace(/nostr:naddr1\S+/g, '[article]')
-      .replace(/https?:\/\/\S+\.(?:jpg|jpeg|png|gif|webp|avif|mp4|mov|mp3|wav|m3u8)(?:\?\S*)?/gi, '[media]')
+      .replace(IMG_RE, '') // shown as thumbnails
+      .replace(AV_RE, '') // shown as a media chip
       .replace(/https?:\/\/([^\s/]+)\S*/g, '$1')
       .replace(/\s+/g, ' ')
       .trim();
@@ -671,7 +683,9 @@
 
   // Load an account's mute list (kind 10000) — newest replaceable event across
   // relays, including both public p-tag mutes and private mutes encrypted in the
-  // content (NIP-04 to self). Deduped per pubkey via a promise cache; when it
+  // content. Private mutes may be NIP-04 (legacy NIP-51) or NIP-44 (newer clients
+  // like Jumble) encrypted to self — try the format the ciphertext looks like,
+  // then fall back to the other. Deduped per pubkey via a promise cache; when it
   // resolves it also drops any already-cached events from muted authors.
   function loadMuteList(pubkey, relays) {
     if (_muteListPromises.has(pubkey)) return _muteListPromises.get(pubkey);
@@ -683,13 +697,19 @@
         if (ev) {
           ev.tags.filter((t) => t[0] === 'p' && t[1]).forEach((t) => muted.add(t[1]));
           if (ev.content) {
-            try {
-              const plain = await call({ type: 'SIDECAR_OWNER_DECRYPT', ciphertext: ev.content, nip: 4 });
-              const privateTags = JSON.parse(plain);
-              if (Array.isArray(privateTags)) {
-                privateTags.filter((t) => t[0] === 'p' && t[1]).forEach((t) => muted.add(t[1]));
-              }
-            } catch (_) {}
+            // NIP-04 ciphertext is "<base64>?iv=<base64>"; NIP-44 is a single
+            // base64 blob. Try the matching scheme first, then the other.
+            const order = ev.content.includes('?iv=') ? [4, 44] : [44, 4];
+            for (const nip of order) {
+              try {
+                const plain = await call({ type: 'SIDECAR_OWNER_DECRYPT', ciphertext: ev.content, nip });
+                const privateTags = JSON.parse(plain);
+                if (Array.isArray(privateTags)) {
+                  privateTags.filter((t) => t[0] === 'p' && t[1]).forEach((t) => muted.add(t[1]));
+                  break;
+                }
+              } catch (_) {}
+            }
           }
         }
       } catch (_) {}
@@ -778,7 +798,6 @@
 
     function buildItem(ev) {
       const isNew = ev.created_at > seenAt;
-      const item = h('div', { className: 'notif-item' + (isNew ? ' notif-new' : '') });
       const { glyph, text } = notifLabel(ev);
 
       let linkTarget = '';
@@ -786,23 +805,31 @@
         linkTarget = NT.nip19.neventEncode({ id: ev.id, author: ev.pubkey, relays: [] });
       } catch (_) {}
 
+      // The whole card is the click target — open the note in the preferred client.
+      const item = linkTarget
+        ? h('a', {
+            className: 'notif-item notif-clickable' + (isNew ? ' notif-new' : ''),
+            href: client.url(linkTarget),
+            target: '_blank',
+            rel: 'noreferrer noopener',
+            title: 'Open in ' + client.label,
+          })
+        : h('div', { className: 'notif-item' + (isNew ? ' notif-new' : '') });
+
       // Top row: glyph · name (truncated) · time · arrow
-      const topRow = h('div', { className: 'notif-top' });
-      topRow.append(
+      const right = h('div', { className: 'notif-top-right' }, [
+        h('span', { className: 'notif-time', textContent: relativeTime(ev.created_at) }),
+      ]);
+      if (linkTarget) {
+        const arrow = h('span', { className: 'notif-link' });
+        arrow.appendChild(icon('arrow-up-right'));
+        right.appendChild(arrow);
+      }
+      const topRow = h('div', { className: 'notif-top' }, [
         h('span', { className: 'notif-glyph', textContent: glyph }),
         h('span', { className: 'notif-author', textContent: notifAuthorName(ev.pubkey) }),
-        h('span', { className: 'notif-time', textContent: relativeTime(ev.created_at) })
-      );
-      if (linkTarget) {
-        const link = document.createElement('a');
-        link.className = 'notif-link';
-        link.href = client.url(linkTarget);
-        link.target = '_blank';
-        link.rel = 'noreferrer noopener';
-        link.title = 'Open in ' + client.label;
-        link.appendChild(icon('arrow-up-right'));
-        topRow.appendChild(link);
-      }
+        right,
+      ]);
       item.appendChild(topRow);
 
       // Action row
@@ -813,6 +840,28 @@
         if (cleaned) {
           const snippet = cleaned.length > 140 ? cleaned.slice(0, 140) + '…' : cleaned;
           item.appendChild(h('p', { className: 'notif-content', textContent: snippet }));
+        }
+
+        const { images, av } = extractMedia(ev.content);
+        if (images.length) {
+          const media = h('div', { className: 'notif-media' });
+          images.slice(0, 3).forEach((src) => {
+            const img = document.createElement('img');
+            img.className = 'notif-thumb';
+            img.src = src;
+            img.alt = '';
+            img.loading = 'lazy';
+            img.referrerPolicy = 'no-referrer';
+            img.onerror = () => img.remove();
+            media.appendChild(img);
+          });
+          item.appendChild(media);
+        }
+        if (av.length) {
+          const isVideo = /\.(?:mp4|mov|webm|m3u8)(?:\?|$)/i.test(av[0]);
+          item.appendChild(
+            h('div', { className: 'notif-media-chip', textContent: (isVideo ? '🎬 ' : '🎵 ') + (isVideo ? 'Video' : 'Audio') })
+          );
         }
       }
       return item;

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -118,7 +118,8 @@
   let balanceCache = { pubkey: null, sats: null }; // last known balance for instant display
   const _notifCache = new Map(); // pubkey → { events: Event[], liveSub: Closeable|null }
   const _notifProfiles = new Map(); // sender pubkey → display name string
-  const _muteLists = new Map(); // pubkey → Set<pubkey>
+  const _muteLists = new Map(); // pubkey → Set<pubkey> (resolved mute set)
+  const _muteListPromises = new Map(); // pubkey → Promise<Set> (dedupe in-flight loads)
   let _notifSeenAt = {}; // pubkey → unix timestamp, persisted to chrome.storage.local
   let _notifSeenLoaded = false;
 
@@ -668,6 +669,44 @@
       .trim();
   }
 
+  // Load an account's mute list (kind 10000) — newest replaceable event across
+  // relays, including both public p-tag mutes and private mutes encrypted in the
+  // content (NIP-04 to self). Deduped per pubkey via a promise cache; when it
+  // resolves it also drops any already-cached events from muted authors.
+  function loadMuteList(pubkey, relays) {
+    if (_muteListPromises.has(pubkey)) return _muteListPromises.get(pubkey);
+    const p = (async () => {
+      const muted = new Set();
+      try {
+        const evs = await getPool().querySync(relays, { kinds: [10000], authors: [pubkey] });
+        const ev = (evs || []).sort((x, y) => y.created_at - x.created_at)[0];
+        if (ev) {
+          ev.tags.filter((t) => t[0] === 'p' && t[1]).forEach((t) => muted.add(t[1]));
+          if (ev.content) {
+            try {
+              const plain = await call({ type: 'SIDECAR_OWNER_DECRYPT', ciphertext: ev.content, nip: 4 });
+              const privateTags = JSON.parse(plain);
+              if (Array.isArray(privateTags)) {
+                privateTags.filter((t) => t[0] === 'p' && t[1]).forEach((t) => muted.add(t[1]));
+              }
+            } catch (_) {}
+          }
+        }
+      } catch (_) {}
+      _muteLists.set(pubkey, muted);
+      // Drop any events that slipped into the cache before the list was ready.
+      const cache = _notifCache.get(pubkey);
+      if (cache && muted.size) {
+        const before = cache.events.length;
+        cache.events = cache.events.filter((e) => !muted.has(e.pubkey));
+        if (cache.events.length !== before && pubkey === state?.activePubkey) refreshBell();
+      }
+      return muted;
+    })();
+    _muteListPromises.set(pubkey, p);
+    return p;
+  }
+
   async function initNotifSubs() {
     if (!state || !state.accounts || state.accounts.length === 0) return;
     await loadNotifSeen();
@@ -676,31 +715,13 @@
     const since = Math.floor(Date.now() / 1000) - 7 * 24 * 3600;
 
     for (const a of state.accounts) {
-      // Fetch mute list (kind 10000) if not already loaded — includes both
-      // public p-tag mutes and private mutes encrypted in content (NIP-04 to self).
-      if (!_muteLists.has(a.pubkey)) {
-        (async () => {
-          try {
-            const ev = await poolGet(relays, { kinds: [10000], authors: [a.pubkey], limit: 1 });
-            if (!ev) { _muteLists.set(a.pubkey, new Set()); return; }
-            const muted = new Set(ev.tags.filter((t) => t[0] === 'p').map((t) => t[1]));
-            if (ev.content) {
-              try {
-                const plain = await call({ type: 'SIDECAR_OWNER_DECRYPT', ciphertext: ev.content, nip: 4 });
-                const privateTags = JSON.parse(plain);
-                if (Array.isArray(privateTags)) {
-                  privateTags.filter((t) => t[0] === 'p' && t[1]).forEach((t) => muted.add(t[1]));
-                }
-              } catch (_) {}
-            }
-            _muteLists.set(a.pubkey, muted);
-          } catch (_) {
-            _muteLists.set(a.pubkey, new Set());
-          }
-        })();
-      }
-
       if (_notifCache.has(a.pubkey)) continue;
+
+      // Load mutes BEFORE subscribing so addEvent filters from the first event.
+      // Cap the wait so a slow relay can't stall notifications — the fetch keeps
+      // running and prunes the cache once it lands.
+      await Promise.race([loadMuteList(a.pubkey, relays), new Promise((r) => setTimeout(r, 5000))]);
+
       const cache = { events: [], liveSub: null };
       _notifCache.set(a.pubkey, cache);
 
@@ -742,11 +763,15 @@
     refreshBell();
 
     const client = await preferredClient();
-    const events = cache.events;
+    const relays = await relayUrls(false);
+
+    // Final guard: ensure the mute list has resolved, then filter the view.
+    await Promise.race([loadMuteList(a.pubkey, relays), new Promise((r) => setTimeout(r, 3000))]);
+    const muted = _muteLists.get(a.pubkey);
+    const events = muted && muted.size ? cache.events.filter((e) => !muted.has(e.pubkey)) : cache.events;
     const PAGE = 25;
 
     // Kick off profile fetches for any senders not yet cached, then wait briefly
-    const relays = await relayUrls(false);
     const uncached = [...new Set(events.map((e) => e.pubkey))].filter((pk) => !_notifProfiles.get(pk));
     uncached.forEach((pk) => prefetchNotifProfile(pk, relays));
     if (uncached.length) await new Promise((r) => setTimeout(r, 600));

--- a/styles.css
+++ b/styles.css
@@ -903,6 +903,21 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
 .compose-author-info { display: flex; flex-direction: column; min-width: 0; }
 .compose-author-eyebrow { font-size: 11px; letter-spacing: 0.04em; text-transform: uppercase; color: var(--muted); }
 .compose-author-name { font-weight: 600; font-size: 14px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.draft-preview {
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--text-2);
+  background: var(--velvet-1);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 10px 12px;
+  margin: 4px 0 2px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 120px;
+  overflow: hidden;
+}
+.draft-preview-meta { font-size: 11.5px; color: var(--muted); margin: 0 0 2px; }
 .compose-tabs { display: flex; gap: 4px; margin-bottom: 10px; border-bottom: 1px solid var(--border); }
 .compose-tab {
   background: none; border: none; border-bottom: 2px solid transparent; margin-bottom: -1px;

--- a/styles.css
+++ b/styles.css
@@ -626,16 +626,24 @@ button:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(203, 161, 78, 0
   margin-top: 4px;
 }
 .notif-item {
-  padding: 10px 0;
+  display: block;
+  padding: 10px 8px;
+  margin: 0 -8px;
+  border-radius: 10px;
   border-bottom: 1px solid var(--border);
+  color: inherit;
+  text-decoration: none;
 }
 .notif-item:last-child { border-bottom: none; }
+a.notif-clickable { cursor: pointer; transition: background 0.12s ease; }
+a.notif-clickable:hover { background: rgba(167, 139, 250, 0.08); }
 .notif-item.notif-new .notif-action { color: var(--lav); }
 .notif-top {
   display: flex;
   align-items: center;
   gap: 6px;
 }
+.notif-top-right { display: flex; align-items: center; gap: 6px; flex-shrink: 0; }
 .notif-glyph { font-size: 14px; line-height: 1; flex-shrink: 0; }
 .notif-author { font-size: 13px; font-weight: 600; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; flex: 1; min-width: 0; }
 .notif-time { font-size: 11px; color: var(--faint); flex-shrink: 0; white-space: nowrap; }
@@ -650,9 +658,31 @@ button:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(203, 161, 78, 0
   -webkit-box-orient: vertical;
   word-break: break-word;
 }
-.notif-link { display: flex; align-items: center; color: var(--faint); text-decoration: none; flex-shrink: 0; }
-.notif-link:hover { color: var(--lav); }
+.notif-link { display: flex; align-items: center; color: var(--faint); flex-shrink: 0; }
+a.notif-clickable:hover .notif-link { color: var(--lav); }
 .notif-link svg { width: 13px; height: 13px; }
+.notif-media { display: flex; flex-wrap: wrap; gap: 6px; margin: 7px 0 0 22px; }
+.notif-thumb {
+  width: 72px;
+  height: 72px;
+  object-fit: cover;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: var(--velvet-1);
+  display: block;
+}
+.notif-media-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin: 7px 0 0 22px;
+  padding: 3px 9px;
+  background: var(--velvet-1);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  font-size: 11.5px;
+  color: var(--muted);
+}
 .item.item-pending { border-color: var(--gold-soft); box-shadow: var(--sheen), 0 0 0 1px var(--gold-soft); }
 .item.item-pending .item-label { color: var(--gold); }
 .item.item-pending .item-sub { color: var(--gold-soft); }

--- a/styles.css
+++ b/styles.css
@@ -814,7 +814,8 @@ button:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(203, 161, 78, 0
 }
 .modal.modal-sheet {
   overflow: hidden;
-  height: 96vh;
+  height: 100%;
+  max-height: none;
 }
 .notif-scroll {
   overflow-y: auto;

--- a/styles.css
+++ b/styles.css
@@ -565,6 +565,100 @@ button:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(203, 161, 78, 0
 .item-sub { font-family: var(--font-mono); font-size: 11.5px; color: var(--muted); word-break: break-all; margin-top: 2px; }
 .item-actions { display: flex; align-items: center; gap: 6px; flex-shrink: 0; }
 .active-check { width: 18px; height: 18px; color: var(--gold); flex-shrink: 0; }
+
+/* notification bell button + unread badge */
+.notif-bell { position: relative; }
+.notif-badge {
+  position: absolute;
+  top: -5px;
+  right: -5px;
+  background: var(--orange);
+  color: #fff;
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 1;
+  min-width: 16px;
+  height: 16px;
+  border-radius: 8px;
+  padding: 0 3px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  border: 1.5px solid var(--velvet-2);
+}
+
+/* notification modal */
+.notif-modal-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 6px;
+}
+.notif-modal-av {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  overflow: hidden;
+  flex-shrink: 0;
+  background: var(--velvet-1);
+  border: 1px solid var(--border);
+}
+.notif-modal-title {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 18px;
+  line-height: 1.2;
+}
+.notif-modal-sub {
+  font-size: 12px;
+  color: var(--muted);
+  margin-top: 1px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.notif-list {
+  display: flex;
+  flex-direction: column;
+  margin-top: 4px;
+}
+.notif-item {
+  padding: 10px 0;
+  border-bottom: 1px solid var(--border);
+}
+.notif-item:last-child { border-bottom: none; }
+.notif-item.notif-new .notif-desc { color: var(--lav); }
+.notif-meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 5px;
+}
+.notif-glyph { font-size: 14px; line-height: 1; flex-shrink: 0; }
+.notif-desc { font-size: 12.5px; color: var(--muted); flex: 1; min-width: 0; }
+.notif-time { font-size: 11px; color: var(--faint); flex-shrink: 0; white-space: nowrap; }
+.notif-body { padding-left: 2px; }
+.notif-content {
+  font-size: 12.5px;
+  color: var(--text-2);
+  margin: 0 0 5px;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  word-break: break-word;
+}
+.notif-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--lav);
+  text-decoration: none;
+}
+.notif-link:hover { color: var(--purple); text-decoration: underline; }
+.notif-link svg { width: 12px; height: 12px; }
 .item.item-pending { border-color: var(--gold-soft); box-shadow: var(--sheen), 0 0 0 1px var(--gold-soft); }
 .item.item-pending .item-label { color: var(--gold); }
 .item.item-pending .item-sub { color: var(--gold-soft); }

--- a/styles.css
+++ b/styles.css
@@ -604,6 +604,8 @@ button:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(203, 161, 78, 0
   background: var(--velvet-1);
   border: 1px solid var(--border);
 }
+.notif-modal-av img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.notif-modal-av.avatar-ph img { width: 60%; height: 60%; margin: 20%; object-fit: contain; opacity: 0.72; }
 .notif-modal-title {
   font-family: var(--font-display);
   font-weight: 700;
@@ -628,37 +630,29 @@ button:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(203, 161, 78, 0
   border-bottom: 1px solid var(--border);
 }
 .notif-item:last-child { border-bottom: none; }
-.notif-item.notif-new .notif-desc { color: var(--lav); }
-.notif-meta {
+.notif-item.notif-new .notif-action { color: var(--lav); }
+.notif-top {
   display: flex;
   align-items: center;
   gap: 6px;
-  margin-bottom: 5px;
 }
 .notif-glyph { font-size: 14px; line-height: 1; flex-shrink: 0; }
-.notif-desc { font-size: 12.5px; color: var(--muted); flex: 1; min-width: 0; }
+.notif-author { font-size: 13px; font-weight: 600; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; flex: 1; min-width: 0; }
 .notif-time { font-size: 11px; color: var(--faint); flex-shrink: 0; white-space: nowrap; }
-.notif-body { padding-left: 2px; }
+.notif-action { font-size: 12px; color: var(--muted); margin: 2px 0 0 22px; }
 .notif-content {
   font-size: 12.5px;
   color: var(--text-2);
-  margin: 0 0 5px;
+  margin: 4px 0 0 22px;
   overflow: hidden;
   display: -webkit-box;
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
   word-break: break-word;
 }
-.notif-link {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  font-size: 12px;
-  color: var(--lav);
-  text-decoration: none;
-}
-.notif-link:hover { color: var(--purple); text-decoration: underline; }
-.notif-link svg { width: 12px; height: 12px; }
+.notif-link { display: flex; align-items: center; color: var(--faint); text-decoration: none; flex-shrink: 0; }
+.notif-link:hover { color: var(--lav); }
+.notif-link svg { width: 13px; height: 13px; }
 .item.item-pending { border-color: var(--gold-soft); box-shadow: var(--sheen), 0 0 0 1px var(--gold-soft); }
 .item.item-pending .item-label { color: var(--gold); }
 .item.item-pending .item-sub { color: var(--gold-soft); }
@@ -818,6 +812,31 @@ button:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(203, 161, 78, 0
   gap: 9px;
   box-shadow: var(--sheen), 0 24px 60px rgba(0, 0, 0, 0.6);
 }
+.modal.modal-sheet {
+  overflow: hidden;
+  height: 96vh;
+}
+.notif-scroll {
+  overflow-y: auto;
+  flex: 1;
+  min-height: 0;
+  margin: 0 -22px -22px;
+  padding: 0 22px 22px;
+}
+.notif-load-more {
+  display: block;
+  width: 100%;
+  margin-top: 10px;
+  padding: 9px;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  color: var(--muted);
+  font-size: 13px;
+  cursor: pointer;
+  text-align: center;
+}
+.notif-load-more:hover { border-color: var(--gold-soft); color: var(--text); }
 .modal::before {
   content: '';
   position: absolute;

--- a/welcome.js
+++ b/welcome.js
@@ -57,6 +57,13 @@ const APPS = [
     desc: 'Live streaming platform with real-time Lightning zaps from your audience.',
   },
   {
+    name: 'Shosho',
+    url: 'https://shosho.live',
+    domain: 'shosho.live',
+    cat: 'live',
+    desc: 'Stream your camera and chat with friends and followers live on Nostr. Watch streams on the web or mobile app, connect to any streaming server.',
+  },
+  {
     name: 'Nostr Nests',
     url: 'https://nostrnests.com',
     domain: 'nostrnests.com',
@@ -98,6 +105,13 @@ const APPS = [
     domain: 'gamestr.io',
     cat: 'gaming',
     desc: 'Decentralized gaming on nostr — play games, earn sats, and own your scores on a censorship-resistant network.',
+  },
+  {
+    name: 'Words with Zaps',
+    url: 'https://www.wordswithzaps.top',
+    domain: 'wordswithzaps.top',
+    cat: 'gaming',
+    desc: 'A two-player word game on Nostr with Lightning micropayments. Challenge friends, build words, and zap your way to victory.',
   },
   {
     name: 'Mutable',


### PR DESCRIPTION
## Summary

A batch of side-panel improvements centered on a new **notification bell**, plus signer reliability and composer quality-of-life work.

_(Supersedes #27.)_

### Notification bell
- Lives in the topbar next to the gear; the badge tracks the active account's unseen count.
- Real-time via a live relay subscription (7-day backfill on open), shown in a full-height sheet with "Load more" pagination.
- Each card is a single click target that opens the note in your preferred client — author name, timestamp, and body are all clickable. Reactions/reposts/zaps open the referenced note, not the meta-event.
- Content is cleaned up: `nostr:` profile entities resolve to `@name`, URLs collapse to their domain, and image URLs render as thumbnails (video/audio as a small chip) instead of a raw `[media]` token.
- **Muted users are filtered** — public p-tag mutes plus private mutes decrypted from the kind:10000 content, trying both NIP-44 (e.g. Jumble) and NIP-04. Mutes load before subscriptions so nothing slips through, with a render-time guard as backup.

### Signer reliability
- When several signed-in apps fire requests at once with the panel closed, they now **reuse a single approval popup** (the window navigates to each queued request) instead of stacking up N windows.
- An incoming signing/payment approval dismisses the notification modal first so it can't get buried.

### Composer
- **Draft autosave** per account: debounced on every edit and flushed on close. Reopening offers *Resume draft* / *Start fresh* with a preview; the draft clears on a successful publish.
- Fixed a modal height leak so the composer and posting countdown size to their content again.

### Welcome page
- Added Words with Zaps (gaming) and Shosho (live) to the app directory; bumped the manifest to 1.0.1.

## Testing
- Syntax-checked all touched JS (`node --check`).
- Manually verified in the side panel: bell badge/modal, mute filtering, clickable cards, media thumbnails, popup reuse, and draft resume/fresh flows.

🥃 Poured with [Claude Code](https://claude.com/claude-code)