### PR TITLE
feat: share Sidecar with a friend + acknowledge Amber

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 **A Classy Nostr Signer.**
 
-> “If it’s a class war, you should be a classy warrior.” — Mos Def
-
 A NIP-07 Nostr signing extension that lives in your browser's side panel. Sidecar
 holds your keys locally — encrypted behind a PIN — and provides `window.nostr` to the
 web apps you use, so you can sign in and sign events across Nostr clients without
@@ -121,3 +119,7 @@ is killed (MV3 idles after ~30s), that map is cleared and the keystore re-locks.
 
 MIT. Bundled fonts are licensed under the SIL Open Font License (see `fonts/`).
 The `qrious` QR library is bundled for the wallet's receive flow.
+
+---
+
+> “If it’s a class war, you should be a classy warrior.” — Mos Def

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 **A Classy Nostr Signer.**
 
+> “If it’s a class war, you should be a classy warrior.” — Mos Def
+
 A NIP-07 Nostr signing extension that lives in your browser's side panel. Sidecar
 holds your keys locally — encrypted behind a PIN — and provides `window.nostr` to the
 web apps you use, so you can sign in and sign events across Nostr clients without
@@ -107,6 +109,7 @@ is killed (MV3 idles after ~30s), that map is cleared and the keystore re-locks.
 
 - Inspired by Nostr Build Shack by [Fishcake](https://github.com/fishcakeday) and [Clave](https://github.com/DocNR/clave) by [Doc](https://github.com/DocNR)
 - Standing on the shoulders of [nos2x](https://github.com/fiatjaf/nos2x) by [fiatjaf](https://github.com/fiatjaf) and the [Alby](https://github.com/getAlby/lightning-browser-extension) browser extension — the OG reliable browser signers most of Nostr grew up with
+- And [Amber](https://github.com/greenart7c3/Amber) by [greenart7c3](https://github.com/greenart7c3) — for showing how good a dedicated Nostr signer can feel on mobile
 - Global @-mention search is powered by the [nostrarchives-api](https://github.com/barrydeen/nostrarchives-api) by [barrydeen](https://github.com/barrydeen)
 
 ## Author

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -87,6 +87,7 @@
         </div>
         <div class="explore-link-wrap">
           <a class="explore-link" id="explore-apps-link" href="#">Explore Nostr apps →</a>
+          <a class="explore-link" id="share-sidecar-link" href="#">Share Sidecar with a friend →</a>
         </div>
       </div>
 
@@ -224,6 +225,12 @@
           <input type="text" id="relay-input" placeholder="wss://relay.example.com" />
           <button class="secondary" id="relay-add">Add</button>
         </div>
+      </div>
+
+      <div class="setting">
+        <h3>Share Sidecar</h3>
+        <p class="hint">Know someone who'd like a classy Nostr signer? Send them the link.</p>
+        <button class="secondary" id="share-sidecar-btn">Share with a friend</button>
       </div>
 
       <div class="setting">

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -87,7 +87,7 @@
         </div>
         <div class="explore-link-wrap">
           <a class="explore-link" id="explore-apps-link" href="#">Explore Nostr apps →</a>
-          <a class="explore-link" id="share-sidecar-link" href="#">Share Sidecar with a friend →</a>
+          <a class="explore-link share-link" id="share-sidecar-link" href="#"><span>Share Sidecar with a friend</span></a>
         </div>
       </div>
 
@@ -230,7 +230,7 @@
       <div class="setting">
         <h3>Share Sidecar</h3>
         <p class="hint">Know someone who'd like a classy Nostr signer? Send them the link.</p>
-        <button class="secondary" id="share-sidecar-btn">Share with a friend</button>
+        <button class="secondary" id="share-sidecar-btn"><span>Share with a friend</span></button>
       </div>
 
       <div class="setting">

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -1598,6 +1598,30 @@
     chrome.tabs.create({ url: chrome.runtime.getURL('welcome.html') });
   });
 
+  // Share Sidecar via the OS's native share sheet when available (Messages, Mail,
+  // AirDrop, …); fall back to copying the store link when Web Share isn't offered
+  // (e.g. desktop Linux). Wired to the Accounts footer link + the Settings button.
+  const SIDECAR_STORE_URL = 'https://chromewebstore.google.com/detail/sidecar-a-classy-nostr-si/moimlikilhheabdafocpmneehpblhiln';
+  async function shareSidecar() {
+    const shareData = {
+      title: 'Sidecar — A Classy Nostr Signer',
+      text: 'A classy Nostr signer with a built-in Lightning wallet, right in your browser side panel.',
+      url: SIDECAR_STORE_URL,
+    };
+    if (navigator.share && (!navigator.canShare || navigator.canShare(shareData))) {
+      try { await navigator.share(shareData); return; }
+      catch (e) { if (e && e.name === 'AbortError') return; } // dismissed → done; else fall through to copy
+    }
+    try {
+      await navigator.clipboard.writeText(SIDECAR_STORE_URL);
+      toast('Link copied — share it with a friend', 'success');
+    } catch (_) {
+      toast('Could not share', 'error');
+    }
+  }
+  $('share-sidecar-link').addEventListener('click', (e) => { e.preventDefault(); shareSidecar(); });
+  $('share-sidecar-btn').addEventListener('click', () => shareSidecar());
+
   // ---- first-post tip balloon (once per imported nsec) ----
   (function initFirstPostBalloon() {
     const balloon = $('first-post-balloon');

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -1608,7 +1608,7 @@
     // share targets use only the url and drop the message — embedding it keeps
     // the blurb + link together everywhere.
     const message = 'Sidecar — a classy Nostr signer right in your browser side panel.\n' + SIDECAR_STORE_URL;
-    const shareData = { title: 'Sidecar — A Classy Nostr Signer', text: message };
+    const shareData = { text: message };
     if (navigator.share && (!navigator.canShare || navigator.canShare(shareData))) {
       try { await navigator.share(shareData); return; }
       catch (e) { if (e && e.name === 'AbortError') return; } // dismissed → done; else fall through to copy

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -1604,19 +1604,18 @@
   // (e.g. desktop Linux). Wired to the Accounts footer link + the Settings button.
   const SIDECAR_STORE_URL = 'https://chromewebstore.google.com/detail/sidecar-a-classy-nostr-si/moimlikilhheabdafocpmneehpblhiln';
   async function shareSidecar() {
-    const shareData = {
-      title: 'Sidecar — A Classy Nostr Signer',
-      text: 'A classy Nostr signer with a built-in Lightning wallet, right in your browser side panel.',
-      url: SIDECAR_STORE_URL,
-    };
+    // Fold the link INTO the text (no separate `url` field): with both set, most
+    // share targets use only the url and drop the message — embedding it keeps
+    // the blurb + link together everywhere.
+    const message = 'Sidecar — a classy Nostr signer with a built-in Lightning wallet, right in your browser side panel.\n' + SIDECAR_STORE_URL;
+    const shareData = { title: 'Sidecar — A Classy Nostr Signer', text: message };
     if (navigator.share && (!navigator.canShare || navigator.canShare(shareData))) {
       try { await navigator.share(shareData); return; }
       catch (e) { if (e && e.name === 'AbortError') return; } // dismissed → done; else fall through to copy
     }
     try {
-      // Copy the blurb + link so a pasted share carries the same default message.
-      await navigator.clipboard.writeText(shareData.text + '\n' + SIDECAR_STORE_URL);
-      toast('Link copied — share it with a friend', 'success');
+      await navigator.clipboard.writeText(message);
+      toast('Message copied — share it with a friend', 'success');
     } catch (_) {
       toast('Could not share', 'error');
     }

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -1607,7 +1607,7 @@
     // Fold the link INTO the text (no separate `url` field): with both set, most
     // share targets use only the url and drop the message — embedding it keeps
     // the blurb + link together everywhere.
-    const message = 'Sidecar — a classy Nostr signer with a built-in Lightning wallet, right in your browser side panel.\n' + SIDECAR_STORE_URL;
+    const message = 'Sidecar — a classy Nostr signer right in your browser side panel.\n' + SIDECAR_STORE_URL;
     const shareData = { title: 'Sidecar — A Classy Nostr Signer', text: message };
     if (navigator.share && (!navigator.canShare || navigator.canShare(shareData))) {
       try { await navigator.share(shareData); return; }

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -54,6 +54,7 @@
     pin: '<path d="M12 17v5"></path><path d="M9 10.76V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v6.76a2 2 0 0 0 .59 1.42l1.12 1.12A2 2 0 0 1 18 14.59V16a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1v-1.41a2 2 0 0 1 .29-1.29l1.12-1.12A2 2 0 0 0 9 10.76Z"></path>',
     bell: '<path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"></path><path d="M13.73 21a2 2 0 0 1-3.46 0"></path>',
     qr: '<rect x="3" y="3" width="7" height="7" rx="1"></rect><rect x="14" y="3" width="7" height="7" rx="1"></rect><rect x="3" y="14" width="7" height="7" rx="1"></rect><path d="M14 14h3v3M21 14v7h-7v-3"></path>',
+    share: '<path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8"></path><polyline points="16 6 12 2 8 6"></polyline><line x1="12" y1="2" x2="12" y2="15"></line>',
   };
   function icon(name) {
     const wrap = document.createElement('span');
@@ -1613,14 +1614,19 @@
       catch (e) { if (e && e.name === 'AbortError') return; } // dismissed → done; else fall through to copy
     }
     try {
-      await navigator.clipboard.writeText(SIDECAR_STORE_URL);
+      // Copy the blurb + link so a pasted share carries the same default message.
+      await navigator.clipboard.writeText(shareData.text + '\n' + SIDECAR_STORE_URL);
       toast('Link copied — share it with a friend', 'success');
     } catch (_) {
       toast('Could not share', 'error');
     }
   }
-  $('share-sidecar-link').addEventListener('click', (e) => { e.preventDefault(); shareSidecar(); });
-  $('share-sidecar-btn').addEventListener('click', () => shareSidecar());
+  const shareLink = $('share-sidecar-link');
+  shareLink.prepend(icon('share'));
+  shareLink.addEventListener('click', (e) => { e.preventDefault(); shareSidecar(); });
+  const shareBtn = $('share-sidecar-btn');
+  shareBtn.prepend(icon('share'));
+  shareBtn.addEventListener('click', () => shareSidecar());
 
   // ---- first-post tip balloon (once per imported nsec) ----
   (function initFirstPostBalloon() {

--- a/styles.css
+++ b/styles.css
@@ -771,6 +771,10 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
 .explore-link-wrap { display: flex; flex-direction: column; gap: 8px; margin-top: 24px; padding: 0 4px; }
 .explore-link { font-size: 13px; color: var(--muted); text-decoration: none; text-align: center; display: block; }
 .explore-link:hover { color: var(--lav); }
+.explore-link.share-link { display: flex; align-items: center; justify-content: center; gap: 6px; }
+.share-link svg { width: 14px; height: 14px; }
+#share-sidecar-btn { display: inline-flex; align-items: center; justify-content: center; gap: 7px; }
+#share-sidecar-btn svg { width: 16px; height: 16px; }
 .first-post-balloon {
   position: absolute; bottom: 90px; right: 12px; z-index: 49;
   background: var(--amber); color: #1a0e08;


### PR DESCRIPTION
## Share Sidecar
- A `shareSidecar()` helper using the Web Share API (`navigator.share`) opens the OS's native share sheet, with a copy-to-clipboard fallback when Web Share isn't available (e.g. desktop Linux).
- Entry points: a **"Share Sidecar with a friend"** link (with a share icon) in the Accounts footer beside "Explore Nostr apps," and a **"Share Sidecar"** section in Settings.
- Shares a single one-line message with the store link folded in (no separate `url`/`title`), so the message actually prefills in Messages, Mail, WhatsApp, etc. — passing a separate `url` makes most targets drop the text.

## README
- Acknowledge [Amber](https://github.com/greenart7c3/Amber) by [greenart7c3](https://github.com/greenart7c3).
- Add a closing Mos Def epigraph at the foot of the README.

🍾 Popped with [Claude Code](https://claude.com/claude-code)