### PR TITLE
feat: global @-mention search via Nostr Archives

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ is killed (MV3 idles after ~30s), that map is cleared and the keystore re-locks.
 
 - Inspired by Nostr Build Shack by [Fishcake](https://github.com/fishcakeday) and [Clave](https://github.com/DocNR/clave) by [Doc](https://github.com/DocNR)
 - Standing on the shoulders of [nos2x](https://github.com/fiatjaf/nos2x) by [fiatjaf](https://github.com/fiatjaf) and the [Alby](https://github.com/getAlby/lightning-browser-extension) browser extension — the OG reliable browser signers most of Nostr grew up with
+- Global @-mention search is powered by the [nostrarchives-api](https://github.com/barrydeen/nostrarchives-api) by [barrydeen](https://github.com/barrydeen)
 
 ## Author
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Connect) and a composer for posting notes directly from the panel.
 - **Backups** — encrypt your profile, follows, and mute list to your own key and store them on your relays (NIP-78), or export a signed JSON bundle.
 - **Follow-list recovery** — if a buggy client overwrites your follows with an empty or shorter list, scan your relays for an earlier kind:3 and republish a healthy version. Powered by [Mutable](https://mutable.top).
 - **Note composer** — post kind:1 notes directly from the panel with a send countdown you can review (the full note renders) and cancel. Drafts autosave per account, so you can close the composer and resume — or start fresh — later. Features include:
-  - **@mention autocomplete** — type `@` to search your follow list; selecting inserts an atomic pill that serializes to `nostr:npub1…` and adds a `p` tag automatically.
+  - **@mention autocomplete** — type `@` to search your follows *and* all of Nostr (global search via [Nostr Archives](https://github.com/barrydeen/nostrarchives-api)), so you can tag anyone; selecting inserts an atomic pill that serializes to `nostr:npub1…` and adds a `p` tag automatically.
   - **Nostr event embeds** — paste a `note1`, `nevent1`, or `naddr1` entity and the preview renders a fetched embed card (author, timestamp, content excerpt).
   - **Link previews** — plain URLs show an OG meta card (title, description, thumbnail) fetched through the extension with no third-party service.
   - **Media upload** — attach images and video; uploads go to your own Blossom servers (from your kind:10063 list) when available, falling back to nostr.build.

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -2130,6 +2130,7 @@
   // Follow list cache for @mention autocomplete (invalidated on account switch)
   let followListCache = null;
   let followListPubkey = null;
+  let followListInflight = null; // dedupe concurrent loads (rapid @-keystrokes)
 
   // Lightweight follow COUNT (unique p-tags on the account's kind:3) — avoids the
   // heavy kind:0 profile batch that getFollowList() does, since the profile just
@@ -2232,7 +2233,9 @@
 
   async function getFollowList() {
     if (followListCache && followListPubkey === state.activePubkey) return followListCache;
+    if (followListInflight) return followListInflight; // a load is already running
     if (!state.activePubkey) return [];
+    followListInflight = (async () => {
     try {
       const relays = await relayUrls(false);
       // maxWait bounds each relay's own connect+EOSE wait individually (they
@@ -2285,6 +2288,9 @@
     } catch (_) {
       return [];
     }
+    })();
+    try { return await followListInflight; }
+    finally { followListInflight = null; }
   }
 
   function npubChip(npub) {
@@ -3023,14 +3029,31 @@
         scheduleSave();
       }
 
-      function renderAcResults(items, ctx) {
+      // Anchor the dropdown just under the caret line rather than the bottom of
+      // the (tall) editor box. Falls back to the CSS default if no caret rect.
+      function positionAcDropdown() {
+        if (!acDropdown) return;
+        try {
+          const sel = window.getSelection();
+          if (!sel.rangeCount) return;
+          const r = sel.getRangeAt(0).getBoundingClientRect();
+          if (!r || (!r.top && !r.bottom)) return;
+          const wrap = editorWrap.getBoundingClientRect();
+          acDropdown.style.top = Math.round(r.bottom - wrap.top + 4) + 'px';
+        } catch (_) {}
+      }
+
+      // `loading` shows a "Searching Nostr…" footer while the global lookup runs,
+      // and keeps the dropdown open even when there are no local matches yet.
+      function renderAcResults(items, ctx, loading) {
         acResults = items;
-        if (!acResults.length) { closeAcDropdown(); return; }
-        acIndex = Math.max(0, Math.min(acIndex, acResults.length - 1));
+        if (!acResults.length && !loading) { closeAcDropdown(); return; }
+        acIndex = Math.max(0, Math.min(acIndex, Math.max(0, acResults.length - 1)));
         if (!acDropdown) {
           acDropdown = h('div', { className: 'ac-dropdown' });
           editorWrap.append(acDropdown);
         }
+        positionAcDropdown();
         acDropdown.innerHTML = '';
         acResults.forEach((c, i) => {
           const item = h('div', { className: 'ac-item' + (i === acIndex ? ' active' : '') });
@@ -3044,30 +3067,58 @@
           });
           acDropdown.append(item);
         });
+        if (loading) {
+          acDropdown.append(h('div', { className: 'ac-loading' }, [
+            h('span', { className: 'ac-spinner' }),
+            h('span', { textContent: acResults.length ? 'Searching more…' : 'Searching Nostr…' }),
+          ]));
+        }
       }
 
+      // Two async sources feed the dropdown: your follow list (instant from
+      // cache, else a slow first relay load) and a global Nostr search. NEVER
+      // block the UI on the follow list — the first load hits relays and can take
+      // many seconds. Paint immediately (with a spinner), then repaint as each
+      // source resolves. `paint()` renders the deduped union + loading state.
       async function updateAcDropdown() {
         const ctx = getCaretContext();
         if (!ctx || ctx.query.length === 0) { closeAcDropdown(); return; }
         const seq = ++acSeq;
         const q = ctx.query.toLowerCase();
-        const follows = await getFollowList();
-        if (seq !== acSeq) return; // a newer keystroke superseded this
-        const followMatches = follows.filter((c) => c.name && c.name.toLowerCase().includes(q));
-        renderAcResults(followMatches.slice(0, 8), ctx);
+        const willSearchGlobal = ctx.query.length >= 2 && naAvailable();
 
-        // Also search all of Nostr (not just follows) so you can tag someone you
-        // don't follow. Debounced; merged below the follow matches, deduped by
-        // pubkey. Best-effort — a failure/rate-limit just leaves the follow list.
-        if (ctx.query.length >= 2) {
+        const matchFollows = (list) => list.filter((c) => c.name && c.name.toLowerCase().includes(q));
+        let followMatches = [];
+        let globals = [];
+        let globalPending = willSearchGlobal;
+        const paint = () => {
+          if (seq !== acSeq) return;
+          const seen = new Set(followMatches.map((c) => c.pubkey));
+          const merged = followMatches.slice();
+          for (const g of globals) { if (!seen.has(g.pubkey)) { seen.add(g.pubkey); merged.push(g); } }
+          renderAcResults(merged.slice(0, 8), ctx, globalPending);
+        };
+
+        // Follows: use the cache synchronously if present; otherwise load in the
+        // background and repaint when ready (no await here).
+        const cached = (followListCache && followListPubkey === state.activePubkey) ? followListCache : null;
+        if (cached) followMatches = matchFollows(cached);
+        paint(); // instant feedback: local matches (maybe none) + spinner if searching
+        if (!cached) {
+          getFollowList().then((list) => { if (seq === acSeq) { followMatches = matchFollows(list); paint(); } });
+        }
+
+        // Global search across all of Nostr so you can tag people you don't
+        // follow. Debounced; best-effort — a failure/rate-limit just clears the
+        // spinner and leaves the follow matches.
+        if (willSearchGlobal) {
           if (acSuggestTimer) clearTimeout(acSuggestTimer);
           acSuggestTimer = setTimeout(async () => {
-            const globals = await naSuggest(ctx.query);
-            if (seq !== acSeq || !globals.length) return;
-            const seen = new Set(followMatches.map((c) => c.pubkey));
-            const merged = followMatches.slice();
-            for (const g of globals) { if (!seen.has(g.pubkey)) { seen.add(g.pubkey); merged.push(g); } }
-            renderAcResults(merged.slice(0, 8), ctx);
+            const res = await naSuggest(ctx.query);
+            if (seq !== acSeq) return; // query changed since
+            globals = res;
+            globalPending = false;
+            paint();
           }, 250);
         }
       }

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -2154,6 +2154,82 @@
     return count;
   }
 
+  // ---- Nostr Archives profile API ----
+  // Global username search + bulk metadata, used to (A) find people to @mention
+  // who aren't in your follow list and (B) resolve follow-list names the relays
+  // didn't return. Best-effort: any error or rate-limit falls back to relay data.
+  // See docs/username-search-plan.md. Approved endpoints only.
+  const NA_BASE = 'https://api.nostrarchives.com';
+  const isHex64 = (s) => typeof s === 'string' && /^[0-9a-f]{64}$/i.test(s);
+  let naCooldownUntil = 0; // epoch ms; a 429 backs us off until this time
+  const naAvailable = () => Date.now() >= naCooldownUntil;
+  function naBackoff(retryAfter) {
+    const secs = Math.min(3600, Math.max(30, Number(retryAfter) || 60));
+    naCooldownUntil = Date.now() + secs * 1000;
+  }
+  const naName = (p) => p.display_name || p.preferred_name || p.name || null;
+
+  // Global username search → [{pubkey, name, picture}]. Returns [] on any failure.
+  async function naSuggest(query) {
+    if (!query || query.length < 2 || !naAvailable()) return [];
+    try {
+      const resp = await fetch(NA_BASE + '/v1/search/suggest?q=' + encodeURIComponent(query) + '&limit=8', {
+        signal: AbortSignal.timeout(5000),
+      });
+      if (resp.status === 429) { naBackoff(resp.headers.get('retry-after')); return []; }
+      if (!resp.ok) return [];
+      const data = await resp.json();
+      return (data.suggestions || [])
+        .filter((s) => s && isHex64(s.pubkey))
+        .map((s) => {
+          const pk = s.pubkey.toLowerCase();
+          let name = naName(s);
+          if (!name) { try { name = shortNpub(NT.nip19.npubEncode(pk)); } catch (_) { name = pk.slice(0, 10) + '…'; } }
+          return { pubkey: pk, name, picture: s.picture || null };
+        });
+    } catch (_) { return []; }
+  }
+
+  // Bulk profile metadata for a set of pubkeys → Map(pubkey → {name, picture}).
+  // Chunks to the API's 500-pubkey limit; stops early on a rate-limit.
+  async function naMetadata(pubkeys) {
+    const out = new Map();
+    const ids = [...new Set((pubkeys || []).filter(isHex64).map((p) => p.toLowerCase()))];
+    if (!ids.length || !naAvailable()) return out;
+    for (let i = 0; i < ids.length; i += 500) {
+      const chunk = ids.slice(i, i + 500);
+      try {
+        const resp = await fetch(NA_BASE + '/v1/profiles/metadata', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ pubkeys: chunk }),
+          signal: AbortSignal.timeout(8000),
+        });
+        if (resp.status === 429) { naBackoff(resp.headers.get('retry-after')); break; }
+        if (!resp.ok) continue;
+        const data = await resp.json();
+        (data.profiles || []).forEach((p) => {
+          if (p && isHex64(p.pubkey)) out.set(p.pubkey.toLowerCase(), { name: naName(p), picture: p.picture || null });
+        });
+      } catch (_) { /* keep whatever resolved so far */ }
+    }
+    return out;
+  }
+
+  // Fire-and-forget: fill in names/pictures the relays didn't return, mutating the
+  // cached follow-list objects in place so those follows become searchable by name
+  // on the next keystroke. Never blocks the initial dropdown.
+  async function enrichFollowNames(list, missingPubkeys) {
+    if (!missingPubkeys.length) return;
+    const meta = await naMetadata(missingPubkeys);
+    if (!meta.size) return;
+    const byPk = new Map(list.map((c) => [c.pubkey, c]));
+    meta.forEach((m, pk) => {
+      const c = byPk.get(pk);
+      if (c && m.name) { c.name = m.name; if (!c.picture && m.picture) c.picture = m.picture; }
+    });
+  }
+
   async function getFollowList() {
     if (followListCache && followListPubkey === state.activePubkey) return followListCache;
     if (!state.activePubkey) return [];
@@ -2201,6 +2277,10 @@
       });
       followListPubkey = state.activePubkey;
       followListCache = list;
