### PR TITLE
Fix draft-resume preview flattening line breaks

### DIFF
--- a/sidepanel.js
+++ b/sidepanel.js
@@ -2982,7 +2982,11 @@
     // Offer to resume a saved draft (or start fresh) before opening the editor.
     function showDraftChooser(saved) {
       modal.innerHTML = '';
-      const snippet = (saved.text || '').trim().replace(/\s+/g, ' ');
+      // Collapse horizontal whitespace and cap long blank-line runs, but keep
+      // real newlines — this preview renders with white-space: pre-wrap, and
+      // "Resume draft" loads the exact saved text, so the preview should look
+      // like what's about to be restored instead of flattening it to one line.
+      const snippet = (saved.text || '').trim().replace(/[ \t]+/g, ' ').replace(/\n{3,}/g, '\n\n');
       const preview = snippet.length > 160 ? snippet.slice(0, 160) + '…' : snippet;
       const when = saved.savedAt ? ' from ' + relativeTime(Math.floor(saved.savedAt / 1000)) : '';
       const mediaNote = saved.media && saved.media.length


### PR DESCRIPTION
## Summary

The "Resume your draft?" preview collapsed *all* whitespace — including newlines — into single spaces (`.replace(/\s+/g, ' ')`), so a draft with a paragraph break rendered as one continuous run in the preview card, even though:
- the card already has `white-space: pre-wrap` and would render real line breaks correctly, and
- clicking "Resume draft" always restored the exact saved text with its original formatting intact — the underlying draft data was never actually corrupted.

Only the preview misrepresented what would come back, which reads as data loss even though nothing was lost.

## Fix

Collapse horizontal whitespace (spaces/tabs) only, keep real newlines, and cap runs of 3+ blank lines down to 2 so a degenerate draft doesn't blow out the preview card's height. The preview now matches what "Resume draft" actually restores.

## Testing
- `node --check`.
- Traced the resume path (`draft = { text: saved.text, ... }` → `showEditor()`) to confirm it already used the untouched saved text — only `showDraftChooser`'s preview snippet needed the fix.

🍹 Shaken with [Claude Code](https://claude.com/claude-code)