### PR TITLE
docs: document shipped features + Nostr capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 **A Classy Nostr Signer.**
 
-A NIP-07 nostr signing extension that lives in your browser's side panel. Sidecar
+A NIP-07 Nostr signing extension that lives in your browser's side panel. Sidecar
 holds your keys locally — encrypted behind a PIN — and provides `window.nostr` to the
-web apps you use, so you can sign in and sign events across nostr clients without
+web apps you use, so you can sign in and sign events across Nostr clients without
 pasting your nsec anywhere. It also has a built-in Lightning wallet (Nostr Wallet
 Connect) and a composer for posting notes directly from the panel.
 
@@ -25,17 +25,20 @@ Connect) and a composer for posting notes directly from the panel.
 - **In-extension signing** — implements the full NIP-07 surface: `getPublicKey`, `signEvent`, `nip04`/`nip44` encrypt & decrypt, and `getRelays`.
 - **Per-site permissions** — approve or reject each site, per method, with a clear prompt that previews what you're signing. Relay auth (NIP-42) signs automatically so clients stay connected.
 - **Per-site account binding** — each site stays pinned to the account it logged in with (no NIP-07 desync). Switch a site to another account from **Connected Sites**.
-- **Identity from your profile** — account names and avatars are imported from your kind 0 metadata; view and edit your profile and publish kind 0.
+- **Identity from your profile** — account names and avatars are imported from your kind 0 metadata; view and edit your profile, see your following count, and publish kind 0.
+- **Outbox relays (NIP-65)** — view, edit, and publish your relay list (kind:10002) with per-relay read/write markers, right from your profile.
 - **Backups** — encrypt your profile, follows, and mute list to your own key and store them on your relays (NIP-78), or export a signed JSON bundle.
