### PR TITLE
security: harden NIP-42 auto-signing, PIN strength, and OG-fetch SSRF

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,6 +1,6 @@
 # Sidecar Privacy Policy
 
-_Last updated: 2026-06-22_
+_Last updated: 2026-07-03_
 
 Sidecar is a browser extension that acts as a Nostr signer (NIP-07) and a
 Lightning wallet client (Nostr Wallet Connect / NIP-47). It is designed so that
@@ -50,6 +50,11 @@ Sidecar only talks to services **you choose**:
 - **Web pages you use** — when you sign in to a Nostr web app, Sidecar provides a
   signature or a public key to that page, with your approval. Pages receive
   signatures and your public key — **never your private key**.
+- **Link previews** — when a note you compose or view contains a URL, Sidecar
+  fetches that page through the extension to read its preview (title,
+  description, image) tags. This contacts the linked site directly; no
+  third-party preview service is involved, and requests to private or local
+  network addresses are blocked.
 
 Sidecar does not send any of this data to the developer or to any third party
 beyond the relays and wallet you configure.

--- a/background.js
+++ b/background.js
@@ -38,6 +38,43 @@ async function getConfiguredRelays() {
   return (await sget('sidecar_relays')).sidecar_relays || DEFAULT_RELAYS;
 }
 
+// ---- SSRF guard for server-side fetches (link previews) ----
+// The service worker fetch bypasses CORS and can reach the user's private
+// network, so refuse hostnames that resolve to loopback / private / link-local
+// space (incl. cloud metadata at 169.254.169.254) and non-http(s) schemes.
+function isPrivateHostname(host) {
+  const h = (host || '').toLowerCase();
+  if (!h) return true;
+  if (h === 'localhost' || h.endsWith('.localhost') || h.endsWith('.local') || h.endsWith('.internal')) return true;
+  const v4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(h);
+  if (v4) {
+    const a = +v4[1], b = +v4[2];
+    if ([a, b, +v4[3], +v4[4]].some((n) => n > 255)) return true;
+    if (a === 0 || a === 10 || a === 127) return true;         // this-host, private, loopback
+    if (a === 169 && b === 254) return true;                    // link-local + metadata
+    if (a === 172 && b >= 16 && b <= 31) return true;           // private
+    if (a === 192 && b === 168) return true;                    // private
+    if (a === 100 && b >= 64 && b <= 127) return true;          // CGNAT
+    if (a >= 224) return true;                                  // multicast / reserved
+    return false;
+  }
+  // IPv6 literals (URL.hostname strips the brackets).
+  if (h === '::1' || h === '::') return true;
+  if (h.startsWith('fe80') || h.startsWith('fc') || h.startsWith('fd')) return true; // link-local / ULA
+  if (h.startsWith('::ffff:')) return true; // IPv4-mapped
+  return false;
+}
+
+// Validate a URL intended for a server-side fetch. Returns the parsed URL or null.
+function safeFetchUrl(raw) {
+  let u;
+  try { u = new URL(raw); } catch (_) { return null; }
+  if (u.protocol !== 'http:' && u.protocol !== 'https:') return null;
+  if (u.username || u.password) return null; // no embedded credentials
+  if (isPrivateHostname(u.hostname)) return null;
+  return u;
+}
+
 // ---- per-site account binding ----
 // A web client caches the pubkey from its first getPublicKey() and has no way to
 // learn about an account switch. So we PIN each host to the account it logged in
