### PR TITLE
feat: lightning address (receive + wallet card + profile sync) & opt-in nsec QR

### DIFF
--- a/sidepanel.js
+++ b/sidepanel.js
@@ -1672,18 +1672,27 @@
         // opt-in backup option, not shown unprompted. Generated only on click, so
         // the scannable image never exists on screen unless requested. nsec is
         // case-sensitive bech32, so encode it as-is (lowercase, byte mode).
-        const qrBox = h('div', { className: 'qr-reveal' });
+        const qrCanvasWrap = h('div', { className: 'qr-reveal hidden' }); // holds the canvas once revealed
         const qrHint = h('p', { className: 'hint hidden', textContent: 'Scan to sign in on a mobile client that supports QR login.' });
-        const showQr = h('button', { className: 'secondary qr-reveal-btn' }, [icon('qr'), h('span', { textContent: 'Show QR code' })]);
+        const showQr = h('button', { className: 'secondary qr-reveal-btn' });
+        let qrShown = false, qrCanvas = null;
+        const setQrLabel = () => {
+          showQr.innerHTML = '';
+          showQr.append(icon('qr'), h('span', { textContent: qrShown ? 'Hide QR code' : 'Show QR code' }));
+        };
+        setQrLabel();
         showQr.addEventListener('click', () => {
-          const canvas = document.createElement('canvas');
-          canvas.className = 'recv-qr modal-qr';
-          try { new window.QRious({ element: canvas, value: opts.nsec, size: 220, level: 'M' }); } catch (_) {}
-          qrBox.innerHTML = '';
-          qrBox.append(canvas);
-          qrHint.classList.remove('hidden');
+          qrShown = !qrShown;
+          if (qrShown && !qrCanvas) {
+            qrCanvas = document.createElement('canvas');
+            qrCanvas.className = 'recv-qr modal-qr';
+            try { new window.QRious({ element: qrCanvas, value: opts.nsec, size: 220, level: 'M' }); } catch (_) {}
+            qrCanvasWrap.append(qrCanvas);
+          }
+          qrCanvasWrap.classList.toggle('hidden', !qrShown);
+          qrHint.classList.toggle('hidden', !qrShown);
+          setQrLabel();
         });
-        qrBox.append(showQr);
 
         const box = h('div', { className: 'secret-box', textContent: opts.nsec });
         const copy = h('button', { className: 'secondary', textContent: 'Copy nsec' });
@@ -1709,7 +1718,8 @@
           opts.intro ? h('p', { className: 'hint', textContent: opts.intro }) : document.createTextNode(''),
           box,
           copy,
-          qrBox,
+          showQr,
+          qrCanvasWrap,
           qrHint,
           h('p', { className: 'hint warn', textContent: 'Anyone with this key fully controls the account. Store it somewhere safe and never share it.' }),
           countdown,
@@ -2157,8 +2167,63 @@
     }
     view.append(body);
 
+    // Offer to sync the profile's lightning address to the connected wallet's
+    // address (from the NWC string) when they differ — filled in async.
+    const lud16Notice = h('div', { className: 'lud16-sync hidden' });
+    view.append(lud16Notice);
+    maybeSuggestLud16(lud16Notice, active, content);
+
     renderNip65Section(view, active);
     renderBackupSection(view, active);
