### PR TITLE
Reuse an open client tab when opening notes (optional)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,7 @@ is killed (MV3 idles after ~30s), that map is cleared and the keystore re-locks.
 ## Acknowledgments
 
 - Inspired by Nostr Build Shack by [Fishcake](https://github.com/fishcakeday) and [Clave](https://github.com/DocNR/clave) by [Doc](https://github.com/DocNR)
-- Standing on the shoulders of [nos2x](https://github.com/fiatjaf/nos2x) by [fiatjaf](https://github.com/fiatjaf) and the [Alby](https://github.com/getAlby/lightning-browser-extension) browser extension — the OG reliable browser signers most of Nostr grew up with
-- And [Amber](https://github.com/greenart7c3/Amber) by [greenart7c3](https://github.com/greenart7c3) — for showing how good a dedicated Nostr signer can feel on mobile
+- Standing on the shoulders of [nos2x](https://github.com/fiatjaf/nos2x) by [fiatjaf](https://github.com/fiatjaf), [Alby](https://github.com/getAlby/lightning-browser-extension) extension, and [Amber](https://github.com/greenart7c3/Amber) by [greenart7c3](https://github.com/greenart7c3) — the OG reliable signers most of Nostr grew up with
 - Global @-mention search is powered by the [nostrarchives-api](https://github.com/barrydeen/nostrarchives-api) by [barrydeen](https://github.com/barrydeen)
 
 ## Author

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -198,6 +198,7 @@
           <option value="zapcooking">zap.cooking</option>
           <option value="njump">njump</option>
         </select>
+        <label class="toggle-row"><input type="checkbox" id="reuse-tab-toggle" /> <span>Reuse an open client tab</span></label>
       </div>
 
       <div class="setting">

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -1240,6 +1240,16 @@
           })
         : h('div', { className: 'notif-item' + (isNew ? ' notif-new' : '') });
 
+      // Reuse an existing client tab on a plain left-click; leave modified clicks
+      // (cmd/ctrl/shift) to the anchor's default new-tab behavior.
+      if (linkTarget) {
+        item.addEventListener('click', (e) => {
+          if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+          e.preventDefault();
+          openInClient(linkTarget);
+        });
+      }
+
       // Top row: glyph · name (truncated) · time · arrow
       const right = h('div', { className: 'notif-top-right' }, [
         h('span', { className: 'notif-time', textContent: relativeTime(ev.created_at) }),
@@ -2905,6 +2915,27 @@
     const settings = await call({ type: 'SIDECAR_GET_SETTINGS' });
     const key = (settings && settings.defaultClient) || DEFAULT_CLIENT;
     return VIEW_CLIENTS[key] || VIEW_CLIENTS[DEFAULT_CLIENT];
+  }
+
+  // Open a client URL, reusing a tab already on that client's host when one is
+  // open (so a stream of notification taps navigates one tab instead of piling
+  // up new ones), and focusing its window. Falls back to a new tab. Reading tab
+  // URLs is covered by the existing host_permissions (https://*/*).
+  function openInClient(url) {
+    let host = null;
+    try { host = new URL(url).host; } catch (_) {}
+    if (!host || !(chrome.tabs && chrome.tabs.query)) { window.open(url, '_blank', 'noopener'); return; }
+    chrome.tabs.query({}, (tabs) => {
+      const match = (tabs || []).find((t) => {
+        try { return t.url && new URL(t.url).host === host; } catch (_) { return false; }
+      });
+      if (match) {
+        chrome.tabs.update(match.id, { active: true, url });
+        if (match.windowId != null) chrome.windows.update(match.windowId, { focused: true });
+      } else {
+        chrome.tabs.create({ url });
+      }
+    });
   }
 
   // Resolve a kind:0 display name for an npub (best-effort, for the About credit).

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -2008,6 +2008,7 @@
     const settings = await call({ type: 'SIDECAR_GET_SETTINGS' });
     $('autolock-select').value = String(settings.autoLockMinutes || 0);
     $('client-select').value = settings.defaultClient || DEFAULT_CLIENT;
+    $('reuse-tab-toggle').checked = settings.reuseClientTab !== false; // default on
     $('paybutton-toggle').checked = settings.showPayButton !== false; // default on
     $('clienttag-toggle').checked = settings.showClientTag !== false; // default on
     $('autozap-toggle').checked = settings.autoZap === true;
@@ -2917,14 +2918,17 @@
     return VIEW_CLIENTS[key] || VIEW_CLIENTS[DEFAULT_CLIENT];
   }
 
-  // Open a client URL, reusing a tab already on that client's host when one is
-  // open (so a stream of notification taps navigates one tab instead of piling
-  // up new ones), and focusing its window. Falls back to a new tab. Reading tab
-  // URLs is covered by the existing host_permissions (https://*/*).
-  function openInClient(url) {
+  // Open a client URL. When the "reuse open client tab" setting is on (default),
+  // navigate a tab already on that client's host and focus its window instead of
+  // piling up new tabs; otherwise always open a new tab. Reading tab URLs is
+  // covered by the existing host_permissions (https://*/*).
+  async function openInClient(url) {
     let host = null;
     try { host = new URL(url).host; } catch (_) {}
-    if (!host || !(chrome.tabs && chrome.tabs.query)) { window.open(url, '_blank', 'noopener'); return; }
+    let reuse = true;
+    try { const s = await call({ type: 'SIDECAR_GET_SETTINGS' }); reuse = s.reuseClientTab !== false; } catch (_) {}
+    if (!(chrome.tabs && chrome.tabs.query)) { window.open(url, '_blank', 'noopener'); return; }
+    if (!reuse || !host) { chrome.tabs.create({ url }); return; }
     chrome.tabs.query({}, (tabs) => {
       const match = (tabs || []).find((t) => {
         try { return t.url && new URL(t.url).host === host; } catch (_) { return false; }
@@ -5984,6 +5988,10 @@
 
   $('client-select').addEventListener('change', async (e) => {
     await call({ type: 'SIDECAR_SET_SETTINGS', settings: { defaultClient: e.target.value } });
+  });
+
+  $('reuse-tab-toggle').addEventListener('change', async (e) => {
+    await call({ type: 'SIDECAR_SET_SETTINGS', settings: { reuseClientTab: e.target.checked } });
   });
 
   $('paybutton-toggle').addEventListener('change', async (e) => {


### PR DESCRIPTION
When you tap a stream of notifications, each note used to spawn a new tab — quickly piling up windows. Now Sidecar can navigate an **already-open client tab** to the note and focus its window instead.

## What's included
- **Tab reuse** — a plain left-click on a notification finds a tab already on your chosen client's host, navigates it to the note, and focuses its window. A new tab opens only when no matching tab exists.
- **Modifier clicks preserved** — Cmd/Ctrl/Shift/middle-click still open a new tab, so the "open in new tab" habit keeps working.
- **Optional setting** — a **Reuse an open client tab** toggle under **Settings → Open notes in** (default on). Off = always open a new tab.
- **No new permission** — reading tab URLs is already covered by the existing `host_permissions` (`https://*/*`); no manifest change.
- **Docs** — consolidated the nos2x / Alby / Amber acknowledgment into a single line.

## Test
1. Open your client (e.g. Jumble); tap several notifications → they reuse/navigate one tab and bring its window forward.
2. Close all client tabs, tap a notification → one new tab opens.
3. Cmd/middle-click a notification → new tab, as before.
4. Toggle the setting off → every tap opens a fresh tab. Reload the panel → setting persists.

🥃 Poured with [Claude Code](https://claude.com/claude-code)