### PR TITLE
Settings toggle to omit the client tag

### DIFF
--- a/sidepanel.html
+++ b/sidepanel.html
@@ -169,6 +169,12 @@
       </div>
 
       <div class="setting">
+        <h3>Client tag</h3>
+        <p class="hint">Add a “client” tag to notes you post, attributing them to Sidecar. Turn off to post without it.</p>
+        <label class="toggle-row"><input type="checkbox" id="clienttag-toggle" /> <span>Tag notes as posted with Sidecar</span></label>
+      </div>
+
+      <div class="setting">
         <h3>Automatic zaps</h3>
         <p class="hint">Pay zaps without a prompt, up to a limit per zap. Larger zaps and all other payments still ask.</p>
         <label class="toggle-row"><input type="checkbox" id="autozap-toggle" /> <span>Auto-approve zaps</span></label>

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -1657,6 +1657,7 @@
     $('autolock-select').value = String(settings.autoLockMinutes || 0);
     $('client-select').value = settings.defaultClient || DEFAULT_CLIENT;
     $('paybutton-toggle').checked = settings.showPayButton !== false; // default on
+    $('clienttag-toggle').checked = settings.showClientTag !== false; // default on
     $('autozap-toggle').checked = settings.autoZap === true;
     $('autozap-max').value = String(settings.autoZapMaxSats || AUTOZAP_DEFAULT_MAX);
     $('autozap-max-row').classList.toggle('hidden', !$('autozap-toggle').checked);
@@ -2282,7 +2283,7 @@
 
   // ---- compose a kind:1 note (FAB) with Wisp-style send countdown ----
   const NOTE_COUNTDOWN_SECS = 15;
-  const CLIENT_TAG = ['client', 'Sidecar 🍸', 'https://github.com/dmnyc/sidecar', 'wss://nos.lol'];
+  const CLIENT_TAG = ['client', 'Sidecar', 'https://github.com/dmnyc/sidecar', 'wss://nos.lol'];
   // ---- About / zap-the-creator ----
   const GITHUB_URL = 'https://github.com/dmnyc/sidecar';
   const CREATOR_NPUB = 'npub1aeh2zw4elewy5682lxc6xnlqzjnxksq303gwu2npfaxd49vmde6qcq4nwx';
@@ -2608,10 +2609,13 @@
           if (pk && !seenPks.has(pk)) { seenPks.add(pk); pTags.push(['p', pk]); }
         } catch (_) {}
       }
+      // The "client" tag (attributes the note to Sidecar) is opt-out via Settings.
+      const settings = await call({ type: 'SIDECAR_GET_SETTINGS' });
+      const tags = settings && settings.showClientTag === false ? [...pTags] : [CLIENT_TAG.slice(), ...pTags];
       const event = {
         kind: 1,
         created_at: Math.floor(Date.now() / 1000),
-        tags: [CLIENT_TAG.slice(), ...pTags],
+        tags,
         content,
       };
       const signed = await call({ type: 'SIDECAR_OWNER_SIGN', event });
@@ -4581,6 +4585,10 @@
 
   $('paybutton-toggle').addEventListener('change', async (e) => {
     await call({ type: 'SIDECAR_SET_SETTINGS', settings: { showPayButton: e.target.checked } });
+  });
+
+  $('clienttag-toggle').addEventListener('change', async (e) => {
+    await call({ type: 'SIDECAR_SET_SETTINGS', settings: { showClientTag: e.target.checked } });
   });
 
   $('autozap-toggle').addEventListener('change', async (e) => {


### PR DESCRIPTION
## Summary

Adds a **Client tag** toggle in Settings (default **on**, so existing behavior is unchanged) that controls whether notes you post carry the `["client", "Sidecar", …]` tag attributing them to Sidecar. Turn it off to post without any client attribution.

- `doPublish` reads `showClientTag` and omits `CLIENT_TAG` from the kind:1 tags when it's off; mention `p` tags are unaffected.
- Persists via the existing `SIDECAR_SET_SETTINGS`, using the same `.toggle-row` pattern/accent as the other setting toggles.
- Also removed the 🍸 emoji from the client tag value itself (`Sidecar 🍸` → `Sidecar`).

## Testing
- `node --check` on `sidepanel.js`.
- Cross-checked the new `clienttag-toggle` element ID between `sidepanel.html` and `sidepanel.js`.

🥃 Poured with [Claude Code](https://claude.com/claude-code)