### PR TITLE
Export NWC connection string (PIN-gated) + QR codes for NWC and nsec

### DIFF
--- a/background.js
+++ b/background.js
@@ -903,6 +903,13 @@ async function handleControl(message, sendResponse) {
       case 'SIDECAR_GET_NWC':
         result = { connection: await KS.getNwc(message.pubkey) };
         break;
+      case 'SIDECAR_REVEAL_NWC': {
+        // Export the raw connection string — always step-up PIN, even while unlocked.
+        if (KS.isLocked()) throw new Error('Keystore is locked');
+        if (!(await KS.verifyPin(message.pin))) throw new Error('Incorrect PIN');
+        result = { connection: await KS.getNwc(message.pubkey) };
+        break;
+      }
       case 'SIDECAR_HAS_NWC':
         result = { has: await KS.hasNwc(message.pubkey) };
         break;

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -1353,6 +1353,12 @@
     let timer = null;
     openModal(
       (modal) => {
+        // Scannable QR for QR sign-in on mobile clients (e.g. Wisp). nsec is
+        // case-sensitive bech32, so encode it as-is (lowercase, byte mode).
+        const canvas = document.createElement('canvas');
+        canvas.className = 'recv-qr modal-qr';
+        try { new window.QRious({ element: canvas, value: opts.nsec, size: 220, level: 'M' }); } catch (_) {}
+
         const box = h('div', { className: 'secret-box', textContent: opts.nsec });
         const copy = h('button', { className: 'secondary', textContent: 'Copy nsec' });
         copy.addEventListener('click', async () => {
@@ -1375,6 +1381,8 @@
         modal.append(
           h('h3', { textContent: opts.title }),
           opts.intro ? h('p', { className: 'hint', textContent: opts.intro }) : document.createTextNode(''),
+          canvas,
+          h('p', { className: 'hint', textContent: 'Scan to sign in on a mobile client that supports QR login.' }),
           box,
           copy,
           h('p', { className: 'hint warn', textContent: 'Anyone with this key fully controls the account. Store it somewhere safe and never share it.' }),
@@ -3689,6 +3697,89 @@
   }
 
   // Backup the NWC connection to relays, with detection of an existing backup.
+  // Export the raw NWC connection string — PIN-gated step-up, then a copyable
+  // reveal that auto-hides (mirrors the nsec reveal).
+  function exportNwcModal() {
+    if (!state.activePubkey) { toast('No active account', 'error'); return; }
+    openModal((modal) => {
+      const pin = h('input', { type: 'password', maxLength: 32 });
+      const err = h('div', { className: 'error' });
+      const go = h('button', { className: 'primary', textContent: 'Reveal' });
+      go.addEventListener('click', async () => {
+        err.textContent = '';
+        if (!pin.value) return (err.textContent = 'Enter your PIN.');
+        go.disabled = true;
+        go.textContent = 'Revealing…';
+        try {
+          const r = await call({ type: 'SIDECAR_REVEAL_NWC', pubkey: state.activePubkey, pin: pin.value });
+          if (!r.connection) throw new Error('No wallet connection saved for this account');
+          nwcRevealModal(r.connection);
+        } catch (e) {
+          err.textContent = e.message;
+          go.disabled = false;
+          go.textContent = 'Reveal';
+          toast(e.message, 'error');
+        }
+      });
+      const cancel = h('button', { className: 'ghost', textContent: 'Cancel' });
+      cancel.addEventListener('click', closeModal);
+      modal.append(
+        h('h3', { textContent: 'Export wallet connection' }),
+        h('p', { className: 'hint', textContent: 'Enter your PIN to reveal the NWC connection string for this account.' }),
+        h('label', { textContent: 'PIN' }),
+        pin,
+        err,
+        h('div', { className: 'actions' }, [go, cancel])
+      );
+      setTimeout(() => pin.focus(), 50);
+    });
+  }
+
+  function nwcRevealModal(connection) {
+    let remaining = NSEC_REVEAL_TIMEOUT_S;
+    let timer = null;
+    openModal(
+      (modal) => {
+        // Scannable QR — NWC URIs are case-sensitive, so don't uppercase, and use
+        // level 'L' for the extra capacity these longer strings need.
+        const canvas = document.createElement('canvas');
+        canvas.className = 'recv-qr modal-qr';
+        try { new window.QRious({ element: canvas, value: connection, size: 220, level: 'L' }); } catch (_) {}
+
+        const box = h('div', { className: 'secret-box', textContent: connection });
+        const copy = h('button', { className: 'secondary', textContent: 'Copy connection string' });
+        copy.addEventListener('click', async () => {
+          try {
+            await navigator.clipboard.writeText(connection);
+            toast('Connection string copied', 'success');
+          } catch (_) {}
+        });
+        const done = h('button', { className: 'primary', textContent: "I've saved it" });
+        done.addEventListener('click', closeModal);
+        const countdown = h('p', {
+          className: 'hint',
+          textContent: 'Hiding in ' + remaining + 's. Reveal again with your PIN.',
+        });
+        timer = setInterval(() => {
+          remaining -= 1;
+          if (remaining <= 0) return closeModal();
+          countdown.textContent = 'Hiding in ' + remaining + 's. Reveal again with your PIN.';
+        }, 1000);
+        modal.append(
+          h('h3', { textContent: 'Wallet connection string' }),
+          h('p', { className: 'hint', textContent: 'Scan in an NWC-compatible app, or copy the string below to connect the same wallet.' }),
+          canvas,
+          box,
+          copy,
+          h('p', { className: 'hint warn', textContent: 'This string can spend from your wallet up to its limits. Store it safely and never share it.' }),
+          countdown,
+          h('div', { className: 'actions' }, [done])
+        );
+      },
+      () => { if (timer) { clearInterval(timer); timer = null; } }
+    );
+  }
+
   function renderWalletBackup() {
     const wrap = h('div', { className: 'setting wallet-backup' });
     wrap.append(h('h3', { textContent: 'Backup' }));
@@ -3724,12 +3815,18 @@
         restore.textContent = 'Restore';
       }
     });
+    const exportBtn = h('button', { className: 'wallet-export-link', textContent: 'Export connection string' });
+    exportBtn.append(icon('key'));
+    exportBtn.addEventListener('click', exportNwcModal);
+    hide(exportBtn); // shown only when a connection exists for the active account
+
     const card = h('div', { className: 'wallet-backup-card' }, [
       h('div', { className: 'wallet-backup-head' }, [
         h('span', { className: 'item-label', textContent: 'Wallet connection' }),
         status,
       ]),
       h('div', { className: 'wallet-backup-actions' }, [back, restore]),
+      exportBtn,
     ]);
     wrap.append(card);
 
@@ -3741,6 +3838,10 @@
       .catch(() => {
         status.textContent = 'Not backed up';
       });
+    // Only offer export when this account actually has a connection saved.
+    call({ type: 'SIDECAR_HAS_NWC', pubkey: state.activePubkey })
+      .then((r) => { if (r && r.has) show(exportBtn); })
+      .catch(() => {});
     return wrap;
   }
 

--- a/styles.css
+++ b/styles.css
@@ -1110,6 +1110,7 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
 .send-comment { width: 100%; margin-top: 8px; }
 .recv-out { display: flex; flex-direction: column; align-items: center; gap: 12px; margin-top: 16px; }
 .recv-qr { background: #fff; border-radius: 12px; padding: 10px; width: 220px; height: 220px; }
+.modal-qr { display: block; margin: 4px auto 2px; }
 .recv-bolt {
   font-family: var(--font-mono); font-size: 12px; color: var(--muted); text-align: center;
   padding: 7px 12px; border-radius: 8px; border: 1px solid var(--border);
@@ -1154,6 +1155,14 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
 .wallet-backup-head .backup-status { margin-top: 0; flex-shrink: 0; }
 .wallet-backup-actions { display: flex; gap: 8px; }
 .wallet-backup-actions button { flex: 1; }
+.wallet-export-link {
+  display: flex; align-items: center; justify-content: center; gap: 6px;
+  width: 100%; margin-top: 10px; padding: 7px;
+  background: transparent; border: none; border-radius: 8px;
+  color: var(--muted); font-size: 12.5px; cursor: pointer;
+}
+.wallet-export-link:hover { color: var(--text); background: rgba(167, 139, 250, 0.06); }
+.wallet-export-link svg { width: 13px; height: 13px; }
 
 /* amount preset chips (receive) */
 .amount-presets { display: flex; flex-wrap: wrap; gap: 6px; margin: 6px 0 8px; }


### PR DESCRIPTION
## Summary

Adds a PIN-guarded way to export the wallet's NWC connection string, and QR codes to both the NWC and nsec reveal modals for easy mobile hand-off.

### Export NWC connection string
- New **Export connection string** action in the wallet Backup card, shown only when the active account actually has a connection saved.
- Steps up with the PIN via a new `SIDECAR_REVEAL_NWC` background handler (requires unlocked keystore + correct PIN, identical gating to the nsec reveal).
- Reveal modal shows a copyable string and a scannable QR, with a spend-risk warning and a 30s auto-hide.
- QR is encoded as-is (case-sensitive) at error-correction level L, since NWC URIs are longer and case-sensitive.

### QR on nsec reveal
- The nsec reveal/backup modal now shows a QR above the key for QR sign-in on mobile clients (e.g. Wisp), encoded as-is since nsec is case-sensitive bech32.
- Appears in both the new-key backup and the reveal-private-key flows.

Shared the QR centering via a generic `.modal-qr` class.

## Security
- Both secrets stay behind the existing step-up PIN and auto-hide. Note the nsec QR puts the full private key on screen as a scannable image — intended, for QR login — but only reachable after the PIN reveal.

## Testing
- `node --check` on the touched JS.
- Manual: exported an NWC string (QR scans, copy works, hides after 30s); revealed an nsec and scanned the QR into a mobile client.

🍷 Blended with [Claude Code](https://claude.com/claude-code)