### PR TITLE
Wallet suggestions page, self-custody notice, balance-card flicker fix (v1.1.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,19 +19,20 @@ Or run from source (no build step required — see below).
 
 ## Features
 
-- **Multiple accounts** — store as many nsecs as you like, drag to reorder, switch the active one in a click. Importing shows a profile preview (name + avatar) so you can confirm the right key before saving.
+- **Multiple accounts** — store as many nsecs as you like, drag to reorder, switch the active one in a click. Importing shows a profile preview (name + avatar) so you can confirm the right key before saving. Reveal a key behind your PIN — with a QR for quick sign-in on mobile clients.
 - **PIN-protected** — every private key is encrypted at rest (PBKDF2 → AES-GCM, WebCrypto). Nothing is stored in plaintext, and the keystore re-locks automatically. A paste guard blocks dropping an nsec anywhere except the import field.
 - **In-extension signing** — implements the full NIP-07 surface: `getPublicKey`, `signEvent`, `nip04`/`nip44` encrypt & decrypt, and `getRelays`.
 - **Per-site permissions** — approve or reject each site, per method, with a clear prompt that previews what you're signing. Relay auth (NIP-42) signs automatically so clients stay connected.
 - **Per-site account binding** — each site stays pinned to the account it logged in with (no NIP-07 desync). Switch a site to another account from **Connected Sites**.
 - **Identity from your profile** — account names and avatars are imported from your kind 0 metadata; view and edit your profile and publish kind 0.
 - **Backups** — encrypt your profile, follows, and mute list to your own key and store them on your relays (NIP-78), or export a signed JSON bundle.
-- **Note composer** — post kind:1 notes directly from the panel with a 15-second undo window. Features include:
+- **Note composer** — post kind:1 notes directly from the panel with a send countdown you can review (the full note renders) and cancel. Drafts autosave per account, so you can close the composer and resume — or start fresh — later. Features include:
   - **@mention autocomplete** — type `@` to search your follow list; selecting inserts an atomic pill that serializes to `nostr:npub1…` and adds a `p` tag automatically.
   - **Nostr event embeds** — paste a `note1`, `nevent1`, or `naddr1` entity and the preview renders a fetched embed card (author, timestamp, content excerpt).
   - **Link previews** — plain URLs show an OG meta card (title, description, thumbnail) fetched through the extension with no third-party service.
-  - **Media upload** — attach images and video; files are uploaded and appended as URLs.
-- **Lightning wallet (NWC)** — connect any Nostr Wallet Connect wallet (Alby Hub, Rizful, YakiHonne, …). Send (BOLT11 or lightning address via LNURL-pay), receive (invoice or your lightning address QR), view paginated history, and back up the connection to your relays. Sidecar never holds your funds.
+  - **Media upload** — attach images and video; uploads go to your own Blossom servers (from your kind:10063 list) when available, falling back to nostr.build.
+- **Notifications** — a bell in the header shows replies, mentions, reposts, reactions, and zaps for the active account — each with the sender's name, a content preview, and a tap-through that opens the note in your preferred client. Muted users (public and private mute lists) are filtered out.
+- **Lightning wallet (NWC)** — connect any Nostr Wallet Connect wallet (Alby Hub, Rizful, YakiHonne, …). Send (BOLT11 or lightning address via LNURL-pay), receive (invoice or your lightning address QR), view paginated history, and back up the connection to your relays — or export it (PIN-gated, with a QR) to move it to another app. New to Lightning? Built-in **wallet suggestions** point you to NWC-capable options. Sidecar never holds your funds.
 - **WebLN provider** — web apps can pay and make invoices through your connected wallet (`window.webln`), gated by an approval prompt with an optional per-site daily budget you can edit or revoke any time.
 - **Pay invoices from any page** — when a nostr client you're signed into shows a Lightning invoice, a **Pay with Sidecar** card appears so you can pay in a tap. You can also right-click a `lightning:` link, a selected BOLT11 invoice, or a QR image.
 - **Auto-approve zaps** (optional, off by default) — pay zaps without a prompt up to a per-zap limit you set. Verified zaps only; larger zaps, non-zaps, and a locked wallet still ask.
@@ -90,6 +91,7 @@ Or regenerate it manually any time:
 | Crypto & keystore | `crypto.js`, `keystore.js`, `permissions.js`, `signer.js` |
 | Approval prompt | `prompt.html`, `prompt.js` |
 | Side panel UI | `sidepanel.html`, `sidepanel.js`, `styles.css`, `fonts.css` |
+| Standalone pages | `welcome.html`/`welcome.js` (nostr app directory, first-run), `wallets.html`/`wallets.js`/`wallets.css` (NWC wallet suggestions) |
 | Lightning (NWC / NIP-47) | `nwc-client.js`, `wallet-budgets.js` |
 | Vendored | `nostr-tools.js`, `qrious.min.js` (receive QR), `jsqr.js` (scan QR to pay), `fonts/` (Playfair Display + Manrope, SIL OFL) |
 | Generated | `version.js` (build stamp), `scripts/stamp-version.sh` |

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Sidecar | A Classy Nostr Signer",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A multi-account NIP-07 nostr signer with a built-in Lightning wallet, in your browser sidebar.",
   "permissions": [
     "storage",

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -138,15 +138,33 @@
   // back into itself and flip the state every frame. The sentinel sits above the
   // card, so the card's resize never moves it — no feedback loop, no flicker.
   let walletCardObserver = null;
-  function observeWalletCard(card, sentinel) {
+  function observeWalletCard(card, sentinel, spacer) {
     if (walletCardObserver) { walletCardObserver.disconnect(); walletCardObserver = null; }
     const root = document.querySelector('.content');
     if (!root || !('IntersectionObserver' in window)) return;
-    walletCardObserver = new IntersectionObserver(
-      (entries) => card.classList.toggle('compact', !entries[0].isIntersecting),
-      { root, rootMargin: '48px 0px 0px 0px', threshold: 0 }
-    );
-    walletCardObserver.observe(sentinel);
+    // Defer until the card has laid out so we can measure its collapse delta.
+    requestAnimationFrame(() => {
+      // How much height the card loses when collapsed. A bottom spacer grows by
+      // exactly this amount while compact, so collapsing never changes the total
+      // scroll height. Without it, collapsing shrinks the document, the scroll
+      // clamps at the bottom, the sentinel re-enters view, and it flickers —
+      // worst on a short page like a wallet with no transactions.
+      card.classList.remove('compact');
+      const expandedH = card.offsetHeight;
+      card.classList.add('compact');
+      const compactH = card.offsetHeight;
+      card.classList.remove('compact');
+      const delta = Math.max(0, expandedH - compactH);
+      walletCardObserver = new IntersectionObserver(
+        (entries) => {
+          const compact = !entries[0].isIntersecting;
+          card.classList.toggle('compact', compact);
+          if (spacer) spacer.style.height = compact ? delta + 'px' : '0px';
+        },
+        { root, rootMargin: '48px 0px 0px 0px', threshold: 0 }
+      );
+      walletCardObserver.observe(sentinel);
+    });
   }
 
   // Background broadcasts (e.g. a WebLN payment paid via the service worker
@@ -3455,6 +3473,18 @@
     });
     restoreBlock.append(restore, restoreNote);
     view.append(restoreBlock);
+
+    // Help users who don't have an NWC-capable wallet yet.
+    const find = h('a', {
+      className: 'explore-link wallet-find-link',
+      href: '#',
+      textContent: 'Need a wallet? See suggestions →',
+    });
+    find.addEventListener('click', (e) => {
+      e.preventDefault();
+      chrome.tabs.create({ url: chrome.runtime.getURL('wallets.html') });
+    });
+    view.append(find);
   }
 
   async function renderWalletConnected(view) {
@@ -3491,7 +3521,6 @@
     });
     card.append(eye, refresh, h('div', { className: 'wallet-bal-label', textContent: 'Balance' }), bal, unit);
     view.append(card);