+      // Background: fill names the relays didn't return via Nostr Archives, so
+      // those follows become searchable by name. Mutates the cached objects in
+      // place; not awaited, so the first dropdown render stays instant.
+      enrichFollowNames(list, pubkeys.filter((pk) => !byPk[pk]));
       return followListCache;
     } catch (_) {
       return [];
@@ -2881,6 +2961,7 @@
 
       // ---- @mention autocomplete ----
       let acDropdown = null, acResults = [], acIndex = 0;
+      let acSeq = 0, acSuggestTimer = null; // guard stale async + debounce global search
 
       function getCaretContext() {
         const sel = window.getSelection();
@@ -2942,14 +3023,10 @@
         scheduleSave();
       }
 
-      async function updateAcDropdown() {
-        const ctx = getCaretContext();
-        if (!ctx || ctx.query.length === 0) { closeAcDropdown(); return; }
-        const follows = await getFollowList();
-        const q = ctx.query.toLowerCase();
-        acResults = follows.filter((c) => c.name && c.name.toLowerCase().includes(q)).slice(0, 8);
+      function renderAcResults(items, ctx) {
+        acResults = items;
         if (!acResults.length) { closeAcDropdown(); return; }
-        acIndex = Math.min(acIndex, acResults.length - 1);
+        acIndex = Math.max(0, Math.min(acIndex, acResults.length - 1));
         if (!acDropdown) {
           acDropdown = h('div', { className: 'ac-dropdown' });
           editorWrap.append(acDropdown);
@@ -2967,6 +3044,32 @@
           });
           acDropdown.append(item);
         });
