### PR TITLE
release: v1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Connect) and a composer for posting notes directly from the panel.
 
 ## Features
 
-- **Multiple accounts** — store as many nsecs as you like, drag to reorder, switch the active one in a click. Importing shows a profile preview (name + avatar) so you can confirm the right key before saving. Reveal a key behind your PIN — with a QR for quick sign-in on mobile clients.
-- **PIN-protected** — every private key is encrypted at rest (PBKDF2 → AES-GCM, WebCrypto). Nothing is stored in plaintext, and the keystore re-locks automatically. A paste guard blocks dropping an nsec anywhere except the import field.
+- **Multiple accounts** — store as many nsecs as you like, drag to reorder, switch the active one in a click. Importing shows a profile preview (name + avatar) so you can confirm the right key before saving. Generating a new key runs a quick guided setup (name, photo, bio). Reveal a key behind your PIN — with a QR for quick sign-in on mobile clients.
+- **PIN-protected** — every private key is encrypted at rest (PBKDF2 → AES-GCM, WebCrypto) under a PIN of at least 8 characters, with a live strength and match check when you set it. Nothing is stored in plaintext, and the keystore re-locks automatically. A paste guard blocks dropping an nsec anywhere except the import field.
 - **In-extension signing** — implements the full NIP-07 surface: `getPublicKey`, `signEvent`, `nip04`/`nip44` encrypt & decrypt, and `getRelays`.
 - **Per-site permissions** — approve or reject each site, per method, with a clear prompt that previews what you're signing. Relay auth (NIP-42) signs automatically so clients stay connected.
 - **Per-site account binding** — each site stays pinned to the account it logged in with (no NIP-07 desync). Switch a site to another account from **Connected Sites**.

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
   "name": "Sidecar | A Classy Nostr Signer",
-  "version": "1.1.1",
-  "description": "A multi-account NIP-07 nostr signer with a built-in Lightning wallet, in your browser sidebar.",
+  "version": "1.2.0",
+  "description": "A multi-account NIP-07 Nostr signer with a built-in Lightning wallet, in your browser sidebar.",
   "permissions": [
     "storage",
     "sidePanel",


### PR DESCRIPTION
Version bump **1.1.1 → 1.2.0** — the next Chrome Web Store release.

- `manifest.json`: version to 1.2.0; capitalize "Nostr" in the store description.
- `README.md`: document the guided setup wizard for new keys and the 8-char PIN minimum with live strength/match check.

Ships everything merged since 1.1.1 — follow-list recovery, NIP-65 outbox relay editor, following count, client-tag toggle, check-for-updates, the Light Mode dropdown fix, the guided new-account setup wizard, and the NIP-42 / PIN-strength / SSRF security hardening.

🍸 Stirred up with [Claude Code](https://claude.com/claude-code)