### PR TITLE
Bump version to 1.1.1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Sidecar | A Classy Nostr Signer",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A multi-account NIP-07 nostr signer with a built-in Lightning wallet, in your browser sidebar.",
   "permissions": [
     "storage",


### PR DESCRIPTION
Marks the next Web Store release. Since 1.1.0 shipped, `main` has gained: zap-notification target fix, repost/quote notifications, @mention autocomplete reliability fix, composer countdown author, draft-preview line breaks, post-banner auto-dismiss, default-relay refresh (off relay.damus.io), check-for-updates, the client-tag toggle, and the NIP-65 relay editor.

🥂 Stirred with [Claude Code](https://claude.com/claude-code)