### PR TITLE
Add an opt-in dev build indicator

### DIFF
--- a/sidepanel.html
+++ b/sidepanel.html
@@ -241,6 +241,12 @@
         <p class="hint" id="check-update-status"></p>
       </div>
 
+      <div class="setting hidden" id="dev-settings-section">
+        <h3>Developer</h3>
+        <p class="hint">Local build only — this section is hidden on the Chrome Web Store version.</p>
+        <label class="toggle-row"><input type="checkbox" id="dev-indicator-toggle" /> <span>Show dev build indicator</span></label>
+      </div>
+
       <div class="setting">
         <h3>Change PIN</h3>
         <button class="secondary" id="change-pin-btn">Change PIN…</button>
@@ -299,6 +305,9 @@
 
   <!-- ===== Toast host ===== -->
   <div id="toasts" class="toasts"></div>
+
+  <!-- ===== Dev build indicator (local/unpacked builds only, opt-in via Settings) ===== -->
+  <button id="dev-badge" class="dev-badge hidden" title="Sidecar dev build"></button>
 
   <script src="nostr-tools.js"></script>
   <script src="qrious.min.js"></script>

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -174,6 +174,7 @@
       t.classList.remove('show');
       setTimeout(() => t.remove(), 250);
     }, 3200);
+    return t;
   }
 
   // ---- nsec paste guard ----
@@ -6359,8 +6360,10 @@
     if (!isDevBuild()) return; // belt-and-suspenders: never show on a store build
     $('dev-badge').classList.toggle('hidden', !on);
   }
+  let devBadgeToast = null;
   $('dev-badge').addEventListener('click', () => {
-    toast('Debug panel coming soon.', 'success');
+    if (devBadgeToast && devBadgeToast.isConnected) devBadgeToast.remove();
+    devBadgeToast = toast('Debug panel coming soon.', 'success');
   });
   $('dev-badge').appendChild(icon('bug'));
 

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -6340,15 +6340,16 @@
   connectApprovalPort();
 
   // ---- dev build indicator ----