+- **Follow-list recovery** — if a buggy client overwrites your follows with an empty or shorter list, scan your relays for an earlier kind:3 and republish a healthy version. Powered by [Mutable](https://mutable.top).
 - **Note composer** — post kind:1 notes directly from the panel with a send countdown you can review (the full note renders) and cancel. Drafts autosave per account, so you can close the composer and resume — or start fresh — later. Features include:
   - **@mention autocomplete** — type `@` to search your follow list; selecting inserts an atomic pill that serializes to `nostr:npub1…` and adds a `p` tag automatically.
   - **Nostr event embeds** — paste a `note1`, `nevent1`, or `naddr1` entity and the preview renders a fetched embed card (author, timestamp, content excerpt).
   - **Link previews** — plain URLs show an OG meta card (title, description, thumbnail) fetched through the extension with no third-party service.
   - **Media upload** — attach images and video; uploads go to your own Blossom servers (from your kind:10063 list) when available, falling back to nostr.build.
+  - **Client tag, your call** — posts carry a `client` tag attributing them to Sidecar; turn it off in Settings to post untagged.
 - **Notifications** — a bell in the header shows replies, mentions, reposts, reactions, and zaps for the active account — each with the sender's name, a content preview, and a tap-through that opens the note in your preferred client. Muted users (public and private mute lists) are filtered out.
 - **Lightning wallet (NWC)** — connect any Nostr Wallet Connect wallet (Alby Hub, Rizful, YakiHonne, …). Send (BOLT11 or lightning address via LNURL-pay), receive (invoice or your lightning address QR), view paginated history, and back up the connection to your relays — or export it (PIN-gated, with a QR) to move it to another app. New to Lightning? Built-in **wallet suggestions** point you to NWC-capable options. Sidecar never holds your funds.
 - **WebLN provider** — web apps can pay and make invoices through your connected wallet (`window.webln`), gated by an approval prompt with an optional per-site daily budget you can edit or revoke any time.
-- **Pay invoices from any page** — when a nostr client you're signed into shows a Lightning invoice, a **Pay with Sidecar** card appears so you can pay in a tap. You can also right-click a `lightning:` link, a selected BOLT11 invoice, or a QR image.
+- **Pay invoices from any page** — when a Nostr client you're signed into shows a Lightning invoice, a **Pay with Sidecar** card appears so you can pay in a tap. You can also right-click a `lightning:` link, a selected BOLT11 invoice, or a QR image.
 - **Auto-approve zaps** (optional, off by default) — pay zaps without a prompt up to a per-zap limit you set. Verified zaps only; larger zaps, non-zaps, and a locked wallet still ask.
 
 ## Install
@@ -64,9 +67,9 @@ Sidecar has **no build step** — it's plain JavaScript loaded directly. To run 
 
 6. **Open the side panel.** Click the Sidecar toolbar icon. On first run you'll set a PIN, then add an account (generate a new key or import an existing `nsec`).
 
-7. **Use it on a nostr site.** Open any NIP-07 client (e.g. [Jumble](https://jumble.social), [Coracle](https://coracle.social), [noStrudel](https://nostrudel.ninja)) and choose "log in with extension" — Sidecar will prompt you to approve.
+7. **Use it on a Nostr site.** Open any NIP-07 client (e.g. [Jumble](https://jumble.social), [Coracle](https://coracle.social), [noStrudel](https://nostrudel.ninja)) and choose "log in with extension" — Sidecar will prompt you to approve.
 
-**Updating:** pull the latest code (`git pull`), then return to the extensions page and click the **reload** (↻) icon on the Sidecar card. Reloading is required after changing `background.js` or any provider script.
+**Updating:** Chrome Web Store installs update automatically — you can trigger a check any time from **Settings → Updates** or the About dialog. For a source build, pull the latest code (`git pull`), then return to the extensions page and click the **reload** (↻) icon on the Sidecar card. Reloading is required after changing `background.js` or any provider script.
 
 ### Build version stamp (optional)
 
@@ -92,7 +95,7 @@ Or regenerate it manually any time:
 | Crypto & keystore | `crypto.js`, `keystore.js`, `permissions.js`, `signer.js` |
 | Approval prompt | `prompt.html`, `prompt.js` |
 | Side panel UI | `sidepanel.html`, `sidepanel.js`, `styles.css`, `fonts.css` |
-| Standalone pages | `welcome.html`/`welcome.js` (nostr app directory, first-run), `wallets.html`/`wallets.js`/`wallets.css` (NWC wallet suggestions) |
+| Standalone pages | `welcome.html`/`welcome.js` (Nostr app directory, first-run), `wallets.html`/`wallets.js`/`wallets.css` (NWC wallet suggestions) |
 | Lightning (NWC / NIP-47) | `nwc-client.js`, `wallet-budgets.js` |
 | Vendored | `nostr-tools.js`, `qrious.min.js` (receive QR), `jsqr.js` (scan QR to pay), `fonts/` (Playfair Display + Manrope, SIL OFL) |
 | Generated | `version.js` (build stamp), `scripts/stamp-version.sh` |
@@ -103,12 +106,12 @@ is killed (MV3 idles after ~30s), that map is cleared and the keystore re-locks.
 ## Acknowledgments
 
 - Inspired by Nostr Build Shack by [Fishcake](https://github.com/fishcakeday) and [Clave](https://github.com/DocNR/clave) by [Doc](https://github.com/DocNR)
-- Standing on the shoulders of [nos2x](https://github.com/fiatjaf/nos2x) by [fiatjaf](https://github.com/fiatjaf) and the [Alby](https://github.com/getAlby/lightning-browser-extension) browser extension — the OG reliable browser signers most of nostr grew up with
+- Standing on the shoulders of [nos2x](https://github.com/fiatjaf/nos2x) by [fiatjaf](https://github.com/fiatjaf) and the [Alby](https://github.com/getAlby/lightning-browser-extension) browser extension — the OG reliable browser signers most of Nostr grew up with
 
 ## Author
 
 - Created by The Daniel 🖖
-- Vibed with Claude ☕️
+- Mixed with Claude 🍸
 
 ## License
 


### PR DESCRIPTION
Brings the README up to date with features that shipped but weren't documented, plus small copy fixes.

**New feature bullets**
- Outbox relays (NIP-65) — view/edit/publish your kind:10002 relay list with read/write markers
- Follow-list recovery — scan relays for an earlier kind:3 and republish a healthy version (credits Mutable)
- Following count on the profile (folded into the Identity bullet)
- Client tag opt-out (composer sub-bullet)
- In-app "Check for updates" (Updating section)

**Copy**
- Capitalize "Nostr" in prose (left `window.nostr`, `nostr:npub…`, filenames, URLs, and the nostr.build service name lowercase)
- Author credit: "Vibed with Claude ☕️" → "Mixed with Claude 🍸"

🍸 Stirred up with [Claude Code](https://claude.com/claude-code)