+      }
+
+      async function updateAcDropdown() {
+        const ctx = getCaretContext();
+        if (!ctx || ctx.query.length === 0) { closeAcDropdown(); return; }
+        const seq = ++acSeq;
+        const q = ctx.query.toLowerCase();
+        const follows = await getFollowList();
+        if (seq !== acSeq) return; // a newer keystroke superseded this
+        const followMatches = follows.filter((c) => c.name && c.name.toLowerCase().includes(q));
+        renderAcResults(followMatches.slice(0, 8), ctx);
+
+        // Also search all of Nostr (not just follows) so you can tag someone you
+        // don't follow. Debounced; merged below the follow matches, deduped by
+        // pubkey. Best-effort — a failure/rate-limit just leaves the follow list.
+        if (ctx.query.length >= 2) {
+          if (acSuggestTimer) clearTimeout(acSuggestTimer);
+          acSuggestTimer = setTimeout(async () => {
+            const globals = await naSuggest(ctx.query);
+            if (seq !== acSeq || !globals.length) return;
+            const seen = new Set(followMatches.map((c) => c.pubkey));
+            const merged = followMatches.slice();
+            for (const g of globals) { if (!seen.has(g.pubkey)) { seen.add(g.pubkey); merged.push(g); } }
+            renderAcResults(merged.slice(0, 8), ctx);
+          }, 250);
+        }
       }
 
       function syncEmptyClass() {

--- a/styles.css
+++ b/styles.css
@@ -1054,6 +1054,9 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
 .ac-item-av { width: 26px; height: 26px; border-radius: 50%; overflow: hidden; flex-shrink: 0; background: var(--velvet-1); border: 1px solid var(--border); }
 .ac-item-av img { width: 100%; height: 100%; object-fit: cover; display: block; }
 .ac-item-name { font-weight: 600; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.ac-loading { display: flex; align-items: center; gap: 9px; padding: 9px 12px; font-size: 12.5px; color: var(--muted); }
+.ac-spinner { width: 14px; height: 14px; flex-shrink: 0; border-radius: 50%; border: 2px solid var(--border-strong); border-top-color: var(--lav); animation: ac-spin 0.7s linear infinite; }
+@keyframes ac-spin { to { transform: rotate(360deg); } }
 .compose-preview {
   min-height: 120px; max-height: 46vh; overflow-y: auto;
   border: 1px solid var(--border); border-radius: 10px; padding: 12px;


### PR DESCRIPTION
## What

@-mention autocomplete only searched your follow list, so you couldn't tag anyone you don't follow, and follows whose `kind:0` the relays didn't return showed as a short npub and weren't searchable by name.

Adds a best-effort [Nostr Archives](https://github.com/barrydeen/nostrarchives-api) client (approved endpoints only) with graceful rate-limit handling.

## How

- **Global search:** typing `@` fires a debounced `GET /v1/search/suggest` across all of Nostr; results merge below your follow matches, deduped by pubkey.
- **Follow-name coverage:** follows the relays couldn't resolve are filled in from `POST /v1/profiles/metadata` (bulk, chunked to 500) in the background, so they become searchable by name.
- **Never blocks the UI:** the dropdown paints instantly with a "Searching Nostr…" spinner; the global search runs in parallel and the follow list loads in the background and merges in when ready. An in-flight guard dedupes concurrent follow-list loads.
- **Placement:** the dropdown anchors under the caret line, not the bottom of the editor.
- **Rate limits:** a `429` backs the client off (honoring `Retry-After`, clamped 30s–1h); all calls fall back to relay data on any error/timeout, which are `AbortSignal`-bounded.

No manifest change needed — host permissions already cover the fetches. Credits `barrydeen/nostrarchives-api` in the README.

## Deferred

`docs/username-search-plan.md` notes a possible OG-fetch-style tightening and DNS-rebinding caveats for the API layer, but those don't apply here (read-only profile lookups).

🥃 Poured with [Claude Code](https://claude.com/claude-code)