@@ -266,6 +303,38 @@ function settlePrompt(promptId, action, extra) {
 // ============================================================================
 // Page RPC handling (window.nostr.*)
 // ============================================================================
+
+// A genuine NIP-42 AUTH event (kind 22242): its only tags are `relay` and
+// `challenge`, its content is empty (per spec), and its timestamp is close to
+// now. We auto-approve only these — a kind-22242 event carrying arbitrary tags,
+// content, or a skewed created_at is treated as a normal signing request that
+// needs the user's approval, so the exemption can't be used as a silent oracle.
+const NIP42_MAX_CLOCK_SKEW = 600; // seconds
+function isNip42AuthEvent(ev) {
+  if (!ev || ev.kind !== 22242 || !Array.isArray(ev.tags)) return false;
+  let hasRelay = false;
+  let hasChallenge = false;
+  for (const t of ev.tags) {
+    if (!Array.isArray(t) || typeof t[0] !== 'string') return false;
+    if (t[0] === 'relay') {
+      if (typeof t[1] !== 'string' || !t[1]) return false;
+      hasRelay = true;
+    } else if (t[0] === 'challenge') {
+      if (typeof t[1] !== 'string' || !t[1]) return false;
+      hasChallenge = true;
+    } else {
+      return false; // any other tag ⇒ not a plain auth event
+    }
+  }
+  if (!hasRelay || !hasChallenge) return false;
+  if (ev.content != null && ev.content !== '') return false;
+  if (ev.created_at != null) {
+    const skew = Math.abs(Math.floor(Date.now() / 1000) - Number(ev.created_at));
+    if (!Number.isFinite(skew) || skew > NIP42_MAX_CLOCK_SKEW) return false;
+  }
+  return true;
+}
+
 async function handleNostrRpc(method, params, host, sendResponse) {
   try {
     if (!host) throw new Error('Missing host');
@@ -284,12 +353,17 @@ async function handleNostrRpc(method, params, host, sendResponse) {
     // event that relays request frequently; an interactive prompt for it
     // guarantees client-side timeouts ("Signer did not respond in time"). Treat
     // it as pre-approved for any non-blocked site — only an unlock can gate it.
+    // But the exemption is a silent signing oracle if abused, so we only skip the
+    // prompt when the event is a *well-formed* auth event (see isNip42AuthEvent):
+    // relay + challenge tags only, near-current timestamp, no arbitrary payload.
+    // Anything else falls back to the normal approval prompt.
     let signKind = null;
+    let signEvent = null;
     if (method === 'signEvent') {
-      const ev = params && (params.event || params);
-      signKind = ev && ev.kind;
+      signEvent = params && (params.event || params);
+      signKind = signEvent && signEvent.kind;
     }
-    const isRelayAuth = method === 'signEvent' && signKind === 22242;
+    const isRelayAuth = method === 'signEvent' && isNip42AuthEvent(signEvent);
 
     const needsKey = SIGNER.needsPrivateKey(method);
     const needUnlock = needsKey && KS.isLocked();
@@ -726,10 +800,16 @@ async function handleControl(message, sendResponse) {
       case 'SIDECAR_FETCH_OG': {
         // Fetch a URL from the SW (no CORS restriction) and parse OG/meta tags.
         // Returns { title, description, image, site } or null on failure.
-        const ogUrl = message.url;
+        const ogTarget = safeFetchUrl(message.url);
+        if (!ogTarget) { result = null; break; }
+        const ogUrl = ogTarget.href;
         try {
-          const resp = await fetch(ogUrl, { signal: AbortSignal.timeout(8000) });
+          const resp = await fetch(ogUrl, { signal: AbortSignal.timeout(8000), redirect: 'follow' });
           if (!resp.ok) { result = null; break; }
+          // A redirect can bounce a public URL onto the private network; reject if
+          // the final response landed on a blocked host.
+          const finalUrl = safeFetchUrl(resp.url || ogUrl);
+          if (!finalUrl) { result = null; break; }
           const ct = resp.headers.get('content-type') || '';
           if (!ct.includes('text/html')) { result = null; break; }
           const html = await resp.text();

--- a/keystore.js
+++ b/keystore.js
@@ -20,6 +20,16 @@
   const STORE_KEY = 'sidecar_keystore';
   const ACTIVE_KEY = 'sidecar_active_pubkey';
 
+  // Minimum PIN/passphrase length. The panel enforces this in the UI, but we also
+  // check here so the trusted context never wraps keys under a trivially weak
+  // secret regardless of how the request arrived.
+  const MIN_PIN_LENGTH = 8;
+  function assertPinStrength(pin) {
+    if (typeof pin !== 'string' || pin.length < MIN_PIN_LENGTH) {
+      throw new Error(`PIN must be at least ${MIN_PIN_LENGTH} characters`);
+    }
+  }
+
   // ---- in-memory unlocked state (module scope; gone when SW is killed) ----
   let derivedKey = null;                 // non-extractable AES-GCM CryptoKey, held while unlocked
   let unlocked = new Map();              // pubkeyHex -> Uint8Array(32) private key
@@ -153,6 +163,7 @@
   // Create a brand-new keystore protected by `pin`. Leaves it unlocked (empty).
   async function initialize(pin) {
     if (await isInitialized()) throw new Error('Keystore already initialized');
+    assertPinStrength(pin);
     const kdf = C.newKdf();
     derivedKey = await C.deriveKey(pin, kdf);
     const store = {
@@ -378,6 +389,7 @@
   async function changePin(oldPin, newPin) {
     const store = await loadStore();
     if (!store) throw new Error('Keystore not initialized');
+    assertPinStrength(newPin);
     const oldKey = await C.deriveKey(oldPin, store.kdf);
     if (!(await C.checkVerifier(oldKey, store.verifier))) throw new Error('Incorrect current PIN');
     const kdf = C.newKdf();

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -20,9 +20,9 @@
       <input type="password" id="ob-pin" autocomplete="new-password" maxlength="32" />
       <label for="ob-pin2">Confirm</label>
       <input type="password" id="ob-pin2" autocomplete="new-password" maxlength="32" />
-      <p class="hint">A longer alphanumeric passphrase is stronger than a short numeric PIN. There is no recovery if you forget it.</p>
+      <p class="hint">Use at least 8 characters. A longer alphanumeric passphrase is stronger than a short numeric PIN. There is no recovery if you forget it.</p>
       <div class="error" id="ob-error"></div>
-      <button type="submit" class="primary">Create keystore</button>
+      <button type="submit" class="primary" id="ob-submit">Create keystore</button>
     </form>
   </section>
 

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -73,6 +73,81 @@
     return wrap.firstElementChild;
   }
 
+  // ---- PIN / passphrase strength + confirmation UI ----
+  // The keystore is encrypted at rest under a key derived from this secret, so its
+  // length is the practical floor on that protection. Require a non-trivial minimum
+  // and give live feedback: a green check appears in the first box once it's long
+  // enough, and a second green check (or a red x on mismatch) as the confirmation
+  // is typed. The proceed button stays disabled until both are satisfied.
+  const MIN_PIN_LEN = 8;
+  const MAX_PIN_LEN = 32;
+
+  function pinMeetsLength(v) {
+    return v.length >= MIN_PIN_LEN && v.length <= MAX_PIN_LEN;
+  }
+
+  function setPinIndicator(ind, state) {
+    ind.classList.remove('ok', 'bad');
+    ind.textContent = '';
+    if (state === 'ok') { ind.classList.add('ok'); ind.appendChild(icon('check')); }
+    else if (state === 'bad') { ind.classList.add('bad'); ind.appendChild(icon('x')); }
+  }
+
+  // Wrap a password <input> so a check/x indicator can sit at its right edge.
+  // Works whether the input is already in the DOM or still detached (in which case
+  // the caller appends the returned wrapper). Returns the indicator element.
+  function addPinIndicator(input) {
+    const wrap = document.createElement('div');
+    wrap.className = 'pin-field';
+    if (input.parentNode) input.parentNode.insertBefore(wrap, input);
+    wrap.appendChild(input);
+    const ind = document.createElement('span');
+    ind.className = 'pin-indicator';
+    ind.setAttribute('aria-hidden', 'true');
+    wrap.appendChild(ind);
+    return ind;
+  }
+
+  // Live-validate a create/confirm PIN pair and gate a submit button. Call after
+  // both inputs are in the DOM. Returns validate(), which also reports validity.
+  // The green check on the confirm box shows the instant it matches; the red x is
+  // held back until the user pauses typing (MISMATCH_DELAY), so it doesn't flash
+  // red while a matching value is still being entered.
+  const PIN_MISMATCH_DELAY = 700; // ms of idle before flagging a mismatch
+  function attachPinValidation(pinInput, confirmInput, submitBtn) {
+    const pinInd = addPinIndicator(pinInput);
+    const confInd = confirmInput ? addPinIndicator(confirmInput) : null;
+    let mismatchTimer = null;
+    const clearMismatchTimer = () => { if (mismatchTimer) { clearTimeout(mismatchTimer); mismatchTimer = null; } };
+    function validate() {
+      const pinOk = pinMeetsLength(pinInput.value);
+      setPinIndicator(pinInd, pinOk ? 'ok' : null);
+      let ready = pinOk;
+      if (confInd) {
+        const cv = confirmInput.value;
+        clearMismatchTimer();
+        if (!cv) {
+          setPinIndicator(confInd, null);            // nothing typed yet
+        } else if (cv === pinInput.value) {
+          setPinIndicator(confInd, pinOk ? 'ok' : null); // contents match; green once the PIN is long enough
+        } else {
+          // Genuine mismatch — defer the red so it doesn't appear mid-keystroke.
+          setPinIndicator(confInd, null);
+          mismatchTimer = setTimeout(() => {
+            if (confirmInput.value && confirmInput.value !== pinInput.value) setPinIndicator(confInd, 'bad');
+          }, PIN_MISMATCH_DELAY);
+        }
+        ready = pinOk && cv.length > 0 && cv === pinInput.value;
+      }
+      if (submitBtn) submitBtn.disabled = !ready;
+      return ready;
+    }
+    pinInput.addEventListener('input', validate);
+    if (confirmInput) confirmInput.addEventListener('input', validate);
+    validate();
+    return validate;
+  }
+
   // ---- toast notifications ----
   function toast(message, type) {
     const t = document.createElement('div');
@@ -224,14 +299,15 @@
 
 
   // ---- onboarding ----
+  attachPinValidation($('ob-pin'), $('ob-pin2'), $('ob-submit'));
   $('onboarding-form').addEventListener('submit', async (e) => {
     e.preventDefault();
     const err = $('ob-error');
     err.textContent = '';
     const pin = $('ob-pin').value;
     const pin2 = $('ob-pin2').value;
-    if (pin.length < 4) return (err.textContent = 'Use at least 4 characters.');
-    if (pin.length > 32) return (err.textContent = 'Use at most 32 characters.');
+    if (pin.length < MIN_PIN_LEN) return (err.textContent = `Use at least ${MIN_PIN_LEN} characters.`);
+    if (pin.length > MAX_PIN_LEN) return (err.textContent = `Use at most ${MAX_PIN_LEN} characters.`);
     if (pin !== pin2) return (err.textContent = 'PINs do not match.');
     try {
       await call({ type: 'SIDECAR_INIT', pin });
@@ -5155,15 +5231,15 @@
 
   $('change-pin-btn').addEventListener('click', () => {
     openModal((modal) => {
-      const oldP = h('input', { type: 'password', placeholder: 'Current PIN', maxLength: 32 });
-      const newP = h('input', { type: 'password', placeholder: 'New PIN', maxLength: 32 });
-      const newP2 = h('input', { type: 'password', placeholder: 'Confirm new PIN', maxLength: 32 });
+      const oldP = h('input', { type: 'password', placeholder: 'Current PIN', maxLength: MAX_PIN_LEN });
+      const newP = h('input', { type: 'password', placeholder: 'New PIN', maxLength: MAX_PIN_LEN });
+      const newP2 = h('input', { type: 'password', placeholder: 'Confirm new PIN', maxLength: MAX_PIN_LEN });
       const err = h('div', { className: 'error' });
       const save = h('button', { className: 'primary', textContent: 'Change PIN' });
       save.addEventListener('click', async () => {
         err.textContent = '';
-        if (newP.value.length < 4) return (err.textContent = 'New PIN too short.');
-        if (newP.value.length > 32) return (err.textContent = 'Max 32 characters.');
+        if (newP.value.length < MIN_PIN_LEN) return (err.textContent = `New PIN must be at least ${MIN_PIN_LEN} characters.`);
+        if (newP.value.length > MAX_PIN_LEN) return (err.textContent = `Max ${MAX_PIN_LEN} characters.`);
         if (newP.value !== newP2.value) return (err.textContent = 'New PINs do not match.');
         try {
           await call({ type: 'SIDECAR_CHANGE_PIN', oldPin: oldP.value, newPin: newP.value });
@@ -5184,6 +5260,8 @@
         err,
         h('div', { className: 'actions' }, [save, cancel])
       );
+      // Live strength/match feedback on the new-PIN pair; gates the Change button.
+      attachPinValidation(newP, newP2, save);
     });
   });
 

--- a/styles.css
+++ b/styles.css
@@ -135,6 +135,28 @@ input:focus, select:focus, textarea:focus {
   box-shadow: 0 0 0 3px rgba(203, 161, 78, 0.16);
 }
 
+/* ===== PIN / passphrase strength + match indicators ===== */
+/* A wrapper that floats a check/x at the right edge of a password box. */
+.pin-field { position: relative; width: 100%; }
+.pin-field input { padding-right: 38px; }
+.pin-indicator {
+  position: absolute;
+  right: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 18px;
+  height: 18px;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+.pin-indicator svg { width: 18px; height: 18px; display: block; }
+.pin-indicator.ok, .pin-indicator.bad { display: flex; }
+.pin-indicator.ok { color: #6ee7a8; }
+.pin-indicator.bad { color: var(--red); }
+.primary:disabled { opacity: 0.4; cursor: default; box-shadow: none; filter: none; }
+
 /* ===== profile (active account) ===== */
 /* profile loading skeleton (mirrors the centered layout) */
 .profile-skeleton { display: flex; flex-direction: column; align-items: center; }


### PR DESCRIPTION
Focused security hardening in three areas. Each fails safe.

## NIP-42 auto-signing
Previously *any* kind:22242 event was signed with no prompt (to avoid relay-auth timeouts) — a silent signing oracle. Now only a well-formed auth event is auto-approved: `relay` + `challenge` tags only, empty content, timestamp within ±600s. Anything else falls back to the normal approval prompt.

## PIN strength
Minimum raised to 8 characters, enforced in the keystore (`initialize` + `changePin`) as well as the UI, so keys are never wrapped under a trivially weak secret. **Unlock is unchanged, so existing accounts with a shorter PIN are not locked out** — the minimum only applies when setting a new secret. Onboarding and change-PIN get a live validator: a green check once the PIN is long enough, and a check/red-x on the confirm box (the red held back until the user pauses typing, so it doesn't flash mid-keystroke), with the submit button gated until both match.

## OG / link-preview fetch (SSRF)
The service-worker fetch bypasses CORS and can reach the private network. `safeFetchUrl` now rejects non-http(s) schemes, embedded credentials, and loopback/private/link-local/CGNAT/multicast hosts (incl. `169.254.169.254` cloud metadata), and re-checks the final URL after redirects.

Known limitation (documented, not addressed here): DNS-rebinding and redirect-hop SSRF can't be fully closed client-side; a `redirect: 'manual'` per-hop refinement is a possible follow-up.

Also documents the server-side link-preview fetch and its SSRF guard in `PRIVACY.md`.

🍸 Stirred up with [Claude Code](https://claude.com/claude-code)