### PR TITLE
feat: auto-erase after 21 failed unlocks (Passport-style), with backoff

### DIFF
--- a/background.js
+++ b/background.js
@@ -766,8 +766,8 @@ chrome.contextMenus &&
 // by accident and offline brute force stays infeasible. Reset on any success.
 const MAX_UNLOCK_FAILS = 21;
 function unlockDelayMs(fails) {
-  if (fails < 5) return 0;                    // first 5 tries: no wait (fat-finger grace)
-  return Math.min(60000, (fails - 4) * 5000); // then 5s, 10s, … capped at 60s
+  if (fails < 10) return 0;                    // first 10 tries: no wait (generous typo grace)
+  return Math.min(60000, (fails - 9) * 5000);  // then 5s, 10s, … capped at 60s
 }
 async function loadUnlockGuard() {
   const g = (await sget('sidecar_unlock_guard')).sidecar_unlock_guard;

--- a/background.js
+++ b/background.js
@@ -757,6 +757,25 @@ chrome.contextMenus &&
 // ============================================================================
 // Keystore control messages (from side panel and prompt)
 // ============================================================================
+
+// ---- unlock throttle + auto-wipe guard ----
+// Persisted (survives service-worker death / browser restart), so an attacker
+// can't reset the counter by killing the worker. After MAX_UNLOCK_FAILS
+// consecutive bad PINs the keystore self-erases (Passport-style), with an
+// escalating delay between tries so a genuine user can't blow through the budget
+// by accident and offline brute force stays infeasible. Reset on any success.
+const MAX_UNLOCK_FAILS = 21;
+function unlockDelayMs(fails) {
+  if (fails < 5) return 0;                    // first 5 tries: no wait (fat-finger grace)
+  return Math.min(60000, (fails - 4) * 5000); // then 5s, 10s, … capped at 60s
+}
+async function loadUnlockGuard() {
+  const g = (await sget('sidecar_unlock_guard')).sidecar_unlock_guard;
+  return g && typeof g.fails === 'number' ? g : { fails: 0, lastAt: 0 };
+}
+const saveUnlockGuard = (g) => sset({ sidecar_unlock_guard: g });
+const clearUnlockGuard = () => new Promise((res) => chrome.storage.local.remove('sidecar_unlock_guard', res));
+
 async function lockKeystore() {
   await KS.lock();
   SIGNER.clearCache();
@@ -789,10 +808,36 @@ async function handleControl(message, sendResponse) {
         result = await KS.initialize(message.pin);
         bumpAutoLock();
         break;
-      case 'SIDECAR_UNLOCK':
-        result = await KS.unlock(message.pin);
-        bumpAutoLock();
+      case 'SIDECAR_UNLOCK': {
+        // Structured result (never throws for PIN/throttle/wipe) so the panel can
+        // show remaining attempts and a cooldown. Throttle + auto-wipe enforced
+        // here in the trusted context, not the UI.
+        const guard = await loadUnlockGuard();
+        const waitMs = unlockDelayMs(guard.fails) - (Date.now() - guard.lastAt);
+        if (waitMs > 0) {
+          result = { status: 'throttled', waitMs, remaining: MAX_UNLOCK_FAILS - guard.fails };
+          break;
+        }
+        try {
+          const state = await KS.unlock(message.pin);
+          await clearUnlockGuard();
+          bumpAutoLock();
+          result = { status: 'ok', state };
+        } catch (e) {
+          if (/not initialized/i.test(e.message || '')) { result = { status: 'error', error: e.message }; break; }
+          const fails = guard.fails + 1;
+          if (fails >= MAX_UNLOCK_FAILS) {
+            // Final strike: erase everything (in-memory + all persisted data).
+            await lockKeystore();
+            await new Promise((res) => chrome.storage.local.clear(() => res()));
+            result = { status: 'wiped' };
+          } else {
+            await saveUnlockGuard({ fails, lastAt: Date.now() });
+            result = { status: 'bad', remaining: MAX_UNLOCK_FAILS - fails, nextWaitMs: unlockDelayMs(fails) };
+          }
+        }
         break;
+      }
       case 'SIDECAR_LOCK':
         await lockKeystore();
         result = await KS.getState();

--- a/background.js
+++ b/background.js
@@ -809,9 +809,19 @@ async function handleControl(message, sendResponse) {
         bumpAutoLock();
         break;
       case 'SIDECAR_UNLOCK': {
-        // Structured result (never throws for PIN/throttle/wipe) so the panel can
-        // show remaining attempts and a cooldown. Throttle + auto-wipe enforced
-        // here in the trusted context, not the UI.
+        // CONTRACT: resolves { ok:true, result:{ status } } — it does NOT throw
+        // ok:false for a wrong PIN. `status` is one of:
+        //   'ok'        → unlocked; result.state is the keystore state
+        //   'bad'       → wrong PIN; result.remaining, result.nextWaitMs
+        //   'throttled' → in cooldown; result.waitMs, result.remaining
+        //   'wiped'     → 21st strike, all data erased
+        //   'error'     → unexpected (e.g. keystore not initialized); result.error
+        // Every caller must branch on result.status — NOT on the outer `ok`
+        // envelope (which is now always true). Callers:
+        //   • sidepanel.js  unlock-form submit handler
+        //   • sidepanel.js  approval submit (in-panel signing/pay prompt)
+        //   • prompt.js     approval popup submit
+        // Throttle + auto-wipe are enforced here (trusted context), not the UI.
         const guard = await loadUnlockGuard();
         const waitMs = unlockDelayMs(guard.fails) - (Date.now() - guard.lastAt);
         if (waitMs > 0) {

--- a/prompt.js
+++ b/prompt.js
@@ -175,6 +175,7 @@
         els.error.textContent = 'Enter your PIN.';
         return;
       }
+      // SIDECAR_UNLOCK contract (see background.js): branch on result.status, not ok.
       const unlocked = await send({ type: 'SIDECAR_UNLOCK', pin });
       const st = unlocked && unlocked.ok && unlocked.result;
       if (!st || st.status !== 'ok') {

--- a/prompt.js
+++ b/prompt.js
@@ -176,8 +176,13 @@
         return;
       }
       const unlocked = await send({ type: 'SIDECAR_UNLOCK', pin });
-      if (!unlocked || !unlocked.ok) {
-        els.error.textContent = (unlocked && unlocked.error) || 'Incorrect PIN';
+      const st = unlocked && unlocked.ok && unlocked.result;
+      if (!st || st.status !== 'ok') {
+        els.error.textContent =
+          st && st.status === 'throttled' ? 'Too many attempts. Try again in ' + Math.ceil(st.waitMs / 1000) + 's.'
+          : st && st.status === 'bad' ? 'Incorrect PIN — ' + st.remaining + ' attempt' + (st.remaining === 1 ? '' : 's') + ' left before all data is erased.'
+          : st && st.status === 'wiped' ? 'Too many attempts — all data on this device was erased.'
+          : (unlocked && unlocked.error) || 'Incorrect PIN';
         els.pin.value = '';
         els.pin.focus();
         return;

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -38,6 +38,7 @@
       <div class="error" id="unlock-error"></div>
       <button type="submit" class="primary">Unlock</button>
     </form>
+    <div id="unlock-cooldown" class="unlock-cooldown hidden"></div>
     <a href="#" id="unlock-forgot" class="unlock-forgot">Forgot your PIN?</a>
   </section>
 

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -38,6 +38,7 @@
       <div class="error" id="unlock-error"></div>
       <button type="submit" class="primary">Unlock</button>
     </form>
+    <a href="#" id="unlock-forgot" class="unlock-forgot">Forgot your PIN?</a>
   </section>
 
   <!-- ===== Main app (unlocked) ===== -->

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -321,20 +321,110 @@
   });
 
   // ---- unlock ----
+  // Unlock guard UI: show remaining attempts before the keystore self-erases and
+  // enforce the same cooldown the background does (defense in depth is server-side;
+  // this is just feedback). The <8-attempt window turns the warning urgent.
+  let unlockCooldownTimer = null;
+  function showUnlockRemaining(remaining) {
+    const err = $('unlock-error');
+    err.classList.toggle('unlock-danger', remaining <= 5);
+    err.textContent = 'Incorrect PIN — ' + remaining + ' attempt' + (remaining === 1 ? '' : 's') +
+      ' left before all data on this device is erased.';
+  }
+  function startUnlockCooldown(ms, remaining, keepRemaining) {
+    const err = $('unlock-error');
+    const btn = $('unlock-form').querySelector('button[type=submit]');
+    const pin = $('unlock-pin');
+    if (unlockCooldownTimer) clearInterval(unlockCooldownTimer);
+    let left = Math.ceil(ms / 1000);
+    btn.disabled = true;
+    pin.disabled = true;
+    err.classList.toggle('unlock-danger', remaining != null && remaining <= 5);
+    const render = () => {
+      const lead = keepRemaining && remaining != null
+        ? 'Incorrect PIN — ' + remaining + ' left. '
+        : 'Too many attempts. ';
+      err.textContent = lead + 'Try again in ' + left + 's.';
+    };
+    render();
+    unlockCooldownTimer = setInterval(() => {
+      left -= 1;
+      if (left > 0) return render();
+      clearInterval(unlockCooldownTimer);
+      unlockCooldownTimer = null;
+      btn.disabled = false;
+      pin.disabled = false;
+      if (keepRemaining && remaining != null) showUnlockRemaining(remaining);
+      else { err.textContent = ''; err.classList.remove('unlock-danger'); }
+      pin.focus();
+    }, 1000);
+  }
+
   $('unlock-form').addEventListener('submit', async (e) => {
     e.preventDefault();
     const err = $('unlock-error');
+    const pin = $('unlock-pin');
     err.textContent = '';
+    err.classList.remove('unlock-danger');
+    let r;
     try {
-      await call({ type: 'SIDECAR_UNLOCK', pin: $('unlock-pin').value });
-      $('unlock-pin').value = '';
-      await refresh();
-      toast('Unlocked', 'success');
-    } catch (e) {
-      err.textContent = e.message;
-      $('unlock-pin').value = '';
-      toast(e.message, 'error');
+      r = await call({ type: 'SIDECAR_UNLOCK', pin: pin.value });
+    } catch (ex) {
+      err.textContent = ex.message;
+      return;
     }
+    pin.value = '';
+    if (r.status === 'ok') { await refresh(); toast('Unlocked', 'success'); return; }
+    if (r.status === 'wiped') { await refresh(); toast('Too many attempts — all data erased', 'error'); return; }
+    if (r.status === 'throttled') { startUnlockCooldown(r.waitMs, r.remaining, false); return; }
+    if (r.status === 'bad') {
+      showUnlockRemaining(r.remaining);
+      if (r.nextWaitMs > 0) startUnlockCooldown(r.nextWaitMs, r.remaining, true);
+      return;
+    }
+    err.textContent = r.error || 'Could not unlock';
+  });
+
+  // Locked out (forgot PIN): let the user erase everything and start over, with a
+  // type-to-confirm so it can't happen by accident.
+  $('unlock-forgot').addEventListener('click', (e) => {
+    e.preventDefault();
+    openModal((modal) => {
+      const err = h('div', { className: 'error' });
+      const warn = h('p', {
+        className: 'hint',
+        textContent:
+          "If you've lost your PIN there is no way to recover it. You can erase everything and start fresh — all accounts and private keys, wallet connections, permissions, and settings on this device are gone for good. Any account without a backed-up nsec cannot be recovered.",
+      });
+      const confirmInput = h('input', { type: 'text', placeholder: 'Type ERASE to confirm' });
+      const del = h('button', { className: 'danger', textContent: 'Erase everything' });
+      del.disabled = true;
+      const matches = () => confirmInput.value.trim().toUpperCase() === 'ERASE';
+      confirmInput.addEventListener('input', () => { del.disabled = !matches(); });
+      del.addEventListener('click', async () => {
+        if (!matches()) return;
+        try {
+          await call({ type: 'SIDECAR_RESET_ALL' });
+          closeModal();
+          await refresh(); // no keystore now → onboarding
+          toast('Sidecar erased', 'success');
+        } catch (ex) {
+          err.textContent = ex.message;
+          toast(ex.message, 'error');
+        }
+      });
+      const cancel = h('button', { className: 'ghost', textContent: 'Cancel' });
+      cancel.addEventListener('click', closeModal);
+      modal.append(
+        h('h3', { textContent: 'Forgot your PIN?' }),
+        warn,
+        h('label', { textContent: 'Confirm' }),
+        confirmInput,
+        err,
+        h('div', { className: 'actions' }, [del, cancel])
+      );
+      setTimeout(() => confirmInput.focus(), 50);
+    });
   });
 
   // ---- lock ----

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -325,11 +325,26 @@
   // enforce the same cooldown the background does (defense in depth is server-side;
   // this is just feedback). The <8-attempt window turns the warning urgent.
   let unlockCooldownTimer = null;
+  // A refined "attempts remaining" notice — the count set in the display face with
+  // a gold accent that turns red as the auto-erase threshold nears.
+  function unlockNotice(remaining) {
+    const low = remaining != null && remaining <= 5;
+    const note = h('div', { className: 'unlock-note' + (low ? ' unlock-danger' : '') });
+    note.append(h('div', { className: 'unlock-note-title', textContent: 'Incorrect PIN' }));
+    if (remaining != null) {
+      note.append(h('div', { className: 'unlock-note-sub' }, [
+        h('span', { className: 'unlock-note-count', textContent: String(remaining) }),
+        document.createTextNode((remaining === 1 ? ' attempt' : ' attempts') + ' left before this device erases'),
+      ]));
+    }
+    return note;
+  }
   function showUnlockRemaining(remaining) {
-    const err = $('unlock-error');
-    err.classList.toggle('unlock-danger', remaining <= 5);
-    err.textContent = 'Incorrect PIN — ' + remaining + ' attempt' + (remaining === 1 ? '' : 's') +
-      ' left before all data on this device is erased.';
+    const box = $('unlock-cooldown');
+    $('unlock-error').textContent = '';
+    box.innerHTML = '';
+    box.append(unlockNotice(remaining));
+    box.classList.remove('hidden');
   }
   function clearUnlockCooldown() {
     if (unlockCooldownTimer) { clearInterval(unlockCooldownTimer); unlockCooldownTimer = null; }
@@ -360,12 +375,9 @@
       '<circle cx="36" cy="36" r="' + R + '" class="ring-fill" stroke-dasharray="' + C + '" stroke-dashoffset="0" transform="rotate(-90 36 36)"/>';
     const num = h('div', { className: 'countdown-num', textContent: String(left) });
     const wrap = h('div', { className: 'countdown-wrap' }, [ring, num]);
-    const cap = h('div', { className: 'unlock-cooldown-cap' });
-    const low = remaining != null && remaining <= 5;
-    cap.classList.toggle('unlock-danger', low);
-    cap.textContent = keepRemaining && remaining != null
-      ? 'Too many attempts — ' + remaining + ' left before erase'
-      : 'Too many attempts';
+    const cap = remaining != null
+      ? unlockNotice(remaining)
+      : h('div', { className: 'unlock-note' }, [h('div', { className: 'unlock-note-title', textContent: 'Too many attempts' })]);
     box.innerHTML = '';
     box.append(wrap, cap);
     box.classList.remove('hidden');

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -368,6 +368,7 @@
     err.classList.remove('unlock-danger');
     let r;
     try {
+      // SIDECAR_UNLOCK contract (see background.js): branch on result.status.
       r = await call({ type: 'SIDECAR_UNLOCK', pin: pin.value });
     } catch (ex) {
       err.textContent = ex.message;
@@ -6143,6 +6144,7 @@
         err.textContent = 'Enter your PIN.';
         return;
       }
+      // SIDECAR_UNLOCK contract (see background.js): branch on result.status, not ok.
       const resp = await bg({ type: 'SIDECAR_UNLOCK', pin });
       const st = resp && resp.ok && resp.result;
       if (!st || st.status !== 'ok') {

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -331,32 +331,58 @@
     err.textContent = 'Incorrect PIN — ' + remaining + ' attempt' + (remaining === 1 ? '' : 's') +
       ' left before all data on this device is erased.';
   }
+  function clearUnlockCooldown() {
+    if (unlockCooldownTimer) { clearInterval(unlockCooldownTimer); unlockCooldownTimer = null; }
+    const box = $('unlock-cooldown');
+    box.classList.add('hidden');
+    box.innerHTML = '';
+  }
+  // A small, classy countdown ring (mirrors the composer's, scaled down) while the
+  // unlock is in cooldown — replaces the raw "try again in Ns" text.
   function startUnlockCooldown(ms, remaining, keepRemaining) {
     const err = $('unlock-error');
     const btn = $('unlock-form').querySelector('button[type=submit]');
     const pin = $('unlock-pin');
+    const box = $('unlock-cooldown');
     if (unlockCooldownTimer) clearInterval(unlockCooldownTimer);
-    let left = Math.ceil(ms / 1000);
+    err.textContent = '';
     btn.disabled = true;
     pin.disabled = true;
-    err.classList.toggle('unlock-danger', remaining != null && remaining <= 5);
-    const render = () => {
-      const lead = keepRemaining && remaining != null
-        ? 'Incorrect PIN — ' + remaining + ' left. '
-        : 'Too many attempts. ';
-      err.textContent = lead + 'Try again in ' + left + 's.';
-    };
-    render();
+
+    const total = Math.max(1, Math.ceil(ms / 1000));
+    let left = total;
+    const R = 30, C = 2 * Math.PI * R;
+    const ring = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    ring.setAttribute('viewBox', '0 0 72 72');
+    ring.setAttribute('class', 'countdown-ring');
+    ring.innerHTML =
+      '<circle cx="36" cy="36" r="' + R + '" class="ring-track"/>' +
+      '<circle cx="36" cy="36" r="' + R + '" class="ring-fill" stroke-dasharray="' + C + '" stroke-dashoffset="0" transform="rotate(-90 36 36)"/>';
+    const num = h('div', { className: 'countdown-num', textContent: String(left) });
+    const wrap = h('div', { className: 'countdown-wrap' }, [ring, num]);
+    const cap = h('div', { className: 'unlock-cooldown-cap' });
+    const low = remaining != null && remaining <= 5;
+    cap.classList.toggle('unlock-danger', low);
+    cap.textContent = keepRemaining && remaining != null
+      ? 'Too many attempts — ' + remaining + ' left before erase'
+      : 'Too many attempts';
+    box.innerHTML = '';
+    box.append(wrap, cap);
+    box.classList.remove('hidden');
+    const fill = ring.querySelector('.ring-fill');
+
     unlockCooldownTimer = setInterval(() => {
       left -= 1;
-      if (left > 0) return render();
-      clearInterval(unlockCooldownTimer);
-      unlockCooldownTimer = null;
-      btn.disabled = false;
-      pin.disabled = false;
-      if (keepRemaining && remaining != null) showUnlockRemaining(remaining);
-      else { err.textContent = ''; err.classList.remove('unlock-danger'); }
-      pin.focus();
+      if (left <= 0) {
+        clearUnlockCooldown();
+        btn.disabled = false;
+        pin.disabled = false;
+        if (keepRemaining && remaining != null) showUnlockRemaining(remaining);
+        pin.focus();
+        return;
+      }
+      num.textContent = String(left);
+      fill.setAttribute('stroke-dashoffset', String(C * (1 - left / total)));
     }, 1000);
   }
 
@@ -375,8 +401,8 @@
       return;
     }
     pin.value = '';
-    if (r.status === 'ok') { await refresh(); toast('Unlocked', 'success'); return; }
-    if (r.status === 'wiped') { await refresh(); toast('Too many attempts — all data erased', 'error'); return; }
+    if (r.status === 'ok') { clearUnlockCooldown(); await refresh(); toast('Unlocked', 'success'); return; }
+    if (r.status === 'wiped') { clearUnlockCooldown(); await refresh(); toast('Too many attempts — all data erased', 'error'); return; }
     if (r.status === 'throttled') { startUnlockCooldown(r.waitMs, r.remaining, false); return; }
     if (r.status === 'bad') {
       showUnlockRemaining(r.remaining);

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -6144,8 +6144,13 @@
         return;
       }
       const resp = await bg({ type: 'SIDECAR_UNLOCK', pin });
-      if (!resp || !resp.ok) {
-        err.textContent = (resp && resp.error) || 'Incorrect PIN';
+      const st = resp && resp.ok && resp.result;
+      if (!st || st.status !== 'ok') {
+        err.textContent =
+          st && st.status === 'throttled' ? 'Too many attempts. Try again in ' + Math.ceil(st.waitMs / 1000) + 's.'
+          : st && st.status === 'bad' ? 'Incorrect PIN — ' + st.remaining + ' attempt' + (st.remaining === 1 ? '' : 's') + ' left before all data is erased.'
+          : st && st.status === 'wiped' ? 'Too many attempts — all data on this device was erased.'
+          : (resp && resp.error) || 'Incorrect PIN';
         $('approval-pin').value = '';
         $('approval-pin').focus();
         return;

--- a/styles.css
+++ b/styles.css
@@ -290,7 +290,7 @@ input:focus, select:focus, textarea:focus {
 .error:empty { display: none; }
 /* urgent unlock warning as failed attempts near the auto-erase threshold */
 .error.unlock-danger { font-weight: 700; }
-.unlock-forgot { display: inline-block; margin-top: 16px; font-size: 13px; color: var(--muted); text-decoration: none; }
+.unlock-forgot { align-self: center; margin-top: 16px; font-size: 13px; color: var(--muted); text-decoration: none; text-align: center; }
 .unlock-forgot:hover { color: var(--lav); text-decoration: underline; }
 /* unlock cooldown: a small countdown ring (same style as the composer's, scaled down) */
 .unlock-cooldown { display: flex; flex-direction: column; align-items: center; gap: 8px; margin-top: 16px; }

--- a/styles.css
+++ b/styles.css
@@ -297,8 +297,13 @@ input:focus, select:focus, textarea:focus {
 .unlock-cooldown .countdown-wrap { width: 56px; height: 56px; margin: 0; }
 .unlock-cooldown .countdown-ring { width: 56px; height: 56px; }
 .unlock-cooldown .countdown-num { font-size: 18px; }
-.unlock-cooldown-cap { font-size: 12.5px; color: var(--muted); text-align: center; }
-.unlock-cooldown-cap.unlock-danger { color: var(--red); font-weight: 700; }
+/* refined attempts-remaining notice (used with and without the cooldown ring) */
+.unlock-note { text-align: center; }
+.unlock-note-title { font-family: var(--font-display); font-weight: 700; font-size: 15px; color: var(--text-2); }
+.unlock-note-sub { font-size: 12.5px; color: var(--muted); margin-top: 3px; }
+.unlock-note-count { font-family: var(--font-display); font-weight: 700; font-size: 16px; color: var(--gold); }
+.unlock-note.unlock-danger .unlock-note-title { color: var(--red); }
+.unlock-note.unlock-danger .unlock-note-count { color: var(--red); }
 
 /* ===== buttons ===== */
 button { cursor: pointer; }

--- a/styles.css
+++ b/styles.css
@@ -288,6 +288,10 @@ input:focus, select:focus, textarea:focus {
 
 .error { color: var(--red); font-size: 13px; min-height: 18px; margin: 4px 0; }
 .error:empty { display: none; }
+/* urgent unlock warning as failed attempts near the auto-erase threshold */
+.error.unlock-danger { font-weight: 700; }
+.unlock-forgot { display: inline-block; margin-top: 16px; font-size: 13px; color: var(--muted); text-decoration: none; }
+.unlock-forgot:hover { color: var(--lav); text-decoration: underline; }
 
 /* ===== buttons ===== */
 button { cursor: pointer; }

--- a/styles.css
+++ b/styles.css
@@ -292,6 +292,13 @@ input:focus, select:focus, textarea:focus {
 .error.unlock-danger { font-weight: 700; }
 .unlock-forgot { display: inline-block; margin-top: 16px; font-size: 13px; color: var(--muted); text-decoration: none; }
 .unlock-forgot:hover { color: var(--lav); text-decoration: underline; }
+/* unlock cooldown: a small countdown ring (same style as the composer's, scaled down) */
+.unlock-cooldown { display: flex; flex-direction: column; align-items: center; gap: 8px; margin-top: 16px; }
+.unlock-cooldown .countdown-wrap { width: 56px; height: 56px; margin: 0; }
+.unlock-cooldown .countdown-ring { width: 56px; height: 56px; }
+.unlock-cooldown .countdown-num { font-size: 18px; }
+.unlock-cooldown-cap { font-size: 12.5px; color: var(--muted); text-align: center; }
+.unlock-cooldown-cap.unlock-danger { color: var(--red); font-weight: 700; }
 
 /* ===== buttons ===== */
 button { cursor: pointer; }


### PR DESCRIPTION
Protects a lost/stolen device: too many wrong PINs and the keystore self-erases. Enforced in the trusted background context, not the UI.

## Behavior
- **Auto-erase at 21** consecutive wrong PINs — a persistent counter (survives service-worker death / restart) that a correct PIN resets to zero.
- **Escalating delay** — the first **10 tries are free** (typo grace), then 5s → 60s (capped) before each further attempt, so offline brute force is infeasible while a genuine mistype isn't punished. The 21-strike cap bounds it regardless.
- **Ample, classy warning** — the lock screen shows an *"Incorrect PIN — N attempts left before this device erases"* notice (Playfair display, gold count turning red as the threshold nears), and a small gold **countdown ring** during the cooldown (from the 11th attempt).
- **Lost-PIN escape hatch** — a centered **"Forgot your PIN?"** link lets a locked-out owner erase and start fresh, gated by a type-ERASE-to-confirm step.

## Safety / correctness
- `SIDECAR_UNLOCK` now returns a structured `{ status }` (ok / bad / throttled / wiped / error). All three callers (lock screen, in-panel approval, approval popup) were updated to branch on `status`, and the handler carries a documented **contract** naming its callers so this can't silently break again.
- Correct PINs of any length (incl. legacy 6-digit) unlock exactly as before — the wipe/throttle only ever triggers on *wrong* PINs.

🥃 Stirred with [Claude Code](https://claude.com/claude-code)