-  // Local/unpacked builds only (see isDevBuild). Off by default even in dev, so it
-  // only appears when explicitly toggled on for screenshots/testing — never on the
-  // Chrome Web Store build, regardless of a stored setting.
+  // Local/unpacked builds only (see isDevBuild). On by default in dev so it's
+  // immediately obvious which build is loaded; the toggle lets it be hidden for
+  // clean screenshots. Never appears on the Chrome Web Store build, regardless of
+  // a stored setting.
   async function initDevBadge() {
     if (!isDevBuild()) return;
     show($('dev-settings-section'));
     const settings = await call({ type: 'SIDECAR_GET_SETTINGS' });
-    $('dev-indicator-toggle').checked = settings.devIndicator === true;
-    applyDevBadge(settings.devIndicator === true);
+    $('dev-indicator-toggle').checked = settings.devIndicator !== false;
+    applyDevBadge(settings.devIndicator !== false);
     $('dev-indicator-toggle').addEventListener('change', async (e) => {
       await call({ type: 'SIDECAR_SET_SETTINGS', settings: { devIndicator: e.target.checked } });
       applyDevBadge(e.target.checked);

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -55,6 +55,7 @@
     bell: '<path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"></path><path d="M13.73 21a2 2 0 0 1-3.46 0"></path>',
     qr: '<rect x="3" y="3" width="7" height="7" rx="1"></rect><rect x="14" y="3" width="7" height="7" rx="1"></rect><rect x="3" y="14" width="7" height="7" rx="1"></rect><path d="M14 14h3v3M21 14v7h-7v-3"></path>',
     share: '<path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8"></path><polyline points="16 6 12 2 8 6"></polyline><line x1="12" y1="2" x2="12" y2="15"></line>',
+    bug: '<path d="m8 2 1.88 1.88"></path><path d="M14.12 3.88 16 2"></path><path d="M9 7.13v-1a3.003 3.003 0 1 1 6 0v1"></path><path d="M12 20c-3.3 0-6-2.7-6-6v-3a4 4 0 0 1 4-4h4a4 4 0 0 1 4 4v3c0 3.3-2.7 6-6 6"></path><path d="M12 20v-9"></path><path d="M6.53 9C4.6 8.8 3 7.1 3 5"></path><path d="M6 13H2"></path><path d="M3 21c0-2.1 1.7-3.9 3.8-4"></path><path d="M20.97 5c0 2.1-1.6 3.8-3.5 4"></path><path d="M22 13h-4"></path><path d="M17.2 17c2.1.1 3.8 1.9 3.8 4"></path>',
   };
   function icon(name) {
     const wrap = document.createElement('span');
@@ -63,6 +64,14 @@
       (ICONS[name] || '') +
       '</svg>';
     return wrap.firstElementChild;
+  }
+
+  // Chrome only adds `update_url` to the manifest object for extensions installed
+  // from the Web Store (or with a configured update URL) — never for an unpacked
+  // load. That makes it a reliable, permission-free way to tell a local dev build
+  // apart from the shipped one, so dev-only UI never leaks into production.
+  function isDevBuild() {
+    try { return !chrome.runtime.getManifest().update_url; } catch (_) { return false; }
   }
 
   // Filled lightning bolt (from wordswithzaps' bolt-yellow.svg). Inherits color
@@ -6330,7 +6339,32 @@
   }
   connectApprovalPort();
 
+  // ---- dev build indicator ----
+  // Local/unpacked builds only (see isDevBuild). Off by default even in dev, so it
+  // only appears when explicitly toggled on for screenshots/testing — never on the
+  // Chrome Web Store build, regardless of a stored setting.
+  async function initDevBadge() {
+    if (!isDevBuild()) return;
+    show($('dev-settings-section'));
+    const settings = await call({ type: 'SIDECAR_GET_SETTINGS' });
+    $('dev-indicator-toggle').checked = settings.devIndicator === true;
+    applyDevBadge(settings.devIndicator === true);
+    $('dev-indicator-toggle').addEventListener('change', async (e) => {
+      await call({ type: 'SIDECAR_SET_SETTINGS', settings: { devIndicator: e.target.checked } });
+      applyDevBadge(e.target.checked);
+    });
+  }
+  function applyDevBadge(on) {
+    if (!isDevBuild()) return; // belt-and-suspenders: never show on a store build
+    $('dev-badge').classList.toggle('hidden', !on);
+  }
+  $('dev-badge').addEventListener('click', () => {
+    toast('Debug panel coming soon.', 'success');
+  });
+  $('dev-badge').appendChild(icon('bug'));
+
   // ---- boot ----
   document.addEventListener('DOMContentLoaded', refresh);
   if (document.readyState !== 'loading') refresh();
+  initDevBadge();
 })();

--- a/styles.css
+++ b/styles.css
@@ -1428,6 +1428,27 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
 .menu-item.danger { color: var(--red); }
 .menu-item.danger svg { color: var(--red); }
 
+/* ===== dev build indicator ===== */
+.dev-badge {
+  position: fixed;
+  bottom: 12px;
+  left: 12px;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 1px solid var(--border-strong);
+  background: rgba(234, 119, 47, 0.16);
+  color: var(--orange);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 150;
+  padding: 0;
+}
+.dev-badge svg { width: 16px; height: 16px; }
+.dev-badge:hover { background: rgba(234, 119, 47, 0.28); }
+
 /* ===== toasts ===== */
 .toasts {
   position: fixed;


### PR DESCRIPTION
Local/unpacked builds and the Chrome Web Store build look identical today, which makes it easy to mix them up when testing or taking screenshots.

## What's included
- **Dev build badge** — a small bug-icon badge in the bottom-left corner, shown automatically on unpacked/dev builds (default on).
- **Settings → Developer** — a "Show dev build indicator" toggle to hide it for clean screenshots. This whole section only appears on a dev build.
- **Store-safe by construction** — gated by `chrome.runtime.getManifest().update_url`, which Chrome only sets for Web Store installs. No manifest change, no new permission.
- **Stub for a future debug panel** — clicking the badge currently just shows a toast ("Debug panel coming soon."); repeated clicks replace the toast instead of stacking it.

## Test
1. Load unpacked → the badge appears automatically without touching Settings.
2. Settings → Developer → toggle off → badge disappears; toggle on → reappears. Reload the panel → the choice persists.
3. Click the badge a few times quickly → only one toast shows at a time, refreshing instead of piling up.
4. This entire feature (badge + Settings section) is invisible in a build with an `update_url` in its manifest, i.e. the Chrome Web Store build.

🍹 Shaken with [Claude Code](https://claude.com/claude-code)