### PR TITLE
Show note preview during the post countdown

### DIFF
--- a/sidepanel.js
+++ b/sidepanel.js
@@ -2729,6 +2729,8 @@
     function showCountdown() {
       modal.innerHTML = '';
       let remaining = NOTE_COUNTDOWN_SECS;
+
+      // Full-size countdown ring, centered below the note preview.
       const R = 30;
       const C = 2 * Math.PI * R;
       const ring = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
@@ -2740,6 +2742,14 @@
         'stroke-dasharray="' + C + '" stroke-dashoffset="0" transform="rotate(-90 36 36)"/>';
       const num = h('div', { className: 'countdown-num', textContent: String(remaining) });
       const ringWrap = h('div', { className: 'countdown-wrap' }, [ring, num]);
+
+      // The note exactly as it will be published, for a last review.
+      const previewScroll = h('div', { className: 'countdown-preview' });
+      const previewBody = h('div', { className: 'preview-body' });
+      const bodyText = draft.text.trim();
+      if (bodyText) renderNotePreview(previewBody, bodyText);
+      else previewBody.append(h('p', { className: 'hint', textContent: 'Empty note.' }));
+      previewScroll.append(previewBody);
 
       const now = h('button', { className: 'primary', textContent: 'Post now' });
       const cancel = h('button', { className: 'ghost', textContent: 'Cancel' });
@@ -2765,7 +2775,8 @@
 
       modal.append(
         h('h3', { textContent: 'Posting your note' }),
-        h('p', { className: 'hint', textContent: 'Sending in a moment. Post now or cancel to keep editing.' }),
+        h('p', { className: 'hint', textContent: 'Review before it posts.' }),
+        previewScroll,
         ringWrap,
         h('div', { className: 'actions' }, [now, cancel])
       );

--- a/styles.css
+++ b/styles.css
@@ -1017,6 +1017,17 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
   font-variant-numeric: lining-nums tabular-nums;
   font-feature-settings: 'lnum' 1, 'tnum' 1;
 }
+/* the note preview leads; the full-size ring (above) sits centered below it */
+.countdown-preview {
+  max-height: 42vh;
+  overflow-y: auto;
+  background: var(--velvet-1);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 12px 14px;
+  margin: 2px 0;
+}
+.countdown-preview .preview-body { font-size: 14px; line-height: 1.5; }
 
 /* ===== wallet (NWC) ===== */
 .nwc-input { min-height: 84px; font-family: var(--font-mono); font-size: 12px; margin-bottom: 4px; }


### PR DESCRIPTION
## Summary

The post countdown previously hid the note behind a full-screen timer. Now it shows the note exactly as it will publish so the user can review it for the entire countdown window.

- Renders the note via the shared note preview (mentions, embeds, and media all show) in a scrollable card.
- Keeps the original large countdown ring, centered below the preview, with a short "Review before it posts." caption.
- Post now / Cancel behavior unchanged (cancel returns to the editor).

## Testing
- `node --check` on the touched file.
- Manual: triggered the countdown with text, mentions, and media — preview renders and the timer counts down below it; Post now and Cancel work.

🥂 Stirred with [Claude Code](https://claude.com/claude-code)