### PR TITLE
Fix @mention autocomplete missing follows (timeout + profile-gap bugs)

### DIFF
--- a/sidepanel.js
+++ b/sidepanel.js
@@ -1938,45 +1938,54 @@
 
   async function getFollowList() {
     if (followListCache && followListPubkey === state.activePubkey) return followListCache;
-    followListPubkey = state.activePubkey;
-    if (!state.activePubkey) return (followListCache = []);
+    if (!state.activePubkey) return [];
     try {
       const relays = await relayUrls(false);
-      const ev = await Promise.race([
-        poolGet(relays, { kinds: [3], authors: [state.activePubkey] }),
-        new Promise((r) => setTimeout(() => r(null), 5000)),
-      ]);
-      if (!ev) return (followListCache = []);
+      // maxWait bounds each relay's own connect+EOSE wait individually (they
+      // run in parallel) instead of racing the WHOLE fetch against an external
+      // timeout — the previous approach discarded every result the moment the
+      // race lost, even if most relays had already answered, so one slow relay
+      // could wipe the entire follow list down to zero. Not cached on failure,
+      // so the next @-mention attempt retries instead of being stuck all session.
+      const ev = await getPool().get(relays, { kinds: [3], authors: [state.activePubkey] }, { maxWait: 8000 });
+      if (!ev) return [];
       const pubkeys = (ev.tags || [])
         .filter((t) => t[0] === 'p')
         .map((t) => t[1])
         .filter((pk) => pk && pk.length === 64);
-      if (!pubkeys.length) return (followListCache = []);
-      const profiles = await Promise.race([
-        getPool().querySync(relays, { kinds: [0], authors: pubkeys }),
-        new Promise((r) => setTimeout(() => r([]), 6000)),
-      ]);
+      if (!pubkeys.length) {
+        followListPubkey = state.activePubkey;
+        return (followListCache = []);
+      }
+      const profiles = await getPool().querySync(relays, { kinds: [0], authors: pubkeys }, { maxWait: 10000 });
       const byPk = {};
       (profiles || []).forEach((p) => {
         if (!byPk[p.pubkey] || p.created_at > byPk[p.pubkey].created_at) byPk[p.pubkey] = p;
       });
-      followListCache = pubkeys
-        .map((pk) => {
-          let name = null, picture = null;
-          const prof = byPk[pk];
-          if (prof) {
-            try {
-              const c = JSON.parse(prof.content);
-              name = c.display_name || c.name || null;
-              picture = c.picture || null;
-            } catch (_) {}
-          }
-          return { pubkey: pk, name, picture };
-        })
-        .filter((c) => c.name);
+      const list = pubkeys.map((pk) => {
+        let name = null, picture = null;
+        const prof = byPk[pk];
+        if (prof) {
+          try {
+            const c = JSON.parse(prof.content);
+            name = c.display_name || c.name || null;
+            picture = c.picture || null;
+          } catch (_) {}
+        }
+        // Keep follows with no resolvable profile (no relay had their kind:0,
+        // or the profile fetch just missed them) — fall back to a short npub
+        // so they're still selectable instead of silently vanishing from
+        // @mention results.
+        if (!name) {
+          try { name = shortNpub(NT.nip19.npubEncode(pk)); } catch (_) { name = pk.slice(0, 10) + '…'; }
+        }
+        return { pubkey: pk, name, picture };
+      });
+      followListPubkey = state.activePubkey;
+      followListCache = list;
       return followListCache;
     } catch (_) {
-      return (followListCache = []);
+      return [];
     }
   }
 


### PR DESCRIPTION
## Summary

`@mention` results were unreliable — people you follow could be missing intermittently, or entirely for the rest of the session. Three compounding bugs in `getFollowList()`:

1. **External timeout discarded everything on loss.** Both the contact-list (kind:3) and profile-batch (kind:0) fetches were wrapped in `Promise.race([fetch, timeout→null/[]])`. If the race lost — e.g. one slow relay among your configured set — the whole result was thrown away, even though the other relays had already answered. A single sluggish relay could wipe the entire follow list to zero.
2. **Profile-less follows were dropped.** If a followed pubkey's kind:0 wasn't found on any relay (or the batch fetch above came back empty), that person was filtered out of the list entirely instead of falling back to a display name.
3. **Failures were cached like successes.** `followListCache = []` is truthy, so a single bad fetch got cached and permanently poisoned the autocomplete for the rest of the session — every later `@`-mention attempt returned zero results until an account switch.

## Fix

- Pass `{ maxWait }` to `getPool().get()`/`.querySync()` instead of an external race. This bounds each relay's own connect + EOSE wait individually — they run in parallel — so one slow relay no longer erases what the others returned.
- Follows with no resolvable profile now fall back to `shortNpub()` (same pattern used elsewhere, e.g. `displayName()`) instead of vanishing from results.
- Only cache successful fetches; failures return `[]` for that call without touching the cache, so the next attempt retries fresh.

## Testing
- `node --check`.
- Traced the caching guard (`followListCache && followListPubkey === activePubkey`) to confirm an empty-array result no longer sticks — only a genuinely successful fetch (including a real "you follow nobody" case) is cached now.

🥃 Poured with [Claude Code](https://claude.com/claude-code)