-    observeWalletCard(card, sentinel);
 
     // Actions
     const actions = h('div', { className: 'wallet-actions' });
@@ -3520,6 +3549,22 @@
     disc.addEventListener('click', () => disconnectModal());
     view.append(disc);
 
+    // Self-custody disclaimer (bottom of the wallet screen).
+    view.append(
+      h('p', { className: 'wallet-disclaimer' }, [
+        h('strong', { textContent: 'IMPORTANT: ' }),
+        document.createTextNode(
+          'Sidecar never holds user funds. You manage your own wallet and are responsible for securing it properly.'
+        ),
+      ])
+    );
+
+    // Bottom spacer that absorbs the card's collapse delta so the page height
+    // stays constant when the balance card compacts (prevents scroll flicker).
+    // The collapse observer is attached later, once content has loaded — see below.
+    const spacer = h('div', { className: 'wallet-spacer' });
+    view.append(spacer);
+
     // Load data
     let client = null;
     try { client = await ensureNwc(); } catch (_) {}
@@ -3532,7 +3577,11 @@
       if (!cached) { bal.textContent = '—'; unit.textContent = 'balance unavailable'; }
     }
     bal.classList.remove('loading');
-    loadTransactions(txList, client);
+    // Attach the collapse observer only after the balance and transactions have
+    // loaded — while content is still resizing, an active observer would cross the
+    // collapse trigger repeatedly and flicker (worst on the loading "…" state).
+    await loadTransactions(txList, client);
+    observeWalletCard(card, sentinel, spacer);
   }
 
   // Centered placeholder for list cards (loading / empty / error) so the text