+  }
+
+  // If the connected wallet advertises a lightning address (NWC lud16) that
+  // differs from — or is missing on — the profile, offer a one-tap update so the
+  // profile matches where zaps actually land. Dismissals are remembered for the
+  // session so it doesn't nag.
+  const _lud16SyncDismissed = new Set(); // `${pubkey}|${walletAddr}`
+  async function maybeSuggestLud16(container, active, content) {
+    let walletAddr = null;
+    try {
+      const { connection } = await call({ type: 'SIDECAR_GET_NWC' });
+      walletAddr = connection ? parseNwcLud16(connection) : null;
+    } catch (_) {}
+    if (!walletAddr) return; // no wallet address to sync
+    if (state.activePubkey !== active.pubkey) return; // account switched during await
+    const profileAddr = (content.lud16 || '').trim();
+    if (profileAddr.toLowerCase() === walletAddr.toLowerCase()) return; // already matches
+    const key = active.pubkey + '|' + walletAddr;
+    if (_lud16SyncDismissed.has(key)) return;
+
+    const title = h('div', { className: 'lud16-sync-title' }, [
+      boltIcon('lud16-sync-bolt'),
+      h('span', { textContent: 'Lightning address' }),
+    ]);
+    const msg = h('p', {
+      className: 'lud16-sync-msg',
+      textContent: profileAddr
+        ? "Your profile's lightning address differs from your connected wallet's."
+        : "Add your wallet's lightning address to your profile so people can zap you.",
+    });
+    const addr = h('div', { className: 'lud16-sync-addr', textContent: walletAddr });
+    const useBtn = h('button', { className: 'primary', textContent: profileAddr ? 'Use wallet address' : 'Add to profile' });
+    const dismiss = h('button', { className: 'ghost', textContent: 'Not now' });
+    useBtn.addEventListener('click', async () => {
+      useBtn.disabled = true;
+      useBtn.textContent = 'Updating…';
+      try {
+        await publishProfile({ lud16: walletAddr }, null); // unlocked → no step-up PIN; additive
+        toast('Lightning address updated', 'success');
+        renderProfile(); // re-render: the address now matches, so the notice won't reappear
+      } catch (e) {
+        useBtn.disabled = false;
+        useBtn.textContent = profileAddr ? 'Use wallet address' : 'Add to profile';
+        toast(e.message, 'error');
+      }
+    });
+    dismiss.addEventListener('click', () => { _lud16SyncDismissed.add(key); container.remove(); });
+    container.append(title, msg, addr, h('div', { className: 'actions lud16-sync-actions' }, [useBtn, dismiss]));
+    container.classList.remove('hidden');
   }
 
   // ---- rich about text: links + npub/nprofile mentions, with show more/less ----
@@ -5441,12 +5506,15 @@
         const canvas = document.createElement('canvas');
         canvas.className = 'recv-qr';
         try { new window.QRious({ element: canvas, value: 'lightning:' + lud16, size: 220, level: 'M' }); } catch (_) {}
-        const copy = h('button', { className: 'secondary', textContent: lud16 });
+        // Truncate to one line if it overflows — the full address is still copied.
+        const copy = h('button', { className: 'secondary recv-addr', title: 'Copy address' });
+        const addrText = h('span', { textContent: lud16 });
+        copy.append(addrText);
         copy.addEventListener('click', async () => {
           try {
             await navigator.clipboard.writeText(lud16);
-            copy.textContent = 'Copied ✓';
-            setTimeout(() => (copy.textContent = lud16), 1200);
+            addrText.textContent = 'Copied ✓';
+            setTimeout(() => (addrText.textContent = lud16), 1200);
           } catch (_) {}
         });
         out.append(canvas, copy, h('p', { className: 'hint', textContent: 'Your reusable lightning address — anyone can pay it any amount.' }));

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -53,6 +53,7 @@
     'eye-off': '<path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"></path><line x1="1" y1="1" x2="23" y2="23"></line>',
     pin: '<path d="M12 17v5"></path><path d="M9 10.76V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v6.76a2 2 0 0 0 .59 1.42l1.12 1.12A2 2 0 0 1 18 14.59V16a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1v-1.41a2 2 0 0 1 .29-1.29l1.12-1.12A2 2 0 0 0 9 10.76Z"></path>',
     bell: '<path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"></path><path d="M13.73 21a2 2 0 0 1-3.46 0"></path>',
