### PR TITLE
Add NoorNote creator testimonial to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,6 @@ Connect) and a composer for posting notes directly from the panel.
 >
 > — [77elements](https://github.com/77elements), creator of [NoorNote](https://github.com/77elements/noornote)
 
-## Install
-
-**[Install from the Chrome Web Store →](https://chromewebstore.google.com/detail/sidecar-a-classy-nostr-si/moimlikilhheabdafocpmneehpblhiln)**
-— works in Chrome, Brave, Edge, and other Chromium browsers.
-
-Or run from source (no build step required — see below).
-
 ## Features
 
 - **Multiple accounts** — store as many nsecs as you like, drag to reorder, switch the active one in a click. Importing shows a profile preview (name + avatar) so you can confirm the right key before saving. Reveal a key behind your PIN — with a QR for quick sign-in on mobile clients.
@@ -106,6 +99,7 @@ is killed (MV3 idles after ~30s), that map is cleared and the keystore re-locks.
 ## Acknowledgments
 
 - Inspired by Nostr Build Shack by [Fishcake](https://github.com/fishcakeday) and [Clave](https://github.com/DocNR/clave) by [Doc](https://github.com/DocNR)
+- Standing on the shoulders of [nos2x](https://github.com/fiatjaf/nos2x) by [fiatjaf](https://github.com/fiatjaf) and the [Alby](https://github.com/getAlby/lightning-browser-extension) browser extension — the OG reliable browser signers most of nostr grew up with
 
 ## Author
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Connect) and a composer for posting notes directly from the panel.
 
 <img width="2816" height="1566" alt="Sidecar" src="https://i.nostr.build/Sr11DBpz7pVITHoS.png" />
 
+> "Best UX for a browser key signer so far. And the nsec is encrypted using PBKDF2/AES-GCM, then stored in chrome.storage.local, so other potentially malicious add-ons can't get to it. In my broad testing across multiple browser key signers last year, only Alby did this, though I don't know if others have added it since. Sidecar also has a better UX than Alby. [...] I'm thinking about replacing Alby with Sidecar in NoorNote's onboarding wizard because Sidecar is better for beginners right now."
+>
+> — [77elements](https://github.com/77elements), creator of [NoorNote](https://github.com/77elements/noornote)
+
 ## Install
 
 **[Install from the Chrome Web Store →](https://chromewebstore.google.com/detail/sidecar-a-classy-nostr-si/moimlikilhheabdafocpmneehpblhiln)**


### PR DESCRIPTION
## Summary

Adds a testimonial blockquote right under the hero screenshot, excerpting a review from [77elements](https://github.com/77elements), creator of [NoorNote](https://github.com/77elements/noornote), praising the PBKDF2/AES-GCM at-rest key encryption and Sidecar's beginner-friendly UX relative to Alby.

🍹 Shaken with [Claude Code](https://claude.com/claude-code)