### PR TITLE
Add "Check for updates" to Settings and About

### DIFF
--- a/sidepanel.html
+++ b/sidepanel.html
@@ -84,7 +84,7 @@
           <button class="secondary" id="add-import">Import nsec</button>
         </div>
         <div class="explore-link-wrap">
-          <a class="explore-link" id="explore-apps-link" href="#">Explore nostr apps →</a>
+          <a class="explore-link" id="explore-apps-link" href="#">Explore Nostr apps →</a>
         </div>
       </div>
 
@@ -200,6 +200,13 @@
           <input type="text" id="relay-input" placeholder="wss://relay.example.com" />
           <button class="secondary" id="relay-add">Add</button>
         </div>
+      </div>
+
+      <div class="setting">
+        <h3>Updates</h3>
+        <p class="hint" id="settings-version"></p>
+        <button class="secondary" id="check-update-btn">Check for updates</button>
+        <p class="hint" id="check-update-status"></p>
       </div>
 
       <div class="setting">

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -1644,6 +1644,14 @@
 
   // ---- settings ----
   async function renderSettings() {
+    // version + update check
+    const build = window.SIDECAR_BUILD || {};
+    const ver = build.version || (chrome.runtime.getManifest && chrome.runtime.getManifest().version) || '';
+    $('settings-version').textContent = ver
+      ? 'Version ' + ver + (build.commit && build.commit !== 'dev' ? ' (' + build.commit + ')' : '')
+      : '';
+    $('check-update-status').textContent = '';
+
     // auto-lock
     const settings = await call({ type: 'SIDECAR_GET_SETTINGS' });
     $('autolock-select').value = String(settings.autoLockMinutes || 0);
@@ -4420,6 +4428,35 @@
     return res.pr;
   }
 
+  // Chrome already checks the Web Store for updates every few hours on its own;
+  // requestUpdateCheck() is the one sanctioned way to trigger that early from a
+  // user-initiated button click (not a timer). It only fetches the update —
+  // installing it still waits for the background worker/browser to restart, or
+  // an explicit chrome.runtime.reload() (which we don't call here, since that
+  // would abruptly tear down an in-progress unlock/signing/wallet flow).
+  async function checkForUpdates(btn, statusEl) {
+    const prevLabel = btn.textContent;
+    btn.disabled = true;
+    btn.textContent = 'Checking…';
+    statusEl.textContent = '';
+    try {
+      const result = await chrome.runtime.requestUpdateCheck();
+      const status = result && result.status;
+      if (status === 'update_available') {
+        const v = result.version ? ' (v' + result.version + ')' : '';
+        statusEl.textContent = 'Update found' + v + ' — it installs the next time Sidecar restarts.';
+      } else if (status === 'throttled') {
+        statusEl.textContent = 'Checked recently — try again in a few minutes.';
+      } else {
+        statusEl.textContent = "You're on the latest version.";
+      }
+    } catch (_) {
+      statusEl.textContent = 'Could not check for updates.';
+    }
+    btn.disabled = false;
+    btn.textContent = prevLabel;
+  }
+
   // ---- About + zap the creator (opened from the Sidecar logo) ----
   function aboutModal() {
     openModal((modal) => {
@@ -4446,6 +4483,10 @@
       const zap = h('button', { className: 'about-link about-link-btn' }, [document.createTextNode('Zap the creator '), boltIcon()]);
       zap.addEventListener('click', () => { closeModal(); creatorZapModal(); });
 
+      const updateBtn = h('button', { className: 'about-update-btn', textContent: 'Check for updates' });
+      const updateStatus = h('p', { className: 'hint about-update-status' });
+      updateBtn.addEventListener('click', () => checkForUpdates(updateBtn, updateStatus));
+
       modal.append(
         xClose,
         h('div', { className: 'about-modal' }, [
@@ -4453,6 +4494,8 @@
           h('p', { className: 'about-description', textContent: 'A classy multi-account Nostr signer with a built-in Lightning wallet. Your keys stay encrypted on this device.' }),
           h('div', { className: 'about-creator' }, [document.createTextNode('Created by '), creator]),
           ver ? h('div', { className: 'about-version', textContent: verText }) : document.createTextNode(''),
+          updateBtn,
+          updateStatus,
           h('div', { className: 'about-links' }, [repo, issues, zap]),
         ])
       );
@@ -4564,6 +4607,10 @@
     await call({ type: 'SIDECAR_SET_RELAYS', relays });
     input.value = '';
     renderSettings();
+  });
+
+  $('check-update-btn').addEventListener('click', () => {
+    checkForUpdates($('check-update-btn'), $('check-update-status'));
   });
 
   // Danger zone: wipe all Sidecar data. Type-to-confirm, since it's irreversible

--- a/styles.css
+++ b/styles.css
@@ -439,6 +439,13 @@ button:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(203, 161, 78, 0
 .about-creator-link:hover, .about-link:hover { text-decoration: underline; }
 .about-version { color: var(--faint); font-size: 11.5px; font-family: var(--font-mono); margin-top: 2px; }
 .about-links { display: flex; flex-wrap: wrap; justify-content: center; align-items: center; gap: 8px 18px; margin-top: 12px; }
+.about-update-btn {
+  background: none; border: none; padding: 0; cursor: pointer;
+  font-size: 11px; color: var(--faint); text-decoration: underline;
+  text-decoration-color: rgba(154, 134, 196, 0.35); margin-top: 4px;
+}
+.about-update-btn:hover { color: var(--muted); text-decoration-color: var(--muted); }
+.about-update-status { margin-top: 2px; font-size: 11px; }
 .about-link-btn { background: none; border: none; padding: 0; cursor: pointer; font-size: 14px; color: var(--gold); font-weight: 600; }
 .about-link-btn:hover { text-decoration: underline; }
 /* zap-the-creator inline send */


### PR DESCRIPTION
## Summary

Adds a manual update check, in the two places that make sense for it:

- **Settings** — new "Updates" section: current version + a **Check for updates** button + status line.
- **About modal** — a small, muted "Check for updates" link placed under the version number (not grouped with GitHub/Report an issue/Zap the creator, to avoid crowding that row) + its own status line.

Both share one `checkForUpdates()` helper that calls `chrome.runtime.requestUpdateCheck()` — the sanctioned way to trigger Chrome's existing periodic Web Store check early from a deliberate user click (Chrome already checks every few hours on its own; this isn't a new polling loop). Reports one of three outcomes: update found (names the version), checked recently (throttled), or already up to date.

Deliberately does **not** call `chrome.runtime.reload()` to force-install — that would abruptly tear down an in-progress unlock/signing/wallet flow. The update installs on its own next time the background worker or browser restarts, consistent with how Chrome extension updates normally apply.

Also capitalizes "Nostr" in the Accounts tab's "Explore Nostr apps" link.

## Testing
- `node --check` on `sidepanel.js`.
- Cross-checked every new element ID between `sidepanel.html` and `sidepanel.js`.

🍸 Mixed with [Claude Code](https://claude.com/claude-code)