+    qr: '<rect x="3" y="3" width="7" height="7" rx="1"></rect><rect x="14" y="3" width="7" height="7" rx="1"></rect><rect x="3" y="14" width="7" height="7" rx="1"></rect><path d="M14 14h3v3M21 14v7h-7v-3"></path>',
   };
   function icon(name) {
     const wrap = document.createElement('span');
@@ -1666,11 +1667,23 @@
     let timer = null;
     openModal(
       (modal) => {
-        // Scannable QR for QR sign-in on mobile clients (e.g. Wisp). nsec is
+        // Scannable QR for QR sign-in on mobile clients (e.g. Wisp). A QR exposes
+        // the full key at a glance, so keep it behind an explicit reveal — an
+        // opt-in backup option, not shown unprompted. Generated only on click, so
+        // the scannable image never exists on screen unless requested. nsec is
         // case-sensitive bech32, so encode it as-is (lowercase, byte mode).
-        const canvas = document.createElement('canvas');
-        canvas.className = 'recv-qr modal-qr';
-        try { new window.QRious({ element: canvas, value: opts.nsec, size: 220, level: 'M' }); } catch (_) {}
+        const qrBox = h('div', { className: 'qr-reveal' });
+        const qrHint = h('p', { className: 'hint hidden', textContent: 'Scan to sign in on a mobile client that supports QR login.' });
+        const showQr = h('button', { className: 'secondary qr-reveal-btn' }, [icon('qr'), h('span', { textContent: 'Show QR code' })]);
+        showQr.addEventListener('click', () => {
+          const canvas = document.createElement('canvas');
+          canvas.className = 'recv-qr modal-qr';
+          try { new window.QRious({ element: canvas, value: opts.nsec, size: 220, level: 'M' }); } catch (_) {}
+          qrBox.innerHTML = '';
+          qrBox.append(canvas);
+          qrHint.classList.remove('hidden');
+        });
+        qrBox.append(showQr);
 
         const box = h('div', { className: 'secret-box', textContent: opts.nsec });
         const copy = h('button', { className: 'secondary', textContent: 'Copy nsec' });
@@ -1694,10 +1707,10 @@
         modal.append(
           h('h3', { textContent: opts.title }),
           opts.intro ? h('p', { className: 'hint', textContent: opts.intro }) : document.createTextNode(''),
-          canvas,
-          h('p', { className: 'hint', textContent: 'Scan to sign in on a mobile client that supports QR login.' }),
           box,
           copy,
+          qrBox,
+          qrHint,
           h('p', { className: 'hint warn', textContent: 'Anyone with this key fully controls the account. Store it somewhere safe and never share it.' }),
           countdown,
           h('div', { className: 'actions' }, [done])
@@ -4587,6 +4600,30 @@
   const fmtSats = (n) => Math.round(n).toLocaleString('en-US');
   const msatToSat = (m) => Math.floor((m || 0) / 1000);
 
+  // Lightning address for receiving. Some NWC connection strings embed a `lud16`
+  // (the wallet's own address) — prefer that, then fall back to the account's
+  // profile lud16. Returns null when neither is present.
+  function parseNwcLud16(connection) {
+    try {
+      const q = connection.split('?')[1];
+      if (!q) return null;
+      const v = new URLSearchParams(q).get('lud16');
+      return v && v.includes('@') ? v.trim() : null;
+    } catch (_) { return null; }
+  }
+  async function getLightningAddress() {
+    try {
+      const { connection } = await call({ type: 'SIDECAR_GET_NWC' });
+      const fromNwc = connection && parseNwcLud16(connection);
+      if (fromNwc) return fromNwc;
+    } catch (_) {}
+    try {
+      const { content } = await fetchActiveProfile();
+      if (content && content.lud16) return content.lud16;
+    } catch (_) {}
+    return null;
+  }
+
   // Shared sats cap + a numeric-only, capped amount input used by send/receive/zap.
   const MAX_SATS = 100000000; // 100M
   function satsInput(placeholder) {
@@ -4749,6 +4786,45 @@
     recvBtn.addEventListener('click', () => receiveModal());
     actions.append(sendBtn, recvBtn);
     view.append(actions);
+
+    // Lightning address card (only if one is available). Shows the copyable
+    // address with a QR icon that toggles a scannable QR inline.
+    const addrCard = h('div', { className: 'setting address-card hidden' });
+    view.append(addrCard);
+    getLightningAddress().then((lud16) => {
+      if (!lud16) return;
+      const row = h('div', { className: 'address-row' });
+      const addr = h('button', { className: 'address-value', title: 'Copy address' }, [
+        boltIcon(), h('span', { textContent: lud16 }),
+      ]);
+      addr.addEventListener('click', async () => {
+        try {
+          await navigator.clipboard.writeText(lud16);
+          const s = addr.querySelector('span');
+          const prev = s.textContent;
+          s.textContent = 'Copied ✓';
+          setTimeout(() => (s.textContent = prev), 1200);
+        } catch (_) {}
+      });
+      const qrToggle = h('button', { className: 'address-qr-toggle', title: 'Show QR code' });
+      qrToggle.appendChild(icon('qr'));
+      const qrBox = h('div', { className: 'address-qr hidden' });
+      let built = false;
+      qrToggle.addEventListener('click', () => {
+        if (!built) {
+          built = true;
+          const canvas = document.createElement('canvas');
+          canvas.className = 'recv-qr';
+          try { new window.QRious({ element: canvas, value: 'lightning:' + lud16, size: 200, level: 'M' }); } catch (_) {}
+          qrBox.append(canvas);
+        }
+        const showing = qrBox.classList.toggle('hidden');
+        qrToggle.classList.toggle('active', !showing);
+      });
+      row.append(addr, qrToggle);
+      addrCard.append(h('h3', { textContent: 'Lightning address' }), row, qrBox);
+      addrCard.classList.remove('hidden');
+    });
 
     // Transactions
     const txWrap = h('div', { className: 'setting' });
@@ -5384,9 +5460,9 @@
       });
       showInvoiceMode();
 
-      // If the active account advertises a lightning address, add an Address tab.
-      fetchActiveProfile().then(({ content }) => {
-        const lud16 = content && content.lud16;
+      // If a lightning address is available (NWC string or profile), add an
+      // Address tab so the user can toggle between an invoice and their address.
+      getLightningAddress().then((lud16) => {
         if (!lud16) return;
         const tabAddress = h('button', { className: 'compose-tab', textContent: 'Address' });
         tabAddress.addEventListener('click', () => {

--- a/styles.css
+++ b/styles.css
@@ -190,6 +190,19 @@ input:focus, select:focus, textarea:focus {
   background: linear-gradient(180deg, #2a1257, #160a30); box-shadow: 0 0 0 1px var(--gold-soft);
 }
 .profile-avatar img { width: 100%; height: 100%; object-fit: cover; display: block; }
+/* profile ↔ wallet lightning-address sync prompt */
+.lud16-sync {
+  text-align: left; margin: 6px 0 14px; padding: 14px;
+  background: linear-gradient(180deg, var(--velvet-1), var(--velvet-2));
+  border: 1px solid var(--gold-soft); border-radius: 12px; box-shadow: var(--sheen);
+}
+.lud16-sync-title { display: flex; align-items: center; gap: 8px; margin-bottom: 6px; font-family: var(--font-display); font-weight: 700; font-size: 15px; color: var(--text); }
+.lud16-sync-title .lud16-sync-bolt { width: 16px; height: 16px; color: var(--gold); flex-shrink: 0; }
+.lud16-sync-msg { margin: 0 0 10px; font-size: 13px; line-height: 1.45; color: var(--text-2); }
+.lud16-sync-addr { font-family: var(--font-mono); font-size: 13px; color: var(--gold); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; margin-bottom: 12px; }
+.lud16-sync-actions { display: flex; flex-direction: row; gap: 8px; margin-top: 0; }
+.lud16-sync-actions .primary { flex: 1; }
+
 .profile-body .profile-edit-cta {
   display: inline-flex; align-items: center; justify-content: center; gap: 7px;
   width: auto; margin: 12px auto 0; padding: 8px 18px; border-radius: 999px;
@@ -1227,10 +1240,14 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
 .recv-out { display: flex; flex-direction: column; align-items: center; gap: 12px; margin-top: 16px; }
 .recv-qr { background: #fff; border-radius: 12px; padding: 10px; width: 220px; height: 220px; }
 .modal-qr { display: block; margin: 4px auto 2px; }
+/* receive lightning address: single line, truncates if it overflows (still copyable) */
+.recv-addr { width: 100%; }
+.recv-addr span { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
-/* opt-in QR reveal (nsec backup) */
-.qr-reveal { display: flex; justify-content: center; margin: 4px 0 2px; }
-.qr-reveal-btn { display: inline-flex; align-items: center; justify-content: center; gap: 7px; width: auto; }
+/* opt-in QR reveal (nsec backup) — button is a direct modal child so it
+   stretches to full width like "Copy nsec"; wrapper just centers the canvas. */
+.qr-reveal { display: flex; justify-content: center; margin: 2px 0; }
+.qr-reveal-btn { display: flex; align-items: center; justify-content: center; gap: 7px; }
 .qr-reveal-btn svg { width: 16px; height: 16px; }
 
 /* wallet lightning-address card */

--- a/styles.css
+++ b/styles.css
@@ -1227,6 +1227,31 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
 .recv-out { display: flex; flex-direction: column; align-items: center; gap: 12px; margin-top: 16px; }
 .recv-qr { background: #fff; border-radius: 12px; padding: 10px; width: 220px; height: 220px; }
 .modal-qr { display: block; margin: 4px auto 2px; }
+
+/* opt-in QR reveal (nsec backup) */
+.qr-reveal { display: flex; justify-content: center; margin: 4px 0 2px; }
+.qr-reveal-btn { display: inline-flex; align-items: center; justify-content: center; gap: 7px; width: auto; }
+.qr-reveal-btn svg { width: 16px; height: 16px; }
+
+/* wallet lightning-address card */
+.address-card { margin-top: 4px; }
+.address-row { display: flex; align-items: center; gap: 8px; }
+.address-value {
+  flex: 1; min-width: 0; display: inline-flex; align-items: center; gap: 8px;
+  background: linear-gradient(180deg, var(--velvet-1), var(--velvet-2));
+  border: 1px solid var(--border); border-radius: 10px; padding: 10px 12px;
+  color: var(--text); font-family: var(--font-mono); font-size: 13px; cursor: pointer;
+}
+.address-value span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.address-value:hover { border-color: var(--gold-soft); }
+.address-qr-toggle {
+  flex-shrink: 0; display: inline-flex; align-items: center; justify-content: center;
+  width: 40px; height: 40px; border-radius: 10px; cursor: pointer;
+  background: linear-gradient(180deg, var(--velvet-1), var(--velvet-2)); border: 1px solid var(--border); color: var(--muted);
+}
+.address-qr-toggle:hover, .address-qr-toggle.active { color: var(--lav); border-color: var(--gold-soft); }
+.address-qr-toggle svg { width: 18px; height: 18px; }
+.address-qr { display: flex; justify-content: center; margin-top: 12px; }
 .recv-bolt {
   font-family: var(--font-mono); font-size: 12px; color: var(--muted); text-align: center;
   padding: 7px 12px; border-radius: 8px; border: 1px solid var(--border);


### PR DESCRIPTION
Wallet/receiving and key-backup improvements for 1.2.0.

## Lightning address
- **Receive screen:** sources an address from the NWC connection string's `lud16` (preferred) or the profile `lud16`, offered as an **Address** tab (QR + copyable) alongside Invoice. Long addresses truncate to one line (still copy in full).
- **Wallet page:** a **Lightning address** card — copyable address with a QR icon that toggles a scannable QR inline. Hidden when no address is available.
- **Profile page:** when the connected wallet's address differs from (or is missing on) the profile, a card offers a one-tap sync — publishes `kind:0` with `lud16` set (additive, no other fields touched), no PIN re-prompt, session-dismissible.

## Opt-in nsec QR
- The scannable QR on the backup/reveal screen is now behind a **Show/Hide QR code** toggle, generated only on reveal — the full key isn't displayed unprompted. The nsec text remains the primary backup, and the toggle button matches the "Copy nsec" width.

## Under the hood
- Adds a `qr` icon glyph; reuses the shared profile cache from the bandwidth work.

🥂 Chilled with [Claude Code](https://claude.com/claude-code)