### PR TITLE
feat: make Edit profile button more visible

### DIFF
--- a/sidepanel.js
+++ b/sidepanel.js
@@ -1969,12 +1969,6 @@
     } else {
       header.append(h('div', { className: 'profile-banner profile-banner-ph' }));
     }
-    const editBtn = document.createElement('button');
-    editBtn.className = 'icon-btn profile-edit-btn';
-    editBtn.title = 'Edit profile';
-    editBtn.appendChild(icon('edit'));
-    editBtn.addEventListener('click', () => openProfileEdit(content));
-    header.append(editBtn);
     header.append(avatarEl({ picture: content.picture || active.picture, npub: active.npub }, 'profile-avatar'));
     view.append(header);
 
@@ -1999,6 +1993,11 @@
     getFollowCount(active.pubkey).then((n) => {
       followNum.textContent = n == null ? '—' : n.toLocaleString('en-US');
     });
+
+    const editBtn = h('button', { className: 'secondary profile-edit-cta' });
+    editBtn.append(icon('edit'), h('span', { textContent: 'Edit profile' }));
+    editBtn.addEventListener('click', () => openProfileEdit(content));
+    body.append(editBtn);
 
     if (content.about) {
       const about = h('p', { className: 'profile-about' });

--- a/styles.css
+++ b/styles.css
@@ -160,11 +160,11 @@ input:focus, select:focus, textarea:focus {
   background: linear-gradient(180deg, #2a1257, #160a30); box-shadow: 0 0 0 1px var(--gold-soft);
 }
 .profile-avatar img { width: 100%; height: 100%; object-fit: cover; display: block; }
-.profile-edit-btn {
-  position: absolute; top: 8px; right: 8px;
-  background: rgba(13, 6, 30, 0.55); border: 1px solid var(--border-strong);
-  backdrop-filter: blur(4px);
+.profile-body .profile-edit-cta {
+  display: inline-flex; align-items: center; justify-content: center; gap: 7px;
+  width: auto; margin: 12px auto 0; padding: 8px 18px; border-radius: 999px;
 }
+.profile-body .profile-edit-cta svg { width: 15px; height: 15px; display: block; }
 .profile-body { text-align: center; }
 .profile-name { font-family: var(--font-display); font-weight: 700; font-size: 22px; margin: 8px 0 3px; overflow-wrap: anywhere; }
 .profile-npub {


### PR DESCRIPTION
## What

The **Edit profile** control was a translucent icon tucked into the top-right corner of the profile banner — easy to miss.

## Change

Replaces it with a clearly labeled **Edit profile** button (pencil icon + text, secondary pill style) centered in the profile body, directly under the following-count row where users look for it. Same editor opens; only placement and visibility change.

🍸 Stirred up with [Claude Code](https://claude.com/claude-code)