### PR TITLE
fix: unreadable dropdowns in Light Mode (#51)

### DIFF
--- a/prompt.html
+++ b/prompt.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="fonts.css" />
   <style>
     :root {
+      color-scheme: dark; /* dark-only UI — keep native controls dark in Light Mode */
       --font-display: 'Playfair Display', Georgia, serif;
       --font-ui: 'Manrope', system-ui, -apple-system, sans-serif;
       --font-mono: ui-monospace, 'SF Mono', Menlo, monospace;

--- a/styles.css
+++ b/styles.css
@@ -4,6 +4,11 @@
    ============================================================ */
 
 :root {
+  /* Sidecar is a dark-only UI. Force the dark palette for native controls
+     (select popups, scrollbars, etc.) so they don't render white-on-white
+     when the browser/OS is in Light Mode. */
+  color-scheme: dark;
+
   /* type */
   --font-display: 'Playfair Display', Georgia, 'Times New Roman', serif;
   --font-ui: 'Manrope', system-ui, -apple-system, sans-serif;
@@ -120,6 +125,9 @@ input, select, textarea {
   transition: border-color 0.15s, box-shadow 0.15s;
 }
 textarea { min-height: 76px; resize: vertical; line-height: 1.5; }
+/* Explicit dark colors for the native option popup — belt-and-suspenders for
+   platforms that draw options with the system theme regardless of color-scheme. */
+select option, select optgroup { background-color: var(--bg-2); color: var(--text); }
 input::placeholder, textarea::placeholder { color: var(--faint); }
 input:focus, select:focus, textarea:focus {
   outline: none;


### PR DESCRIPTION
## Problem

Reported in #51: in browser/OS **Light Mode**, `<select>` dropdowns render white text on a white background and are unreadable (Settings menu and the permission-tier dialog).

## Cause

Native `<select>` option popups are drawn by the browser using the OS theme. Sidecar's dark-only UI sets near-white text (`var(--text)`) on the control, so when the OS is in Light Mode the popup is white → white-on-white.

## Fix

- `color-scheme: dark` on `:root` in `styles.css` (covers both reported dropdowns, which live in `sidepanel.html`) and in the standalone `prompt.html` window. This makes the browser paint native controls — option popups, scrollbars — with the dark palette regardless of the OS Light/Dark setting.
- Explicit dark `option`/`optgroup` colors as a fallback for platforms that draw options with the system theme regardless of `color-scheme`.

CSS-only, no JS. Verified against Light Mode.

Fixes #51

🍸 Stirred up with [Claude Code](https://claude.com/claude-code)