### PR TITLE
Refresh default relays off relay.damus.io

### DIFF
--- a/background.js
+++ b/background.js
@@ -17,9 +17,10 @@ const BUDGETS = self.SidecarBudgets;
 const NWC = self.SidecarNWC;
 
 const DEFAULT_RELAYS = {
-  'wss://relay.damus.io': { read: true, write: true },
   'wss://nos.lol': { read: true, write: true },
   'wss://relay.snort.social': { read: true, write: true },
+  'wss://nostr.mom': { read: true, write: true },
+  'wss://offchain.pub': { read: true, write: true },
   'wss://relay.primal.net': { read: true, write: false },
 };
 

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -2274,7 +2274,7 @@
 
   // ---- compose a kind:1 note (FAB) with Wisp-style send countdown ----
   const NOTE_COUNTDOWN_SECS = 15;
-  const CLIENT_TAG = ['client', 'Sidecar 🍸', 'https://github.com/dmnyc/sidecar', 'wss://relay.damus.io'];
+  const CLIENT_TAG = ['client', 'Sidecar 🍸', 'https://github.com/dmnyc/sidecar', 'wss://nos.lol'];
   // ---- About / zap-the-creator ----
   const GITHUB_URL = 'https://github.com/dmnyc/sidecar';
   const CREATOR_NPUB = 'npub1aeh2zw4elewy5682lxc6xnlqzjnxksq303gwu2npfaxd49vmde6qcq4nwx';


### PR DESCRIPTION
## Summary

The Damus relay operator posted that they plan to shut `relay.damus.io` down by end of month; `relay.nostr.band` is already dead (confirmed: connection refused). Both were touchpoints in Sidecar's config.

- Replace `relay.damus.io` in `DEFAULT_RELAYS` (background.js) with two independently-operated relays — **not** a 1-for-1 swap. Going from 4 to 5 defaults adds redundancy so losing one relay doesn't thin the set back down to a single point of failure like this again.
- Swap the `CLIENT_TAG` relay hint (sidepanel.js, the `["client", "Sidecar 🍸", ...]` tag stamped on posted notes) off damus.io too.

## New default set
```js
{
  'wss://nos.lol':            { read: true, write: true },
  'wss://relay.snort.social': { read: true, write: true },
  'wss://nostr.mom':          { read: true, write: true },
  'wss://offchain.pub':       { read: true, write: true },
  'wss://relay.primal.net':   { read: true, write: false },  // unchanged, read-only
}
```

## Verification
Checked each candidate's live NIP-11 status just now:
- `nos.lol` — up, 13d uptime
- `relay.snort.social` — up, 0d uptime reported (likely a recent restart, not dead)
- `nostr.mom` — up, 13d uptime, stricter spam/nudity filtering than nos.lol
- `offchain.pub` — up, 4d uptime, independent operator
- `relay.primal.net` — up, kept read-only as before
- `relay.nostr.band` — confirmed dead (connection refused)

## Testing
- `node --check` on both touched files.

🥂 Stirred with [Claude Code](https://claude.com/claude-code)