--- a/styles.css
+++ b/styles.css
@@ -1050,6 +1050,17 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
 }
 /* sentinel above the card; IntersectionObserver watches it to drive the collapse */
 .wallet-sentinel { height: 1px; margin: 0; pointer-events: none; }
+.wallet-spacer { flex: 0 0 auto; height: 0; pointer-events: none; }
+.wallet-disclaimer {
+  margin-top: 18px;
+  padding-top: 14px;
+  border-top: 1px solid var(--border);
+  font-size: 11.5px;
+  line-height: 1.55;
+  color: var(--faint);
+  text-align: center;
+}
+.wallet-disclaimer strong { color: var(--muted); letter-spacing: 0.03em; }
 /* collapsed (scrolled) — slim sticky header; tap to scroll back to top */
 .wallet-card.compact { padding: 11px 16px; cursor: pointer; }
 .wallet-card.compact .wallet-bal-label,

--- a/wallets.css
+++ b/wallets.css
@@ -1,0 +1,15 @@
+/* ============================================================
+   Sidecar — Wallet suggestions
+   Reuses welcome.css for layout/cards/filters; only adds the
+   trust-model badge palette specific to wallets.
+   ============================================================ */
+
+.cat-custodial     { background: rgba(203, 161, 78,  0.14); color: var(--gold); }
+.cat-selfcustodial { background: rgba(52,  211, 153, 0.16); color: #34d399; }
+.cat-ecash         { background: rgba(167, 139, 250, 0.14); color: var(--lav); }
+
+/* Fixed 3-up grid (6 wallets → 2 rows of 3). Overrides welcome.css's auto-fill;
+   loaded after it, so these win — including the responsive fallbacks below. */
+.grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+@media (max-width: 720px) { .grid { grid-template-columns: 1fr 1fr; } }
+@media (max-width: 460px) { .grid { grid-template-columns: 1fr; } }

--- a/wallets.html
+++ b/wallets.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Find a wallet for Sidecar</title>
+  <link rel="stylesheet" href="fonts.css">
+  <link rel="stylesheet" href="welcome.css">
+  <link rel="stylesheet" href="wallets.css">
+</head>
+<body>
+  <div class="page">
+
+    <header class="header">
+      <img class="wordmark" src="icons/sidecar-logo.svg" alt="Sidecar">
+      <h1>Pick a Lightning wallet.</h1>
+      <p>Sidecar connects to any wallet that supports Nostr Wallet Connect (NWC). Choose one below, create a connection string in it, then paste that into Sidecar's Wallet tab. Sidecar never holds your funds.</p>
+    </header>
+
+    <div class="filters" id="filters">
+      <button class="filter-btn active" data-cat="all">All</button>
+      <button class="filter-btn" data-cat="custodial">Custodial</button>
+      <button class="filter-btn" data-cat="selfcustodial">Self-custodial</button>
+      <button class="filter-btn" data-cat="ecash">Ecash</button>
+    </div>
+
+    <div class="grid" id="grid"></div>
+
+    <footer class="footer">
+      <div class="footer-divider"></div>
+      <p class="footer-tip"><strong>Custodial</strong> wallets hold your funds for you (easiest to start). <strong>Self-custodial</strong> means you hold your own keys. <strong>Ecash</strong> wallets use Cashu bearer tokens.</p>
+      <p class="footer-tip">New to Lightning? Any wallet here gets you started — you can always switch later.</p>
+      <p class="footer-tip"><a href="https://github.com/dmnyc/sidecar/issues" target="_blank" rel="noopener">Suggest a wallet to add →</a></p>
+    </footer>
+
+  </div>
+
+  <script src="wallets.js"></script>
+</body>
+</html>

--- a/wallets.js
+++ b/wallets.js
@@ -1,0 +1,150 @@
+// Sidecar — wallet suggestions. Each entry is a wallet that can hand you a
+// Nostr Wallet Connect (NWC) string to paste into Sidecar. Rendered in array
+// order (curated), not sorted.
+const WALLETS = [
+  {
+    name: 'Alby Hub',
+    url: 'https://albyhub.com',
+    domain: 'albyhub.com',
+    cat: 'selfcustodial',
+    desc: 'Your own Lightning node — self-host it or run it on Alby Cloud — then create an NWC connection for Sidecar.',
+  },
+  {
+    name: 'Zeus',
+    url: 'https://zeusln.com',
+    domain: 'zeusln.com',
+    cat: 'selfcustodial',
+    desc: 'Self-custodial mobile wallet with an embedded node. Export a Nostr Wallet Connect string and paste it into Sidecar.',
+  },
+  {
+    name: 'YakiHonne',
+    url: 'https://yakihonne.com',
+    domain: 'yakihonne.com',
+    cat: 'custodial',
+    desc: 'Custodial wallet built into the YakiHonne app. Spin up a wallet and grab an NWC connection in a couple of taps — the quickest way to get going.',
+  },
+  {
+    name: 'Rizful',
+    url: 'https://www.rizful.com',
+    domain: 'rizful.com',
+    cat: 'custodial',
+    desc: 'Custodial hosted Lightning node. Create a Nostr Wallet Connect string from your dashboard and paste it into Sidecar.',
+  },
+  {
+    name: 'Coinos',
+    url: 'https://coinos.io',
+    domain: 'coinos.io',
+    cat: 'custodial',
+    logo: '<svg viewBox="0 0 72 72" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" style="width:34px;height:34px;color:#f1e8f8"><path fill-rule="evenodd" clip-rule="evenodd" d="M36 4.23529C18.4568 4.23529 4.23529 18.4568 4.23529 36C4.23529 53.5432 18.4568 67.7647 36 67.7647C53.5432 67.7647 67.7647 53.5432 67.7647 36C67.7647 18.4568 53.5432 4.23529 36 4.23529ZM0 36C0 16.1177 16.1177 0 36 0C55.8823 0 72 16.1177 72 36C72 55.8823 55.8823 72 36 72C16.1177 72 0 55.8823 0 36Z" fill="currentColor"></path><path fill-rule="evenodd" clip-rule="evenodd" d="M36 58.5882C48.4751 58.5882 58.5882 48.4751 58.5882 36C58.5882 23.5248 48.4751 13.4117 36 13.4117C23.5249 13.4117 13.4118 23.5248 13.4118 36C13.4118 48.4751 23.5249 58.5882 36 58.5882ZM36 54C45.9411 54 54 45.9411 54 36C54 26.0589 45.9411 18 36 18C26.0589 18 18 26.0589 18 36C18 45.9411 26.0589 54 36 54Z" fill="currentColor"></path><path fill-rule="evenodd" clip-rule="evenodd" d="M36.0001 22.8988C36.0001 22.8988 36 22.8988 36 22.8988C28.7644 22.8988 22.8988 28.7644 22.8988 36C22.8988 43.2356 28.7644 49.1012 36 49.1012C36 49.1012 36.0001 49.1012 36.0001 49.1012V22.8988Z" fill="currentColor"></path></svg>',
+    desc: 'Custodial web wallet. Turn on Nostr Wallet Connect in settings and paste the connection string into Sidecar.',
+  },
+  {
+    name: 'Minibits',
+    url: 'https://www.minibits.cash',
+    domain: 'minibits.cash',
+    cat: 'ecash',
+    desc: 'Cashu ecash mobile wallet. Create a Nostr Wallet Connect string to connect it to Sidecar.',
+  },
+];
+
+const CAT_LABELS = {
+  custodial: 'Custodial',
+  selfcustodial: 'Self-custodial',
+  ecash: 'Ecash',
+};
+
+function faviconUrl(domain) {
+  return `https://www.google.com/s2/favicons?domain=${domain}&sz=64`;
+}
+
+function renderCard(wallet) {
+  const a = document.createElement('a');
+  a.className = 'card';
+  a.href = wallet.url;
+  a.target = '_blank';
+  a.rel = 'noopener noreferrer';
+  a.dataset.cat = wallet.cat;
+
+  const faviconWrap = document.createElement('div');
+  faviconWrap.className = 'favicon-wrap';
+
+  if (wallet.logo) {
+    faviconWrap.innerHTML = wallet.logo;
+  } else {
+    const img = document.createElement('img');
+    img.src = wallet.icon || faviconUrl(wallet.domain);
+    img.alt = wallet.name;
+    img.width = 32;
+    img.height = 32;
+
+    const fallback = document.createElement('span');
+    fallback.className = 'favicon-fallback';
+    fallback.textContent = wallet.name[0];
+    fallback.style.display = 'none';
+
+    img.onerror = () => {
+      img.style.display = 'none';
+      fallback.style.display = '';
+    };
+
+    faviconWrap.appendChild(img);
+    faviconWrap.appendChild(fallback);
+  }
+
+  const nameEl = document.createElement('div');
+  nameEl.className = 'card-name';
+  nameEl.textContent = wallet.name;
+
+  const urlEl = document.createElement('div');
+  urlEl.className = 'card-url';
+  urlEl.textContent = wallet.domain;
+
+  const nameGroup = document.createElement('div');
+  nameGroup.appendChild(nameEl);
+  nameGroup.appendChild(urlEl);
+
+  const top = document.createElement('div');
+  top.className = 'card-top';
+  top.appendChild(faviconWrap);
+  top.appendChild(nameGroup);
+
+  const badge = document.createElement('span');
+  badge.className = `cat-badge cat-${wallet.cat}`;
+  badge.textContent = CAT_LABELS[wallet.cat];
+
+  const desc = document.createElement('p');
+  desc.className = 'card-desc';
+  desc.textContent = wallet.desc;
+
+  const cta = document.createElement('div');
+  cta.className = 'card-cta';
+  cta.textContent = 'Get this wallet →';
+
+  a.appendChild(top);
+  a.appendChild(badge);
+  a.appendChild(desc);
+  a.appendChild(cta);
+
+  return a;
+}
+
+const grid = document.getElementById('grid');
+WALLETS.forEach((wallet) => grid.appendChild(renderCard(wallet)));
+
+// Category filter
+document.getElementById('filters').addEventListener('click', (e) => {
+  const btn = e.target.closest('.filter-btn');
+  if (!btn) return;
+  const cat = btn.dataset.cat;
+
+  document.querySelectorAll('.filter-btn').forEach((b) => b.classList.remove('active'));
+  btn.classList.add('active');
+
+  document.querySelectorAll('.card').forEach((card) => {
+    if (cat === 'all' || card.dataset.cat === cat) {
+      card.classList.remove('hidden-cat');
+    } else {
+      card.classList.add('hidden-cat');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Final batch for the **1.1.0** release, plus a README refresh and version bump.

### Wallet suggestions page
- New `wallets.html` / `wallets.js` / `wallets.css`, reachable via a "Need a wallet? See suggestions →" link in the wallet connect view.
- Curated, NWC-capable list: **Alby Hub · Zeus · YakiHonne · Rizful · Coinos · Minibits**, grouped self-custodial → custodial → ecash, in a fixed 3-up grid (2 rows of 3; responsive down to 2- and 1-up).
- Each card has a custody badge and a one-line "how to get a connection string." Coinos uses its real logo (inline SVG); Blitz was dropped after it failed NWC testing.

### Self-custody notice
- Disclaimer at the bottom of the wallet screen: "Sidecar never holds user funds. You manage your own wallet and are responsible for securing it properly."

### Balance-card flicker fix
- The collapse-on-scroll balance card flickered on short pages (e.g. a wallet with no transactions), including during the loading "…" state.
- Fix: attach the collapse observer only after balance + transactions load, and absorb the card's collapse delta with a bottom spacer so the page height never changes (no scroll clamp, no oscillation).

### Release housekeeping
- Bump manifest to **1.1.0** — this release grew well beyond the original plan: notification bell, Blossom uploads with fallback, NWC + nsec export with QR, composer draft autosave, and now the wallet directory.
- README feature list refreshed; Architecture table lists the standalone pages.

## Testing
- `node --check` on all touched JS.
- Manual: wallet suggestions render in the 3-up grid and filter by category; "see suggestions" link opens the page; empty-wallet balance card no longer flickers while loading or scrolling; disclaimer shows at the bottom.

🍸 Mixed with [Claude Code](https://claude.com/claude-code)