### PR TITLE
Import/export NIP-49 (ncryptsec) encrypted keys

### DIFF
--- a/nip49.js
+++ b/nip49.js
@@ -1,0 +1,1704 @@
+var SidecarNip49 = (() => {
+  var __defProp = Object.defineProperty;
+  var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+  var __getOwnPropNames = Object.getOwnPropertyNames;
+  var __hasOwnProp = Object.prototype.hasOwnProperty;
+  var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+  var __export = (target, all) => {
+    for (var name in all)
+      __defProp(target, name, { get: all[name], enumerable: true });
+  };
+  var __copyProps = (to, from, except, desc) => {
+    if (from && typeof from === "object" || typeof from === "function") {
+      for (let key of __getOwnPropNames(from))
+        if (!__hasOwnProp.call(to, key) && key !== except)
+          __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+    }
+    return to;
+  };
+  var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+  var __publicField = (obj, key, value) => __defNormalProp(obj, typeof key !== "symbol" ? key + "" : key, value);
+
+  // .nt-entry.mjs
+  var nt_entry_exports = {};
+  __export(nt_entry_exports, {
+    decrypt: () => decrypt,
+    encrypt: () => encrypt
+  });
+
+  // node_modules/@scure/base/index.js
+  function isBytes(a) {
+    return a instanceof Uint8Array || ArrayBuffer.isView(a) && a.constructor.name === "Uint8Array";
+  }
+  function isArrayOf(isString, arr) {
+    if (!Array.isArray(arr))
+      return false;
+    if (arr.length === 0)
+      return true;
+    if (isString) {
+      return arr.every((item) => typeof item === "string");
+    } else {
+      return arr.every((item) => Number.isSafeInteger(item));
+    }
+  }
+  function afn(input) {
+    if (typeof input !== "function")
+      throw new Error("function expected");
+    return true;
+  }
+  function astr(label, input) {
+    if (typeof input !== "string")
+      throw new Error(`${label}: string expected`);
+    return true;
+  }
+  function anumber(n) {
+    if (!Number.isSafeInteger(n))
+      throw new Error(`invalid integer: ${n}`);
+  }
+  function aArr(input) {
+    if (!Array.isArray(input))
+      throw new Error("array expected");
+  }
+  function astrArr(label, input) {
+    if (!isArrayOf(true, input))
+      throw new Error(`${label}: array of strings expected`);
+  }
+  function anumArr(label, input) {
+    if (!isArrayOf(false, input))
+      throw new Error(`${label}: array of numbers expected`);
+  }
+  // @__NO_SIDE_EFFECTS__
+  function chain(...args) {
+    const id = (a) => a;
+    const wrap = (a, b) => (c) => a(b(c));
+    const encode = args.map((x) => x.encode).reduceRight(wrap, id);
+    const decode = args.map((x) => x.decode).reduce(wrap, id);
+    return { encode, decode };
+  }
+  // @__NO_SIDE_EFFECTS__
+  function alphabet(letters) {
+    const lettersA = typeof letters === "string" ? letters.split("") : letters;
+    const len = lettersA.length;
+    astrArr("alphabet", lettersA);
+    const indexes = new Map(lettersA.map((l, i) => [l, i]));
+    return {
+      encode: (digits) => {
+        aArr(digits);
+        return digits.map((i) => {
+          if (!Number.isSafeInteger(i) || i < 0 || i >= len)
+            throw new Error(`alphabet.encode: digit index outside alphabet "${i}". Allowed: ${letters}`);
+          return lettersA[i];
+        });
+      },
+      decode: (input) => {
+        aArr(input);
+        return input.map((letter) => {
+          astr("alphabet.decode", letter);
+          const i = indexes.get(letter);
+          if (i === void 0)
+            throw new Error(`Unknown letter: "${letter}". Allowed: ${letters}`);
+          return i;
+        });
+      }
+    };
+  }
+  // @__NO_SIDE_EFFECTS__
+  function join(separator = "") {
+    astr("join", separator);
+    return {
+      encode: (from) => {
+        astrArr("join.decode", from);
+        return from.join(separator);
+      },
+      decode: (to) => {
+        astr("join.decode", to);
+        return to.split(separator);
+      }
+    };
+  }
+  var gcd = (a, b) => b === 0 ? a : gcd(b, a % b);
+  var radix2carry = /* @__NO_SIDE_EFFECTS__ */ (from, to) => from + (to - gcd(from, to));
+  var powers = /* @__PURE__ */ (() => {
+    let res = [];
+    for (let i = 0; i < 40; i++)
+      res.push(2 ** i);
+    return res;
+  })();
+  function convertRadix2(data, from, to, padding) {
+    aArr(data);
+    if (from <= 0 || from > 32)
+      throw new Error(`convertRadix2: wrong from=${from}`);
+    if (to <= 0 || to > 32)
+      throw new Error(`convertRadix2: wrong to=${to}`);
+    if (/* @__PURE__ */ radix2carry(from, to) > 32) {
+      throw new Error(`convertRadix2: carry overflow from=${from} to=${to} carryBits=${/* @__PURE__ */ radix2carry(from, to)}`);
+    }
+    let carry = 0;
+    let pos = 0;
+    const max = powers[from];
+    const mask = powers[to] - 1;
+    const res = [];
+    for (const n of data) {
+      anumber(n);
+      if (n >= max)
+        throw new Error(`convertRadix2: invalid data word=${n} from=${from}`);
+      carry = carry << from | n;
+      if (pos + from > 32)
+        throw new Error(`convertRadix2: carry overflow pos=${pos} from=${from}`);
+      pos += from;
+      for (; pos >= to; pos -= to)
+        res.push((carry >> pos - to & mask) >>> 0);
+      const pow = powers[pos];
+      if (pow === void 0)
+        throw new Error("invalid carry");
+      carry &= pow - 1;
+    }
+    carry = carry << to - pos & mask;
+    if (!padding && pos >= from)
+      throw new Error("Excess padding");
+    if (!padding && carry > 0)
+      throw new Error(`Non-zero padding: ${carry}`);
+    if (padding && pos > 0)
+      res.push(carry >>> 0);
+    return res;
+  }
+  // @__NO_SIDE_EFFECTS__
+  function radix2(bits, revPadding = false) {
+    anumber(bits);
+    if (bits <= 0 || bits > 32)
+      throw new Error("radix2: bits should be in (0..32]");
+    if (/* @__PURE__ */ radix2carry(8, bits) > 32 || /* @__PURE__ */ radix2carry(bits, 8) > 32)
+      throw new Error("radix2: carry overflow");
+    return {
+      encode: (bytes) => {
+        if (!isBytes(bytes))
+          throw new Error("radix2.encode input should be Uint8Array");
+        return convertRadix2(Array.from(bytes), 8, bits, !revPadding);
+      },
+      decode: (digits) => {
+        anumArr("radix2.decode", digits);
+        return Uint8Array.from(convertRadix2(digits, bits, 8, revPadding));
+      }
+    };
+  }
+  function unsafeWrapper(fn) {
+    afn(fn);
+    return function(...args) {
+      try {
+        return fn.apply(null, args);
+      } catch (e) {
+      }
+    };
+  }
+  var BECH_ALPHABET = /* @__PURE__ */ chain(/* @__PURE__ */ alphabet("qpzry9x8gf2tvdw0s3jn54khce6mua7l"), /* @__PURE__ */ join(""));
+  var POLYMOD_GENERATORS = [996825010, 642813549, 513874426, 1027748829, 705979059];
+  function bech32Polymod(pre) {
+    const b = pre >> 25;
+    let chk = (pre & 33554431) << 5;
+    for (let i = 0; i < POLYMOD_GENERATORS.length; i++) {
+      if ((b >> i & 1) === 1)
+        chk ^= POLYMOD_GENERATORS[i];
+    }
+    return chk;
+  }
+  function bechChecksum(prefix, words, encodingConst = 1) {
+    const len = prefix.length;
+    let chk = 1;
+    for (let i = 0; i < len; i++) {
+      const c = prefix.charCodeAt(i);
+      if (c < 33 || c > 126)
+        throw new Error(`Invalid prefix (${prefix})`);
+      chk = bech32Polymod(chk) ^ c >> 5;
+    }
+    chk = bech32Polymod(chk);
+    for (let i = 0; i < len; i++)
+      chk = bech32Polymod(chk) ^ prefix.charCodeAt(i) & 31;
+    for (let v of words)
+      chk = bech32Polymod(chk) ^ v;
+    for (let i = 0; i < 6; i++)
+      chk = bech32Polymod(chk);
+    chk ^= encodingConst;
+    return BECH_ALPHABET.encode(convertRadix2([chk % powers[30]], 30, 5, false));
+  }
+  // @__NO_SIDE_EFFECTS__
+  function genBech32(encoding) {
+    const ENCODING_CONST = encoding === "bech32" ? 1 : 734539939;
+    const _words = /* @__PURE__ */ radix2(5);
+    const fromWords = _words.decode;
+    const toWords = _words.encode;
+    const fromWordsUnsafe = unsafeWrapper(fromWords);
+    function encode(prefix, words, limit = 90) {
+      astr("bech32.encode prefix", prefix);
+      if (isBytes(words))
+        words = Array.from(words);
+      anumArr("bech32.encode", words);
+      const plen = prefix.length;
+      if (plen === 0)
+        throw new TypeError(`Invalid prefix length ${plen}`);
+      const actualLength = plen + 7 + words.length;
+      if (limit !== false && actualLength > limit)
+        throw new TypeError(`Length ${actualLength} exceeds limit ${limit}`);
+      const lowered = prefix.toLowerCase();
+      const sum = bechChecksum(lowered, words, ENCODING_CONST);
+      return `${lowered}1${BECH_ALPHABET.encode(words)}${sum}`;
+    }
+    function decode(str, limit = 90) {
+      astr("bech32.decode input", str);
+      const slen = str.length;
+      if (slen < 8 || limit !== false && slen > limit)
+        throw new TypeError(`invalid string length: ${slen} (${str}). Expected (8..${limit})`);
+      const lowered = str.toLowerCase();
+      if (str !== lowered && str !== str.toUpperCase())
+        throw new Error(`String must be lowercase or uppercase`);
+      const sepIndex = lowered.lastIndexOf("1");
+      if (sepIndex === 0 || sepIndex === -1)
+        throw new Error(`Letter "1" must be present between prefix and data only`);
+      const prefix = lowered.slice(0, sepIndex);
+      const data = lowered.slice(sepIndex + 1);
+      if (data.length < 6)
+        throw new Error("Data must be at least 6 characters long");
+      const words = BECH_ALPHABET.decode(data).slice(0, -6);
+      const sum = bechChecksum(prefix, words, ENCODING_CONST);
+      if (!data.endsWith(sum))
+        throw new Error(`Invalid checksum in ${str}: expected "${sum}"`);
+      return { prefix, words };
+    }
+    const decodeUnsafe = unsafeWrapper(decode);
+    function decodeToBytes(str) {
+      const { prefix, words } = decode(str, false);
+      return { prefix, words, bytes: fromWords(words) };
+    }
+    function encodeFromBytes(prefix, bytes) {
+      return encode(prefix, toWords(bytes));
+    }
+    return {
+      encode,
+      decode,
+      encodeFromBytes,
+      decodeToBytes,
+      decodeUnsafe,
+      fromWords,
+      fromWordsUnsafe,
+      toWords
+    };
+  }
+  var bech32 = /* @__PURE__ */ genBech32("bech32");
+
+  // node_modules/@noble/hashes/utils.js
+  function isBytes2(a) {
+    return a instanceof Uint8Array || ArrayBuffer.isView(a) && a.constructor.name === "Uint8Array";
+  }
+  function anumber2(n, title = "") {
+    if (!Number.isSafeInteger(n) || n < 0) {
+      const prefix = title && `"${title}" `;
+      throw new Error(`${prefix}expected integer >= 0, got ${n}`);
+    }
+  }
+  function abytes(value, length, title = "") {
+    const bytes = isBytes2(value);
+    const len = value?.length;
+    const needsLen = length !== void 0;
+    if (!bytes || needsLen && len !== length) {
+      const prefix = title && `"${title}" `;
+      const ofLen = needsLen ? ` of length ${length}` : "";
+      const got = bytes ? `length=${len}` : `type=${typeof value}`;
+      throw new Error(prefix + "expected Uint8Array" + ofLen + ", got " + got);
+    }
+    return value;
+  }
+  function ahash(h) {
+    if (typeof h !== "function" || typeof h.create !== "function")
+      throw new Error("Hash must wrapped by utils.createHasher");
+    anumber2(h.outputLen);
+    anumber2(h.blockLen);
+  }
+  function aexists(instance, checkFinished = true) {
+    if (instance.destroyed)
+      throw new Error("Hash instance has been destroyed");
+    if (checkFinished && instance.finished)
+      throw new Error("Hash#digest() has already been called");
+  }
+  function aoutput(out, instance) {
+    abytes(out, void 0, "digestInto() output");
+    const min = instance.outputLen;
+    if (out.length < min) {
+      throw new Error('"digestInto() output" expected to be of length >=' + min);
+    }
+  }
+  function u32(arr) {
+    return new Uint32Array(arr.buffer, arr.byteOffset, Math.floor(arr.byteLength / 4));
+  }
+  function clean(...arrays) {
+    for (let i = 0; i < arrays.length; i++) {
+      arrays[i].fill(0);
+    }
+  }
+  function createView(arr) {
+    return new DataView(arr.buffer, arr.byteOffset, arr.byteLength);
+  }
+  function rotr(word, shift) {
+    return word << 32 - shift | word >>> shift;
+  }
+  function rotl(word, shift) {
+    return word << shift | word >>> 32 - shift >>> 0;
+  }
+  var isLE = /* @__PURE__ */ (() => new Uint8Array(new Uint32Array([287454020]).buffer)[0] === 68)();
+  function byteSwap(word) {
+    return word << 24 & 4278190080 | word << 8 & 16711680 | word >>> 8 & 65280 | word >>> 24 & 255;
+  }
+  function byteSwap32(arr) {
+    for (let i = 0; i < arr.length; i++) {
+      arr[i] = byteSwap(arr[i]);
+    }
+    return arr;
+  }
+  var swap32IfBE = isLE ? (u) => u : byteSwap32;
+  function utf8ToBytes(str) {
+    if (typeof str !== "string")
+      throw new Error("string expected");
+    return new Uint8Array(new TextEncoder().encode(str));
+  }
+  function kdfInputToBytes(data, errorTitle = "") {
+    if (typeof data === "string")
+      return utf8ToBytes(data);
+    return abytes(data, void 0, errorTitle);
+  }
+  function concatBytes(...arrays) {
+    let sum = 0;
+    for (let i = 0; i < arrays.length; i++) {
+      const a = arrays[i];
+      abytes(a);
+      sum += a.length;
+    }
+    const res = new Uint8Array(sum);
+    for (let i = 0, pad = 0; i < arrays.length; i++) {
+      const a = arrays[i];
+      res.set(a, pad);
+      pad += a.length;
+    }
+    return res;
+  }
+  function checkOpts(defaults, opts) {
+    if (opts !== void 0 && {}.toString.call(opts) !== "[object Object]")
+      throw new Error("options must be object or undefined");
+    const merged = Object.assign(defaults, opts);
+    return merged;
+  }
+  function createHasher(hashCons, info = {}) {
+    const hashC = (msg, opts) => hashCons(opts).update(msg).digest();
+    const tmp = hashCons(void 0);
+    hashC.outputLen = tmp.outputLen;
+    hashC.blockLen = tmp.blockLen;
+    hashC.create = (opts) => hashCons(opts);
+    Object.assign(hashC, info);
+    return Object.freeze(hashC);
+  }
+  function randomBytes(bytesLength = 32) {
+    const cr = typeof globalThis === "object" ? globalThis.crypto : null;
+    if (typeof cr?.getRandomValues !== "function")
+      throw new Error("crypto.getRandomValues must be defined");
+    return cr.getRandomValues(new Uint8Array(bytesLength));
+  }
+  var oidNist = (suffix) => ({
+    oid: Uint8Array.from([6, 9, 96, 134, 72, 1, 101, 3, 4, 2, suffix])
+  });
+
+  // node_modules/@noble/hashes/hmac.js
+  var _HMAC = class {
+    constructor(hash, key) {
+      __publicField(this, "oHash");
+      __publicField(this, "iHash");
+      __publicField(this, "blockLen");
+      __publicField(this, "outputLen");
+      __publicField(this, "finished", false);
+      __publicField(this, "destroyed", false);
+      ahash(hash);
+      abytes(key, void 0, "key");
+      this.iHash = hash.create();
+      if (typeof this.iHash.update !== "function")
+        throw new Error("Expected instance of class which extends utils.Hash");
+      this.blockLen = this.iHash.blockLen;
+      this.outputLen = this.iHash.outputLen;
+      const blockLen = this.blockLen;
+      const pad = new Uint8Array(blockLen);
+      pad.set(key.length > blockLen ? hash.create().update(key).digest() : key);
+      for (let i = 0; i < pad.length; i++)
+        pad[i] ^= 54;
+      this.iHash.update(pad);
+      this.oHash = hash.create();
+      for (let i = 0; i < pad.length; i++)
+        pad[i] ^= 54 ^ 92;
+      this.oHash.update(pad);
+      clean(pad);
+    }
+    update(buf) {
+      aexists(this);
+      this.iHash.update(buf);
+      return this;
+    }
+    digestInto(out) {
+      aexists(this);
+      abytes(out, this.outputLen, "output");
+      this.finished = true;
+      this.iHash.digestInto(out);
+      this.oHash.update(out);
+      this.oHash.digestInto(out);
+      this.destroy();
+    }
+    digest() {
+      const out = new Uint8Array(this.oHash.outputLen);
+      this.digestInto(out);
+      return out;
+    }
+    _cloneInto(to) {
+      to || (to = Object.create(Object.getPrototypeOf(this), {}));
+      const { oHash, iHash, finished, destroyed, blockLen, outputLen } = this;
+      to = to;
+      to.finished = finished;
+      to.destroyed = destroyed;
+      to.blockLen = blockLen;
+      to.outputLen = outputLen;
+      to.oHash = oHash._cloneInto(to.oHash);
+      to.iHash = iHash._cloneInto(to.iHash);
+      return to;
+    }
+    clone() {
+      return this._cloneInto();
+    }
+    destroy() {
+      this.destroyed = true;
+      this.oHash.destroy();
+      this.iHash.destroy();
+    }
+  };
+  var hmac = (hash, key, message) => new _HMAC(hash, key).update(message).digest();
+  hmac.create = (hash, key) => new _HMAC(hash, key);
+
+  // node_modules/@noble/hashes/pbkdf2.js
+  function pbkdf2Init(hash, _password, _salt, _opts) {
+    ahash(hash);
+    const opts = checkOpts({ dkLen: 32, asyncTick: 10 }, _opts);
+    const { c, dkLen, asyncTick } = opts;
+    anumber2(c, "c");
+    anumber2(dkLen, "dkLen");
+    anumber2(asyncTick, "asyncTick");
+    if (c < 1)
+      throw new Error("iterations (c) must be >= 1");
+    const password = kdfInputToBytes(_password, "password");
+    const salt = kdfInputToBytes(_salt, "salt");
+    const DK = new Uint8Array(dkLen);
+    const PRF = hmac.create(hash, password);
+    const PRFSalt = PRF._cloneInto().update(salt);
+    return { c, dkLen, asyncTick, DK, PRF, PRFSalt };
+  }
+  function pbkdf2Output(PRF, PRFSalt, DK, prfW, u) {
+    PRF.destroy();
+    PRFSalt.destroy();
+    if (prfW)
+      prfW.destroy();
+    clean(u);
+    return DK;
+  }
+  function pbkdf2(hash, password, salt, opts) {
+    const { c, dkLen, DK, PRF, PRFSalt } = pbkdf2Init(hash, password, salt, opts);
+    let prfW;
+    const arr = new Uint8Array(4);
+    const view = createView(arr);
+    const u = new Uint8Array(PRF.outputLen);
+    for (let ti = 1, pos = 0; pos < dkLen; ti++, pos += PRF.outputLen) {
+      const Ti = DK.subarray(pos, pos + PRF.outputLen);
+      view.setInt32(0, ti, false);
+      (prfW = PRFSalt._cloneInto(prfW)).update(arr).digestInto(u);
+      Ti.set(u.subarray(0, Ti.length));
+      for (let ui = 1; ui < c; ui++) {
+        PRF._cloneInto(prfW).update(u).digestInto(u);
+        for (let i = 0; i < Ti.length; i++)
+          Ti[i] ^= u[i];
+      }
+    }
+    return pbkdf2Output(PRF, PRFSalt, DK, prfW, u);
+  }
+
+  // node_modules/@noble/hashes/_md.js
+  function Chi(a, b, c) {
+    return a & b ^ ~a & c;
+  }
+  function Maj(a, b, c) {
+    return a & b ^ a & c ^ b & c;
+  }
+  var HashMD = class {
+    constructor(blockLen, outputLen, padOffset, isLE3) {
+      __publicField(this, "blockLen");
+      __publicField(this, "outputLen");
+      __publicField(this, "padOffset");
+      __publicField(this, "isLE");
+      // For partial updates less than block size
+      __publicField(this, "buffer");
+      __publicField(this, "view");
+      __publicField(this, "finished", false);
+      __publicField(this, "length", 0);
+      __publicField(this, "pos", 0);
+      __publicField(this, "destroyed", false);
+      this.blockLen = blockLen;
+      this.outputLen = outputLen;
+      this.padOffset = padOffset;
+      this.isLE = isLE3;
+      this.buffer = new Uint8Array(blockLen);
+      this.view = createView(this.buffer);
+    }
+    update(data) {
+      aexists(this);
+      abytes(data);
+      const { view, buffer, blockLen } = this;
+      const len = data.length;
+      for (let pos = 0; pos < len; ) {
+        const take = Math.min(blockLen - this.pos, len - pos);
+        if (take === blockLen) {
+          const dataView = createView(data);
+          for (; blockLen <= len - pos; pos += blockLen)
+            this.process(dataView, pos);
+          continue;
+        }
+        buffer.set(data.subarray(pos, pos + take), this.pos);
+        this.pos += take;
+        pos += take;
+        if (this.pos === blockLen) {
+          this.process(view, 0);
+          this.pos = 0;
+        }
+      }
+      this.length += data.length;
+      this.roundClean();
+      return this;
+    }
+    digestInto(out) {
+      aexists(this);
+      aoutput(out, this);
+      this.finished = true;
+      const { buffer, view, blockLen, isLE: isLE3 } = this;
+      let { pos } = this;
+      buffer[pos++] = 128;
+      clean(this.buffer.subarray(pos));
+      if (this.padOffset > blockLen - pos) {
+        this.process(view, 0);
+        pos = 0;
+      }
+      for (let i = pos; i < blockLen; i++)
+        buffer[i] = 0;
+      view.setBigUint64(blockLen - 8, BigInt(this.length * 8), isLE3);
+      this.process(view, 0);
+      const oview = createView(out);
+      const len = this.outputLen;
+      if (len % 4)
+        throw new Error("_sha2: outputLen must be aligned to 32bit");
+      const outLen = len / 4;
+      const state = this.get();
+      if (outLen > state.length)
+        throw new Error("_sha2: outputLen bigger than state");
+      for (let i = 0; i < outLen; i++)
+        oview.setUint32(4 * i, state[i], isLE3);
+    }
+    digest() {
+      const { buffer, outputLen } = this;
+      this.digestInto(buffer);
+      const res = buffer.slice(0, outputLen);
+      this.destroy();
+      return res;
+    }
+    _cloneInto(to) {
+      to || (to = new this.constructor());
+      to.set(...this.get());
+      const { blockLen, buffer, length, finished, destroyed, pos } = this;
+      to.destroyed = destroyed;
+      to.finished = finished;
+      to.length = length;
+      to.pos = pos;
+      if (length % blockLen)
+        to.buffer.set(buffer);
+      return to;
+    }
+    clone() {
+      return this._cloneInto();
+    }
+  };
+  var SHA256_IV = /* @__PURE__ */ Uint32Array.from([
+    1779033703,
+    3144134277,
+    1013904242,
+    2773480762,
+    1359893119,
+    2600822924,
+    528734635,
+    1541459225
+  ]);
+
+  // node_modules/@noble/hashes/sha2.js
+  var SHA256_K = /* @__PURE__ */ Uint32Array.from([
+    1116352408,
+    1899447441,
+    3049323471,
+    3921009573,
+    961987163,
+    1508970993,
+    2453635748,
+    2870763221,
+    3624381080,
+    310598401,
+    607225278,
+    1426881987,
+    1925078388,
+    2162078206,
+    2614888103,
+    3248222580,
+    3835390401,
+    4022224774,
+    264347078,
+    604807628,
+    770255983,
+    1249150122,
+    1555081692,
+    1996064986,
+    2554220882,
+    2821834349,
+    2952996808,
+    3210313671,
+    3336571891,
+    3584528711,
+    113926993,
+    338241895,
+    666307205,
+    773529912,
+    1294757372,
+    1396182291,
+    1695183700,
+    1986661051,
+    2177026350,
+    2456956037,
+    2730485921,
+    2820302411,
+    3259730800,
+    3345764771,
+    3516065817,
+    3600352804,
+    4094571909,
+    275423344,
+    430227734,
+    506948616,
+    659060556,
+    883997877,
+    958139571,
+    1322822218,
+    1537002063,
+    1747873779,
+    1955562222,
+    2024104815,
+    2227730452,
+    2361852424,
+    2428436474,
+    2756734187,
+    3204031479,
+    3329325298
+  ]);
+  var SHA256_W = /* @__PURE__ */ new Uint32Array(64);
+  var SHA2_32B = class extends HashMD {
+    constructor(outputLen) {
+      super(64, outputLen, 8, false);
+    }
+    get() {
+      const { A, B, C, D, E, F, G, H } = this;
+      return [A, B, C, D, E, F, G, H];
+    }
+    // prettier-ignore
+    set(A, B, C, D, E, F, G, H) {
+      this.A = A | 0;
+      this.B = B | 0;
+      this.C = C | 0;
+      this.D = D | 0;
+      this.E = E | 0;
+      this.F = F | 0;
+      this.G = G | 0;
+      this.H = H | 0;
+    }
+    process(view, offset) {
+      for (let i = 0; i < 16; i++, offset += 4)
+        SHA256_W[i] = view.getUint32(offset, false);
+      for (let i = 16; i < 64; i++) {
+        const W15 = SHA256_W[i - 15];
+        const W2 = SHA256_W[i - 2];
+        const s0 = rotr(W15, 7) ^ rotr(W15, 18) ^ W15 >>> 3;
+        const s1 = rotr(W2, 17) ^ rotr(W2, 19) ^ W2 >>> 10;
+        SHA256_W[i] = s1 + SHA256_W[i - 7] + s0 + SHA256_W[i - 16] | 0;
+      }
+      let { A, B, C, D, E, F, G, H } = this;
+      for (let i = 0; i < 64; i++) {
+        const sigma1 = rotr(E, 6) ^ rotr(E, 11) ^ rotr(E, 25);
+        const T1 = H + sigma1 + Chi(E, F, G) + SHA256_K[i] + SHA256_W[i] | 0;
+        const sigma0 = rotr(A, 2) ^ rotr(A, 13) ^ rotr(A, 22);
+        const T2 = sigma0 + Maj(A, B, C) | 0;
+        H = G;
+        G = F;
+        F = E;
+        E = D + T1 | 0;
+        D = C;
+        C = B;
+        B = A;
+        A = T1 + T2 | 0;
+      }
+      A = A + this.A | 0;
+      B = B + this.B | 0;
+      C = C + this.C | 0;
+      D = D + this.D | 0;
+      E = E + this.E | 0;
+      F = F + this.F | 0;
+      G = G + this.G | 0;
+      H = H + this.H | 0;
+      this.set(A, B, C, D, E, F, G, H);
+    }
+    roundClean() {
+      clean(SHA256_W);
+    }
+    destroy() {
+      this.set(0, 0, 0, 0, 0, 0, 0, 0);
+      clean(this.buffer);
+    }
+  };
+  var _SHA256 = class extends SHA2_32B {
+    constructor() {
+      super(32);
+      // We cannot use array here since array allows indexing by variable
+      // which means optimizer/compiler cannot use registers.
+      __publicField(this, "A", SHA256_IV[0] | 0);
+      __publicField(this, "B", SHA256_IV[1] | 0);
+      __publicField(this, "C", SHA256_IV[2] | 0);
+      __publicField(this, "D", SHA256_IV[3] | 0);
+      __publicField(this, "E", SHA256_IV[4] | 0);
+      __publicField(this, "F", SHA256_IV[5] | 0);
+      __publicField(this, "G", SHA256_IV[6] | 0);
+      __publicField(this, "H", SHA256_IV[7] | 0);
+    }
+  };
+  var sha256 = /* @__PURE__ */ createHasher(
+    () => new _SHA256(),
+    /* @__PURE__ */ oidNist(1)
+  );
+
+  // node_modules/@noble/hashes/scrypt.js
+  function XorAndSalsa(prev, pi, input, ii, out, oi) {
+    let y00 = prev[pi++] ^ input[ii++], y01 = prev[pi++] ^ input[ii++];
+    let y02 = prev[pi++] ^ input[ii++], y03 = prev[pi++] ^ input[ii++];
+    let y04 = prev[pi++] ^ input[ii++], y05 = prev[pi++] ^ input[ii++];
+    let y06 = prev[pi++] ^ input[ii++], y07 = prev[pi++] ^ input[ii++];
+    let y08 = prev[pi++] ^ input[ii++], y09 = prev[pi++] ^ input[ii++];
+    let y10 = prev[pi++] ^ input[ii++], y11 = prev[pi++] ^ input[ii++];
+    let y12 = prev[pi++] ^ input[ii++], y13 = prev[pi++] ^ input[ii++];
+    let y14 = prev[pi++] ^ input[ii++], y15 = prev[pi++] ^ input[ii++];
+    let x00 = y00, x01 = y01, x02 = y02, x03 = y03, x04 = y04, x05 = y05, x06 = y06, x07 = y07, x08 = y08, x09 = y09, x10 = y10, x11 = y11, x12 = y12, x13 = y13, x14 = y14, x15 = y15;
+    for (let i = 0; i < 8; i += 2) {
+      x04 ^= rotl(x00 + x12 | 0, 7);
+      x08 ^= rotl(x04 + x00 | 0, 9);
+      x12 ^= rotl(x08 + x04 | 0, 13);
+      x00 ^= rotl(x12 + x08 | 0, 18);
+      x09 ^= rotl(x05 + x01 | 0, 7);
+      x13 ^= rotl(x09 + x05 | 0, 9);
+      x01 ^= rotl(x13 + x09 | 0, 13);
+      x05 ^= rotl(x01 + x13 | 0, 18);
+      x14 ^= rotl(x10 + x06 | 0, 7);
+      x02 ^= rotl(x14 + x10 | 0, 9);
+      x06 ^= rotl(x02 + x14 | 0, 13);
+      x10 ^= rotl(x06 + x02 | 0, 18);
+      x03 ^= rotl(x15 + x11 | 0, 7);
+      x07 ^= rotl(x03 + x15 | 0, 9);
+      x11 ^= rotl(x07 + x03 | 0, 13);
+      x15 ^= rotl(x11 + x07 | 0, 18);
+      x01 ^= rotl(x00 + x03 | 0, 7);
+      x02 ^= rotl(x01 + x00 | 0, 9);
+      x03 ^= rotl(x02 + x01 | 0, 13);
+      x00 ^= rotl(x03 + x02 | 0, 18);
+      x06 ^= rotl(x05 + x04 | 0, 7);
+      x07 ^= rotl(x06 + x05 | 0, 9);
+      x04 ^= rotl(x07 + x06 | 0, 13);
+      x05 ^= rotl(x04 + x07 | 0, 18);
+      x11 ^= rotl(x10 + x09 | 0, 7);
+      x08 ^= rotl(x11 + x10 | 0, 9);
+      x09 ^= rotl(x08 + x11 | 0, 13);
+      x10 ^= rotl(x09 + x08 | 0, 18);
+      x12 ^= rotl(x15 + x14 | 0, 7);
+      x13 ^= rotl(x12 + x15 | 0, 9);
+      x14 ^= rotl(x13 + x12 | 0, 13);
+      x15 ^= rotl(x14 + x13 | 0, 18);
+    }
+    out[oi++] = y00 + x00 | 0;
+    out[oi++] = y01 + x01 | 0;
+    out[oi++] = y02 + x02 | 0;
+    out[oi++] = y03 + x03 | 0;
+    out[oi++] = y04 + x04 | 0;
+    out[oi++] = y05 + x05 | 0;
+    out[oi++] = y06 + x06 | 0;
+    out[oi++] = y07 + x07 | 0;
+    out[oi++] = y08 + x08 | 0;
+    out[oi++] = y09 + x09 | 0;
+    out[oi++] = y10 + x10 | 0;
+    out[oi++] = y11 + x11 | 0;
+    out[oi++] = y12 + x12 | 0;
+    out[oi++] = y13 + x13 | 0;
+    out[oi++] = y14 + x14 | 0;
+    out[oi++] = y15 + x15 | 0;
+  }
+  function BlockMix(input, ii, out, oi, r) {
+    let head = oi + 0;
+    let tail = oi + 16 * r;
+    for (let i = 0; i < 16; i++)
+      out[tail + i] = input[ii + (2 * r - 1) * 16 + i];
+    for (let i = 0; i < r; i++, head += 16, ii += 16) {
+      XorAndSalsa(out, tail, input, ii, out, head);
+      if (i > 0)
+        tail += 16;
+      XorAndSalsa(out, head, input, ii += 16, out, tail);
+    }
+  }
+  function scryptInit(password, salt, _opts) {
+    const opts = checkOpts({
+      dkLen: 32,
+      asyncTick: 10,
+      maxmem: 1024 ** 3 + 1024
+    }, _opts);
+    const { N, r, p, dkLen, asyncTick, maxmem, onProgress } = opts;
+    anumber2(N, "N");
+    anumber2(r, "r");
+    anumber2(p, "p");
+    anumber2(dkLen, "dkLen");
+    anumber2(asyncTick, "asyncTick");
+    anumber2(maxmem, "maxmem");
+    if (onProgress !== void 0 && typeof onProgress !== "function")
+      throw new Error("progressCb must be a function");
+    const blockSize = 128 * r;
+    const blockSize32 = blockSize / 4;
+    const pow32 = Math.pow(2, 32);
+    if (N <= 1 || (N & N - 1) !== 0 || N > pow32)
+      throw new Error('"N" expected a power of 2, and 2^1 <= N <= 2^32');
+    if (p < 1 || p > (pow32 - 1) * 32 / blockSize)
+      throw new Error('"p" expected integer 1..((2^32 - 1) * 32) / (128 * r)');
+    if (dkLen < 1 || dkLen > (pow32 - 1) * 32)
+      throw new Error('"dkLen" expected integer 1..(2^32 - 1) * 32');
+    const memUsed = blockSize * (N + p);
+    if (memUsed > maxmem)
+      throw new Error('"maxmem" limit was hit, expected 128*r*(N+p) <= "maxmem"=' + maxmem);
+    const B = pbkdf2(sha256, password, salt, { c: 1, dkLen: blockSize * p });
+    const B32 = u32(B);
+    const V = u32(new Uint8Array(blockSize * N));
+    const tmp = u32(new Uint8Array(blockSize));
+    let blockMixCb = () => {
+    };
+    if (onProgress) {
+      const totalBlockMix = 2 * N * p;
+      const callbackPer = Math.max(Math.floor(totalBlockMix / 1e4), 1);
+      let blockMixCnt = 0;
+      blockMixCb = () => {
+        blockMixCnt++;
+        if (onProgress && (!(blockMixCnt % callbackPer) || blockMixCnt === totalBlockMix))
+          onProgress(blockMixCnt / totalBlockMix);
+      };
+    }
+    return { N, r, p, dkLen, blockSize32, V, B32, B, tmp, blockMixCb, asyncTick };
+  }
+  function scryptOutput(password, dkLen, B, V, tmp) {
+    const res = pbkdf2(sha256, password, B, { c: 1, dkLen });
+    clean(B, V, tmp);
+    return res;
+  }
+  function scrypt(password, salt, opts) {
+    const { N, r, p, dkLen, blockSize32, V, B32, B, tmp, blockMixCb } = scryptInit(password, salt, opts);
+    swap32IfBE(B32);
+    for (let pi = 0; pi < p; pi++) {
+      const Pi = blockSize32 * pi;
+      for (let i = 0; i < blockSize32; i++)
+        V[i] = B32[Pi + i];
+      for (let i = 0, pos = 0; i < N - 1; i++) {
+        BlockMix(V, pos, V, pos += blockSize32, r);
+        blockMixCb();
+      }
+      BlockMix(V, (N - 1) * blockSize32, B32, Pi, r);
+      blockMixCb();
+      for (let i = 0; i < N; i++) {
+        const j = (B32[Pi + blockSize32 - 16] & N - 1) >>> 0;
+        for (let k = 0; k < blockSize32; k++)
+          tmp[k] = B32[Pi + k] ^ V[j * blockSize32 + k];
+        BlockMix(tmp, 0, B32, Pi, r);
+        blockMixCb();
+      }
+    }
+    swap32IfBE(B32);
+    return scryptOutput(password, dkLen, B, V, tmp);
+  }
+
+  // node_modules/@noble/ciphers/utils.js
+  function isBytes3(a) {
+    return a instanceof Uint8Array || ArrayBuffer.isView(a) && a.constructor.name === "Uint8Array";
+  }
+  function abool(b) {
+    if (typeof b !== "boolean")
+      throw new Error(`boolean expected, not ${b}`);
+  }
+  function anumber3(n) {
+    if (!Number.isSafeInteger(n) || n < 0)
+      throw new Error("positive integer expected, got " + n);
+  }
+  function abytes2(value, length, title = "") {
+    const bytes = isBytes3(value);
+    const len = value?.length;
+    const needsLen = length !== void 0;
+    if (!bytes || needsLen && len !== length) {
+      const prefix = title && `"${title}" `;
+      const ofLen = needsLen ? ` of length ${length}` : "";
+      const got = bytes ? `length=${len}` : `type=${typeof value}`;
+      throw new Error(prefix + "expected Uint8Array" + ofLen + ", got " + got);
+    }
+    return value;
+  }
+  function aexists2(instance, checkFinished = true) {
+    if (instance.destroyed)
+      throw new Error("Hash instance has been destroyed");
+    if (checkFinished && instance.finished)
+      throw new Error("Hash#digest() has already been called");
+  }
+  function aoutput2(out, instance) {
+    abytes2(out, void 0, "output");
+    const min = instance.outputLen;
+    if (out.length < min) {
+      throw new Error("digestInto() expects output buffer of length at least " + min);
+    }
+  }
+  function u322(arr) {
+    return new Uint32Array(arr.buffer, arr.byteOffset, Math.floor(arr.byteLength / 4));
+  }
+  function clean2(...arrays) {
+    for (let i = 0; i < arrays.length; i++) {
+      arrays[i].fill(0);
+    }
+  }
+  function createView2(arr) {
+    return new DataView(arr.buffer, arr.byteOffset, arr.byteLength);
+  }
+  var isLE2 = /* @__PURE__ */ (() => new Uint8Array(new Uint32Array([287454020]).buffer)[0] === 68)();
+  function checkOpts2(defaults, opts) {
+    if (opts == null || typeof opts !== "object")
+      throw new Error("options must be defined");
+    const merged = Object.assign(defaults, opts);
+    return merged;
+  }
+  function equalBytes(a, b) {
+    if (a.length !== b.length)
+      return false;
+    let diff = 0;
+    for (let i = 0; i < a.length; i++)
+      diff |= a[i] ^ b[i];
+    return diff === 0;
+  }
+  var wrapCipher = /* @__NO_SIDE_EFFECTS__ */ (params, constructor) => {
+    function wrappedCipher(key, ...args) {
+      abytes2(key, void 0, "key");
+      if (!isLE2)
+        throw new Error("Non little-endian hardware is not yet supported");
+      if (params.nonceLength !== void 0) {
+        const nonce = args[0];
+        abytes2(nonce, params.varSizeNonce ? void 0 : params.nonceLength, "nonce");
+      }
+      const tagl = params.tagLength;
+      if (tagl && args[1] !== void 0)
+        abytes2(args[1], void 0, "AAD");
+      const cipher = constructor(key, ...args);
+      const checkOutput = (fnLength, output) => {
+        if (output !== void 0) {
+          if (fnLength !== 2)
+            throw new Error("cipher output not supported");
+          abytes2(output, void 0, "output");
+        }
+      };
+      let called = false;
+      const wrCipher = {
+        encrypt(data, output) {
+          if (called)
+            throw new Error("cannot encrypt() twice with same key + nonce");
+          called = true;
+          abytes2(data);
+          checkOutput(cipher.encrypt.length, output);
+          return cipher.encrypt(data, output);
+        },
+        decrypt(data, output) {
+          abytes2(data);
+          if (tagl && data.length < tagl)
+            throw new Error('"ciphertext" expected length bigger than tagLength=' + tagl);
+          checkOutput(cipher.decrypt.length, output);
+          return cipher.decrypt(data, output);
+        }
+      };
+      return wrCipher;
+    }
+    Object.assign(wrappedCipher, params);
+    return wrappedCipher;
+  };
+  function getOutput(expectedLength, out, onlyAligned = true) {
+    if (out === void 0)
+      return new Uint8Array(expectedLength);
+    if (out.length !== expectedLength)
+      throw new Error('"output" expected Uint8Array of length ' + expectedLength + ", got: " + out.length);
+    if (onlyAligned && !isAligned32(out))
+      throw new Error("invalid output, must be aligned");
+    return out;
+  }
+  function u64Lengths(dataLength, aadLength, isLE3) {
+    abool(isLE3);
+    const num = new Uint8Array(16);
+    const view = createView2(num);
+    view.setBigUint64(0, BigInt(aadLength), isLE3);
+    view.setBigUint64(8, BigInt(dataLength), isLE3);
+    return num;
+  }
+  function isAligned32(bytes) {
+    return bytes.byteOffset % 4 === 0;
+  }
+  function copyBytes(bytes) {
+    return Uint8Array.from(bytes);
+  }
+
+  // node_modules/@noble/ciphers/_arx.js
+  var encodeStr = (str) => Uint8Array.from(str.split(""), (c) => c.charCodeAt(0));
+  var sigma16 = encodeStr("expand 16-byte k");
+  var sigma32 = encodeStr("expand 32-byte k");
+  var sigma16_32 = u322(sigma16);
+  var sigma32_32 = u322(sigma32);
+  function rotl2(a, b) {
+    return a << b | a >>> 32 - b;
+  }
+  function isAligned322(b) {
+    return b.byteOffset % 4 === 0;
+  }
+  var BLOCK_LEN = 64;
+  var BLOCK_LEN32 = 16;
+  var MAX_COUNTER = 2 ** 32 - 1;
+  var U32_EMPTY = Uint32Array.of();
+  function runCipher(core, sigma, key, nonce, data, output, counter, rounds) {
+    const len = data.length;
+    const block = new Uint8Array(BLOCK_LEN);
+    const b32 = u322(block);
+    const isAligned = isAligned322(data) && isAligned322(output);
+    const d32 = isAligned ? u322(data) : U32_EMPTY;
+    const o32 = isAligned ? u322(output) : U32_EMPTY;
+    for (let pos = 0; pos < len; counter++) {
+      core(sigma, key, nonce, b32, counter, rounds);
+      if (counter >= MAX_COUNTER)
+        throw new Error("arx: counter overflow");
+      const take = Math.min(BLOCK_LEN, len - pos);
+      if (isAligned && take === BLOCK_LEN) {
+        const pos32 = pos / 4;
+        if (pos % 4 !== 0)
+          throw new Error("arx: invalid block position");
+        for (let j = 0, posj; j < BLOCK_LEN32; j++) {
+          posj = pos32 + j;
+          o32[posj] = d32[posj] ^ b32[j];
+        }
+        pos += BLOCK_LEN;
+        continue;
+      }
+      for (let j = 0, posj; j < take; j++) {
+        posj = pos + j;
+        output[posj] = data[posj] ^ block[j];
+      }
+      pos += take;
+    }
+  }
+  function createCipher(core, opts) {
+    const { allowShortKeys, extendNonceFn, counterLength, counterRight, rounds } = checkOpts2({ allowShortKeys: false, counterLength: 8, counterRight: false, rounds: 20 }, opts);
+    if (typeof core !== "function")
+      throw new Error("core must be a function");
+    anumber3(counterLength);
+    anumber3(rounds);
+    abool(counterRight);
+    abool(allowShortKeys);
+    return (key, nonce, data, output, counter = 0) => {
+      abytes2(key, void 0, "key");
+      abytes2(nonce, void 0, "nonce");
+      abytes2(data, void 0, "data");
+      const len = data.length;
+      if (output === void 0)
+        output = new Uint8Array(len);
+      abytes2(output, void 0, "output");
+      anumber3(counter);
+      if (counter < 0 || counter >= MAX_COUNTER)
+        throw new Error("arx: counter overflow");
+      if (output.length < len)
+        throw new Error(`arx: output (${output.length}) is shorter than data (${len})`);
+      const toClean = [];
+      let l = key.length;
+      let k;
+      let sigma;
+      if (l === 32) {
+        toClean.push(k = copyBytes(key));
+        sigma = sigma32_32;
+      } else if (l === 16 && allowShortKeys) {
+        k = new Uint8Array(32);
+        k.set(key);
+        k.set(key, 16);
+        sigma = sigma16_32;
+        toClean.push(k);
+      } else {
+        abytes2(key, 32, "arx key");
+        throw new Error("invalid key size");
+      }
+      if (!isAligned322(nonce))
+        toClean.push(nonce = copyBytes(nonce));
+      const k32 = u322(k);
+      if (extendNonceFn) {
+        if (nonce.length !== 24)
+          throw new Error(`arx: extended nonce must be 24 bytes`);
+        extendNonceFn(sigma, k32, u322(nonce.subarray(0, 16)), k32);
+        nonce = nonce.subarray(16);
+      }
+      const nonceNcLen = 16 - counterLength;
+      if (nonceNcLen !== nonce.length)
+        throw new Error(`arx: nonce must be ${nonceNcLen} or 16 bytes`);
+      if (nonceNcLen !== 12) {
+        const nc = new Uint8Array(12);
+        nc.set(nonce, counterRight ? 0 : 12 - nonce.length);
+        nonce = nc;
+        toClean.push(nonce);
+      }
+      const n32 = u322(nonce);
+      runCipher(core, sigma, k32, n32, data, output, counter, rounds);
+      clean2(...toClean);
+      return output;
+    };
+  }
+
+  // node_modules/@noble/ciphers/_poly1305.js
+  function u8to16(a, i) {
+    return a[i++] & 255 | (a[i++] & 255) << 8;
+  }
+  var Poly1305 = class {
+    // Can be speed-up using BigUint64Array, at the cost of complexity
+    constructor(key) {
+      __publicField(this, "blockLen", 16);
+      __publicField(this, "outputLen", 16);
+      __publicField(this, "buffer", new Uint8Array(16));
+      __publicField(this, "r", new Uint16Array(10));
+      // Allocating 1 array with .subarray() here is slower than 3
+      __publicField(this, "h", new Uint16Array(10));
+      __publicField(this, "pad", new Uint16Array(8));
+      __publicField(this, "pos", 0);
+      __publicField(this, "finished", false);
+      key = copyBytes(abytes2(key, 32, "key"));
+      const t0 = u8to16(key, 0);
+      const t1 = u8to16(key, 2);
+      const t2 = u8to16(key, 4);
+      const t3 = u8to16(key, 6);
+      const t4 = u8to16(key, 8);
+      const t5 = u8to16(key, 10);
+      const t6 = u8to16(key, 12);
+      const t7 = u8to16(key, 14);
+      this.r[0] = t0 & 8191;
+      this.r[1] = (t0 >>> 13 | t1 << 3) & 8191;
+      this.r[2] = (t1 >>> 10 | t2 << 6) & 7939;
+      this.r[3] = (t2 >>> 7 | t3 << 9) & 8191;
+      this.r[4] = (t3 >>> 4 | t4 << 12) & 255;
+      this.r[5] = t4 >>> 1 & 8190;
+      this.r[6] = (t4 >>> 14 | t5 << 2) & 8191;
+      this.r[7] = (t5 >>> 11 | t6 << 5) & 8065;
+      this.r[8] = (t6 >>> 8 | t7 << 8) & 8191;
+      this.r[9] = t7 >>> 5 & 127;
+      for (let i = 0; i < 8; i++)
+        this.pad[i] = u8to16(key, 16 + 2 * i);
+    }
+    process(data, offset, isLast = false) {
+      const hibit = isLast ? 0 : 1 << 11;
+      const { h, r } = this;
+      const r0 = r[0];
+      const r1 = r[1];
+      const r2 = r[2];
+      const r3 = r[3];
+      const r4 = r[4];
+      const r5 = r[5];
+      const r6 = r[6];
+      const r7 = r[7];
+      const r8 = r[8];
+      const r9 = r[9];
+      const t0 = u8to16(data, offset + 0);
+      const t1 = u8to16(data, offset + 2);
+      const t2 = u8to16(data, offset + 4);
+      const t3 = u8to16(data, offset + 6);
+      const t4 = u8to16(data, offset + 8);
+      const t5 = u8to16(data, offset + 10);
+      const t6 = u8to16(data, offset + 12);
+      const t7 = u8to16(data, offset + 14);
+      let h0 = h[0] + (t0 & 8191);
+      let h1 = h[1] + ((t0 >>> 13 | t1 << 3) & 8191);
+      let h2 = h[2] + ((t1 >>> 10 | t2 << 6) & 8191);
+      let h3 = h[3] + ((t2 >>> 7 | t3 << 9) & 8191);
+      let h4 = h[4] + ((t3 >>> 4 | t4 << 12) & 8191);
+      let h5 = h[5] + (t4 >>> 1 & 8191);
+      let h6 = h[6] + ((t4 >>> 14 | t5 << 2) & 8191);
+      let h7 = h[7] + ((t5 >>> 11 | t6 << 5) & 8191);
+      let h8 = h[8] + ((t6 >>> 8 | t7 << 8) & 8191);
+      let h9 = h[9] + (t7 >>> 5 | hibit);
+      let c = 0;
+      let d0 = c + h0 * r0 + h1 * (5 * r9) + h2 * (5 * r8) + h3 * (5 * r7) + h4 * (5 * r6);
+      c = d0 >>> 13;
+      d0 &= 8191;
+      d0 += h5 * (5 * r5) + h6 * (5 * r4) + h7 * (5 * r3) + h8 * (5 * r2) + h9 * (5 * r1);
+      c += d0 >>> 13;
+      d0 &= 8191;
+      let d1 = c + h0 * r1 + h1 * r0 + h2 * (5 * r9) + h3 * (5 * r8) + h4 * (5 * r7);
+      c = d1 >>> 13;
+      d1 &= 8191;
+      d1 += h5 * (5 * r6) + h6 * (5 * r5) + h7 * (5 * r4) + h8 * (5 * r3) + h9 * (5 * r2);
+      c += d1 >>> 13;
+      d1 &= 8191;
+      let d2 = c + h0 * r2 + h1 * r1 + h2 * r0 + h3 * (5 * r9) + h4 * (5 * r8);
+      c = d2 >>> 13;
+      d2 &= 8191;
+      d2 += h5 * (5 * r7) + h6 * (5 * r6) + h7 * (5 * r5) + h8 * (5 * r4) + h9 * (5 * r3);
+      c += d2 >>> 13;
+      d2 &= 8191;
+      let d3 = c + h0 * r3 + h1 * r2 + h2 * r1 + h3 * r0 + h4 * (5 * r9);
+      c = d3 >>> 13;
+      d3 &= 8191;
+      d3 += h5 * (5 * r8) + h6 * (5 * r7) + h7 * (5 * r6) + h8 * (5 * r5) + h9 * (5 * r4);
+      c += d3 >>> 13;
+      d3 &= 8191;
+      let d4 = c + h0 * r4 + h1 * r3 + h2 * r2 + h3 * r1 + h4 * r0;
+      c = d4 >>> 13;
+      d4 &= 8191;
+      d4 += h5 * (5 * r9) + h6 * (5 * r8) + h7 * (5 * r7) + h8 * (5 * r6) + h9 * (5 * r5);
+      c += d4 >>> 13;
+      d4 &= 8191;
+      let d5 = c + h0 * r5 + h1 * r4 + h2 * r3 + h3 * r2 + h4 * r1;
+      c = d5 >>> 13;
+      d5 &= 8191;
+      d5 += h5 * r0 + h6 * (5 * r9) + h7 * (5 * r8) + h8 * (5 * r7) + h9 * (5 * r6);
+      c += d5 >>> 13;
+      d5 &= 8191;
+      let d6 = c + h0 * r6 + h1 * r5 + h2 * r4 + h3 * r3 + h4 * r2;
+      c = d6 >>> 13;
+      d6 &= 8191;
+      d6 += h5 * r1 + h6 * r0 + h7 * (5 * r9) + h8 * (5 * r8) + h9 * (5 * r7);
+      c += d6 >>> 13;
+      d6 &= 8191;
+      let d7 = c + h0 * r7 + h1 * r6 + h2 * r5 + h3 * r4 + h4 * r3;
+      c = d7 >>> 13;
+      d7 &= 8191;
+      d7 += h5 * r2 + h6 * r1 + h7 * r0 + h8 * (5 * r9) + h9 * (5 * r8);
+      c += d7 >>> 13;
+      d7 &= 8191;
+      let d8 = c + h0 * r8 + h1 * r7 + h2 * r6 + h3 * r5 + h4 * r4;
+      c = d8 >>> 13;
+      d8 &= 8191;
+      d8 += h5 * r3 + h6 * r2 + h7 * r1 + h8 * r0 + h9 * (5 * r9);
+      c += d8 >>> 13;
+      d8 &= 8191;
+      let d9 = c + h0 * r9 + h1 * r8 + h2 * r7 + h3 * r6 + h4 * r5;
+      c = d9 >>> 13;
+      d9 &= 8191;
+      d9 += h5 * r4 + h6 * r3 + h7 * r2 + h8 * r1 + h9 * r0;
+      c += d9 >>> 13;
+      d9 &= 8191;
+      c = (c << 2) + c | 0;
+      c = c + d0 | 0;
+      d0 = c & 8191;
+      c = c >>> 13;
+      d1 += c;
+      h[0] = d0;
+      h[1] = d1;
+      h[2] = d2;
+      h[3] = d3;
+      h[4] = d4;
+      h[5] = d5;
+      h[6] = d6;
+      h[7] = d7;
+      h[8] = d8;
+      h[9] = d9;
+    }
+    finalize() {
+      const { h, pad } = this;
+      const g = new Uint16Array(10);
+      let c = h[1] >>> 13;
+      h[1] &= 8191;
+      for (let i = 2; i < 10; i++) {
+        h[i] += c;
+        c = h[i] >>> 13;
+        h[i] &= 8191;
+      }
+      h[0] += c * 5;
+      c = h[0] >>> 13;
+      h[0] &= 8191;
+      h[1] += c;
+      c = h[1] >>> 13;
+      h[1] &= 8191;
+      h[2] += c;
+      g[0] = h[0] + 5;
+      c = g[0] >>> 13;
+      g[0] &= 8191;
+      for (let i = 1; i < 10; i++) {
+        g[i] = h[i] + c;
+        c = g[i] >>> 13;
+        g[i] &= 8191;
+      }
+      g[9] -= 1 << 13;
+      let mask = (c ^ 1) - 1;
+      for (let i = 0; i < 10; i++)
+        g[i] &= mask;
+      mask = ~mask;
+      for (let i = 0; i < 10; i++)
+        h[i] = h[i] & mask | g[i];
+      h[0] = (h[0] | h[1] << 13) & 65535;
+      h[1] = (h[1] >>> 3 | h[2] << 10) & 65535;
+      h[2] = (h[2] >>> 6 | h[3] << 7) & 65535;
+      h[3] = (h[3] >>> 9 | h[4] << 4) & 65535;
+      h[4] = (h[4] >>> 12 | h[5] << 1 | h[6] << 14) & 65535;
+      h[5] = (h[6] >>> 2 | h[7] << 11) & 65535;
+      h[6] = (h[7] >>> 5 | h[8] << 8) & 65535;
+      h[7] = (h[8] >>> 8 | h[9] << 5) & 65535;
+      let f = h[0] + pad[0];
+      h[0] = f & 65535;
+      for (let i = 1; i < 8; i++) {
+        f = (h[i] + pad[i] | 0) + (f >>> 16) | 0;
+        h[i] = f & 65535;
+      }
+      clean2(g);
+    }
+    update(data) {
+      aexists2(this);
+      abytes2(data);
+      data = copyBytes(data);
+      const { buffer, blockLen } = this;
+      const len = data.length;
+      for (let pos = 0; pos < len; ) {
+        const take = Math.min(blockLen - this.pos, len - pos);
+        if (take === blockLen) {
+          for (; blockLen <= len - pos; pos += blockLen)
+            this.process(data, pos);
+          continue;
+        }
+        buffer.set(data.subarray(pos, pos + take), this.pos);
+        this.pos += take;
+        pos += take;
+        if (this.pos === blockLen) {
+          this.process(buffer, 0, false);
+          this.pos = 0;
+        }
+      }
+      return this;
+    }
+    destroy() {
+      clean2(this.h, this.r, this.buffer, this.pad);
+    }
+    digestInto(out) {
+      aexists2(this);
+      aoutput2(out, this);
+      this.finished = true;
+      const { buffer, h } = this;
+      let { pos } = this;
+      if (pos) {
+        buffer[pos++] = 1;
+        for (; pos < 16; pos++)
+          buffer[pos] = 0;
+        this.process(buffer, 0, true);
+      }
+      this.finalize();
+      let opos = 0;
+      for (let i = 0; i < 8; i++) {
+        out[opos++] = h[i] >>> 0;
+        out[opos++] = h[i] >>> 8;
+      }
+      return out;
+    }
+    digest() {
+      const { buffer, outputLen } = this;
+      this.digestInto(buffer);
+      const res = buffer.slice(0, outputLen);
+      this.destroy();
+      return res;
+    }
+  };
+  function wrapConstructorWithKey(hashCons) {
+    const hashC = (msg, key) => hashCons(key).update(msg).digest();
+    const tmp = hashCons(new Uint8Array(32));
+    hashC.outputLen = tmp.outputLen;
+    hashC.blockLen = tmp.blockLen;
+    hashC.create = (key) => hashCons(key);
+    return hashC;
+  }
+  var poly1305 = /* @__PURE__ */ (() => wrapConstructorWithKey((key) => new Poly1305(key)))();
+
+  // node_modules/@noble/ciphers/chacha.js
+  function chachaCore(s, k, n, out, cnt, rounds = 20) {
+    let y00 = s[0], y01 = s[1], y02 = s[2], y03 = s[3], y04 = k[0], y05 = k[1], y06 = k[2], y07 = k[3], y08 = k[4], y09 = k[5], y10 = k[6], y11 = k[7], y12 = cnt, y13 = n[0], y14 = n[1], y15 = n[2];
+    let x00 = y00, x01 = y01, x02 = y02, x03 = y03, x04 = y04, x05 = y05, x06 = y06, x07 = y07, x08 = y08, x09 = y09, x10 = y10, x11 = y11, x12 = y12, x13 = y13, x14 = y14, x15 = y15;
+    for (let r = 0; r < rounds; r += 2) {
+      x00 = x00 + x04 | 0;
+      x12 = rotl2(x12 ^ x00, 16);
+      x08 = x08 + x12 | 0;
+      x04 = rotl2(x04 ^ x08, 12);
+      x00 = x00 + x04 | 0;
+      x12 = rotl2(x12 ^ x00, 8);
+      x08 = x08 + x12 | 0;
+      x04 = rotl2(x04 ^ x08, 7);
+      x01 = x01 + x05 | 0;
+      x13 = rotl2(x13 ^ x01, 16);
+      x09 = x09 + x13 | 0;
+      x05 = rotl2(x05 ^ x09, 12);
+      x01 = x01 + x05 | 0;
+      x13 = rotl2(x13 ^ x01, 8);
+      x09 = x09 + x13 | 0;
+      x05 = rotl2(x05 ^ x09, 7);
+      x02 = x02 + x06 | 0;
+      x14 = rotl2(x14 ^ x02, 16);
+      x10 = x10 + x14 | 0;
+      x06 = rotl2(x06 ^ x10, 12);
+      x02 = x02 + x06 | 0;
+      x14 = rotl2(x14 ^ x02, 8);
+      x10 = x10 + x14 | 0;
+      x06 = rotl2(x06 ^ x10, 7);
+      x03 = x03 + x07 | 0;
+      x15 = rotl2(x15 ^ x03, 16);
+      x11 = x11 + x15 | 0;
+      x07 = rotl2(x07 ^ x11, 12);
+      x03 = x03 + x07 | 0;
+      x15 = rotl2(x15 ^ x03, 8);
+      x11 = x11 + x15 | 0;
+      x07 = rotl2(x07 ^ x11, 7);
+      x00 = x00 + x05 | 0;
+      x15 = rotl2(x15 ^ x00, 16);
+      x10 = x10 + x15 | 0;
+      x05 = rotl2(x05 ^ x10, 12);
+      x00 = x00 + x05 | 0;
+      x15 = rotl2(x15 ^ x00, 8);
+      x10 = x10 + x15 | 0;
+      x05 = rotl2(x05 ^ x10, 7);
+      x01 = x01 + x06 | 0;
+      x12 = rotl2(x12 ^ x01, 16);
+      x11 = x11 + x12 | 0;
+      x06 = rotl2(x06 ^ x11, 12);
+      x01 = x01 + x06 | 0;
+      x12 = rotl2(x12 ^ x01, 8);
+      x11 = x11 + x12 | 0;
+      x06 = rotl2(x06 ^ x11, 7);
+      x02 = x02 + x07 | 0;
+      x13 = rotl2(x13 ^ x02, 16);
+      x08 = x08 + x13 | 0;
+      x07 = rotl2(x07 ^ x08, 12);
+      x02 = x02 + x07 | 0;
+      x13 = rotl2(x13 ^ x02, 8);
+      x08 = x08 + x13 | 0;
+      x07 = rotl2(x07 ^ x08, 7);
+      x03 = x03 + x04 | 0;
+      x14 = rotl2(x14 ^ x03, 16);
+      x09 = x09 + x14 | 0;
+      x04 = rotl2(x04 ^ x09, 12);
+      x03 = x03 + x04 | 0;
+      x14 = rotl2(x14 ^ x03, 8);
+      x09 = x09 + x14 | 0;
+      x04 = rotl2(x04 ^ x09, 7);
+    }
+    let oi = 0;
+    out[oi++] = y00 + x00 | 0;
+    out[oi++] = y01 + x01 | 0;
+    out[oi++] = y02 + x02 | 0;
+    out[oi++] = y03 + x03 | 0;
+    out[oi++] = y04 + x04 | 0;
+    out[oi++] = y05 + x05 | 0;
+    out[oi++] = y06 + x06 | 0;
+    out[oi++] = y07 + x07 | 0;
+    out[oi++] = y08 + x08 | 0;
+    out[oi++] = y09 + x09 | 0;
+    out[oi++] = y10 + x10 | 0;
+    out[oi++] = y11 + x11 | 0;
+    out[oi++] = y12 + x12 | 0;
+    out[oi++] = y13 + x13 | 0;
+    out[oi++] = y14 + x14 | 0;
+    out[oi++] = y15 + x15 | 0;
+  }
+  function hchacha(s, k, i, out) {
+    let x00 = s[0], x01 = s[1], x02 = s[2], x03 = s[3], x04 = k[0], x05 = k[1], x06 = k[2], x07 = k[3], x08 = k[4], x09 = k[5], x10 = k[6], x11 = k[7], x12 = i[0], x13 = i[1], x14 = i[2], x15 = i[3];
+    for (let r = 0; r < 20; r += 2) {
+      x00 = x00 + x04 | 0;
+      x12 = rotl2(x12 ^ x00, 16);
+      x08 = x08 + x12 | 0;
+      x04 = rotl2(x04 ^ x08, 12);
+      x00 = x00 + x04 | 0;
+      x12 = rotl2(x12 ^ x00, 8);
+      x08 = x08 + x12 | 0;
+      x04 = rotl2(x04 ^ x08, 7);
+      x01 = x01 + x05 | 0;
+      x13 = rotl2(x13 ^ x01, 16);
+      x09 = x09 + x13 | 0;
+      x05 = rotl2(x05 ^ x09, 12);
+      x01 = x01 + x05 | 0;
+      x13 = rotl2(x13 ^ x01, 8);
+      x09 = x09 + x13 | 0;
+      x05 = rotl2(x05 ^ x09, 7);
+      x02 = x02 + x06 | 0;
+      x14 = rotl2(x14 ^ x02, 16);
+      x10 = x10 + x14 | 0;
+      x06 = rotl2(x06 ^ x10, 12);
+      x02 = x02 + x06 | 0;
+      x14 = rotl2(x14 ^ x02, 8);
+      x10 = x10 + x14 | 0;
+      x06 = rotl2(x06 ^ x10, 7);
+      x03 = x03 + x07 | 0;
+      x15 = rotl2(x15 ^ x03, 16);
+      x11 = x11 + x15 | 0;
+      x07 = rotl2(x07 ^ x11, 12);
+      x03 = x03 + x07 | 0;
+      x15 = rotl2(x15 ^ x03, 8);
+      x11 = x11 + x15 | 0;
+      x07 = rotl2(x07 ^ x11, 7);
+      x00 = x00 + x05 | 0;
+      x15 = rotl2(x15 ^ x00, 16);
+      x10 = x10 + x15 | 0;
+      x05 = rotl2(x05 ^ x10, 12);
+      x00 = x00 + x05 | 0;
+      x15 = rotl2(x15 ^ x00, 8);
+      x10 = x10 + x15 | 0;
+      x05 = rotl2(x05 ^ x10, 7);
+      x01 = x01 + x06 | 0;
+      x12 = rotl2(x12 ^ x01, 16);
+      x11 = x11 + x12 | 0;
+      x06 = rotl2(x06 ^ x11, 12);
+      x01 = x01 + x06 | 0;
+      x12 = rotl2(x12 ^ x01, 8);
+      x11 = x11 + x12 | 0;
+      x06 = rotl2(x06 ^ x11, 7);
+      x02 = x02 + x07 | 0;
+      x13 = rotl2(x13 ^ x02, 16);
+      x08 = x08 + x13 | 0;
+      x07 = rotl2(x07 ^ x08, 12);
+      x02 = x02 + x07 | 0;
+      x13 = rotl2(x13 ^ x02, 8);
+      x08 = x08 + x13 | 0;
+      x07 = rotl2(x07 ^ x08, 7);
+      x03 = x03 + x04 | 0;
+      x14 = rotl2(x14 ^ x03, 16);
+      x09 = x09 + x14 | 0;
+      x04 = rotl2(x04 ^ x09, 12);
+      x03 = x03 + x04 | 0;
+      x14 = rotl2(x14 ^ x03, 8);
+      x09 = x09 + x14 | 0;
+      x04 = rotl2(x04 ^ x09, 7);
+    }
+    let oi = 0;
+    out[oi++] = x00;
+    out[oi++] = x01;
+    out[oi++] = x02;
+    out[oi++] = x03;
+    out[oi++] = x12;
+    out[oi++] = x13;
+    out[oi++] = x14;
+    out[oi++] = x15;
+  }
+  var chacha20 = /* @__PURE__ */ createCipher(chachaCore, {
+    counterRight: false,
+    counterLength: 4,
+    allowShortKeys: false
+  });
+  var xchacha20 = /* @__PURE__ */ createCipher(chachaCore, {
+    counterRight: false,
+    counterLength: 8,
+    extendNonceFn: hchacha,
+    allowShortKeys: false
+  });
+  var ZEROS16 = /* @__PURE__ */ new Uint8Array(16);
+  var updatePadded = (h, msg) => {
+    h.update(msg);
+    const leftover = msg.length % 16;
+    if (leftover)
+      h.update(ZEROS16.subarray(leftover));
+  };
+  var ZEROS32 = /* @__PURE__ */ new Uint8Array(32);
+  function computeTag(fn, key, nonce, ciphertext, AAD) {
+    if (AAD !== void 0)
+      abytes2(AAD, void 0, "AAD");
+    const authKey = fn(key, nonce, ZEROS32);
+    const lengths = u64Lengths(ciphertext.length, AAD ? AAD.length : 0, true);
+    const h = poly1305.create(authKey);
+    if (AAD)
+      updatePadded(h, AAD);
+    updatePadded(h, ciphertext);
+    h.update(lengths);
+    const res = h.digest();
+    clean2(authKey, lengths);
+    return res;
+  }
+  var _poly1305_aead = (xorStream) => (key, nonce, AAD) => {
+    const tagLength = 16;
+    return {
+      encrypt(plaintext, output) {
+        const plength = plaintext.length;
+        output = getOutput(plength + tagLength, output, false);
+        output.set(plaintext);
+        const oPlain = output.subarray(0, -tagLength);
+        xorStream(key, nonce, oPlain, oPlain, 1);
+        const tag = computeTag(xorStream, key, nonce, oPlain, AAD);
+        output.set(tag, plength);
+        clean2(tag);
+        return output;
+      },
+      decrypt(ciphertext, output) {
+        output = getOutput(ciphertext.length - tagLength, output, false);
+        const data = ciphertext.subarray(0, -tagLength);
+        const passedTag = ciphertext.subarray(-tagLength);
+        const tag = computeTag(xorStream, key, nonce, data, AAD);
+        if (!equalBytes(passedTag, tag))
+          throw new Error("invalid tag");
+        output.set(ciphertext.subarray(0, -tagLength));
+        xorStream(key, nonce, output, output, 1);
+        clean2(tag);
+        return output;
+      }
+    };
+  };
+  var chacha20poly1305 = /* @__PURE__ */ wrapCipher({ blockSize: 64, nonceLength: 12, tagLength: 16 }, _poly1305_aead(chacha20));
+  var xchacha20poly1305 = /* @__PURE__ */ wrapCipher({ blockSize: 64, nonceLength: 24, tagLength: 16 }, _poly1305_aead(xchacha20));
+
+  // node_modules/nostr-tools/lib/esm/nip49.js
+  var Bech32MaxSize = 5e3;
+  function encodeBech32(prefix, data) {
+    let words = bech32.toWords(data);
+    return bech32.encode(prefix, words, Bech32MaxSize);
+  }
+  function encodeBytes(prefix, bytes) {
+    return encodeBech32(prefix, bytes);
+  }
+  function encrypt(sec, password, logn = 16, ksb = 2) {
+    let salt = randomBytes(16);
+    let n = 2 ** logn;
+    let key = scrypt(password.normalize("NFKC"), salt, { N: n, r: 8, p: 1, dkLen: 32 });
+    let nonce = randomBytes(24);
+    let aad = Uint8Array.from([ksb]);
+    let xc2p1 = xchacha20poly1305(key, nonce, aad);
+    let ciphertext = xc2p1.encrypt(sec);
+    let b = concatBytes(Uint8Array.from([2]), Uint8Array.from([logn]), salt, nonce, aad, ciphertext);
+    return encodeBytes("ncryptsec", b);
+  }
+  function decrypt(ncryptsec, password) {
+    let { prefix, words } = bech32.decode(ncryptsec, Bech32MaxSize);
+    if (prefix !== "ncryptsec") {
+      throw new Error(`invalid prefix ${prefix}, expected 'ncryptsec'`);
+    }
+    let b = new Uint8Array(bech32.fromWords(words));
+    let version = b[0];
+    if (version !== 2) {
+      throw new Error(`invalid version ${version}, expected 0x02`);
+    }
+    let logn = b[1];
+    let n = 2 ** logn;
+    let salt = b.slice(2, 2 + 16);
+    let nonce = b.slice(2 + 16, 2 + 16 + 24);
+    let ksb = b[2 + 16 + 24];
+    let aad = Uint8Array.from([ksb]);
+    let ciphertext = b.slice(2 + 16 + 24 + 1);
+    let key = scrypt(password.normalize("NFKC"), salt, { N: n, r: 8, p: 1, dkLen: 32 });
+    let xc2p1 = xchacha20poly1305(key, nonce, aad);
+    let sec = xc2p1.decrypt(ciphertext);
+    return sec;
+  }
+  return __toCommonJS(nt_entry_exports);
+})();

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -301,6 +301,7 @@
   <div id="toasts" class="toasts"></div>
 
   <script src="nostr-tools.js"></script>
+  <script src="nip49.js"></script>
   <script src="qrious.min.js"></script>
   <script src="nwc-client.js"></script>
   <script src="version.js"></script>

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -1723,12 +1723,38 @@
     }
   }
 
+  // Decrypt a NIP-49 ncryptsec string to an nsec, so the rest of the import path
+  // (SIDECAR_ADD_ACCOUNT, decodeSecret) never has to know ncryptsec exists. Throws
+  // a friendly message on a bad password or malformed string.
+  function decryptNcryptsec(ncryptsec, password) {
+    let sk;
+    try {
+      sk = window.SidecarNip49.decrypt(ncryptsec, password);
+    } catch (_) {
+      throw new Error('Incorrect password, or not a valid ncryptsec key.');
+    }
+    return NT.nip19.nsecEncode(sk);
+  }
+
   function importAccountModal() {
     openModal((modal) => {
       modal.append(h('h3', { textContent: 'Import account' }));
       const err = h('div', { className: 'error' });
-      const secretInput = h('input', { type: 'password', className: 'nsec-field', placeholder: 'nsec1… or 64-char hex' });
+      const secretInput = h('input', {
+        type: 'password',
+        className: 'nsec-field',
+        placeholder: 'nsec1…, ncryptsec1…, or 64-char hex',
+      });
       modal.append(h('label', { textContent: 'Private key' }), secretInput);
+
+      // ncryptsec (NIP-49) is a password-encrypted key, so it needs a second field
+      // to decrypt — shown only once the pasted value looks like one.
+      const cryptPass = h('input', { type: 'password', placeholder: 'Decryption password' });
+      const cryptRow = h('div', { className: 'stack hidden' }, [
+        h('label', { textContent: 'Password' }),
+        cryptPass,
+      ]);
+      modal.append(cryptRow);
 
       // Live preview: once the pasted key is valid, show whose account it is
       // (npub + kind 0 name/picture) so the user can confirm before importing.
@@ -1744,7 +1770,24 @@
       let previewSeq = 0;
       let previewTimer = null;
       async function updatePreview() {
-        const pubkey = pubkeyFromSecret(secretInput.value.trim());
+        err.textContent = '';
+        const raw = secretInput.value.trim();
+        const isNcryptsec = /^ncryptsec1/i.test(raw);
+        cryptRow.classList.toggle('hidden', !isNcryptsec);
+
+        let pubkey = '';
+        if (isNcryptsec) {
+          if (!cryptPass.value) return preview.classList.add('hidden');
+          try {
+            pubkey = pubkeyFromSecret(decryptNcryptsec(raw, cryptPass.value));
+          } catch (_) {
+            preview.classList.add('hidden');
+            return;
+          }
+        } else {
+          pubkey = pubkeyFromSecret(raw);
+        }
+
         const seq = ++previewSeq;
         if (!pubkey) return preview.classList.add('hidden');
         const npub = NT.nip19.npubEncode(pubkey);
@@ -1765,6 +1808,10 @@
         clearTimeout(previewTimer);
         previewTimer = setTimeout(updatePreview, 350);
       });
+      cryptPass.addEventListener('input', () => {
+        clearTimeout(previewTimer);
+        previewTimer = setTimeout(updatePreview, 350);
+      });
 
       modal.append(
         h('p', {
@@ -1779,8 +1826,9 @@
       save.addEventListener('click', async () => {
         err.textContent = '';
         try {
-          const secret = secretInput.value.trim();
-          if (!secret) throw new Error('Enter an nsec or hex private key.');
+          const raw = secretInput.value.trim();
+          if (!raw) throw new Error('Enter an nsec, ncryptsec, or hex private key.');
+          const secret = /^ncryptsec1/i.test(raw) ? decryptNcryptsec(raw, cryptPass.value) : raw;
           await call({ type: 'SIDECAR_ADD_ACCOUNT', secret });
           closeModal();
           await refresh();
@@ -1813,6 +1861,7 @@
           closeModal();
         }),
         menuItem('Back up private key', 'key', () => revealNsecModal(a)),
+        menuItem('Export ncryptsec', 'lock', () => exportNcryptsecModal(a)),
         menuItem('Rename', 'edit', () => renameModal(a)),
         menuItem('Remove account', 'trash', () => removeModal(a), true),
       ]);
@@ -1826,22 +1875,30 @@
     });
   }
 
-  // Show an nsec with copy + warning (used after generate, and from reveal).
-  // The key auto-hides after 30s so it can't be left exposed on screen; viewing
-  // it again goes back through the PIN-gated reveal.
+  // Show a secret string (nsec or ncryptsec) with copy + warning (used after
+  // generate, from reveal, and from ncryptsec export). The key auto-hides after
+  // 30s so it can't be left exposed on screen; viewing it again goes back through
+  // the PIN-gated reveal. opts.secret is the value shown; opts.noun labels the
+  // copy button/toast ('nsec' by default).
   const NSEC_REVEAL_TIMEOUT_S = 30;
   function nsecModal(opts) {
+    const secret = opts.secret || opts.nsec;
+    const noun = opts.noun || 'nsec';
     let remaining = NSEC_REVEAL_TIMEOUT_S;
     let timer = null;
     openModal(
       (modal) => {
-        // Scannable QR for QR sign-in on mobile clients (e.g. Wisp). A QR exposes
-        // the full key at a glance, so keep it behind an explicit reveal — an
-        // opt-in backup option, not shown unprompted. Generated only on click, so
-        // the scannable image never exists on screen unless requested. nsec is
-        // case-sensitive bech32, so encode it as-is (lowercase, byte mode).
+        // Scannable QR for QR sign-in on mobile clients (e.g. Wisp), or to move an
+        // ncryptsec export to another NIP-49-aware app. A QR exposes the full
+        // secret at a glance, so keep it behind an explicit reveal — an opt-in
+        // backup option, not shown unprompted. Generated only on click, so the
+        // scannable image never exists on screen unless requested. Case-sensitive
+        // bech32, so encode as-is (lowercase, byte mode).
         const qrCanvasWrap = h('div', { className: 'qr-reveal hidden' }); // holds the canvas once revealed
-        const qrHint = h('p', { className: 'hint hidden', textContent: 'Scan to sign in on a mobile client that supports QR login.' });
+        const qrHint = h('p', {
+          className: 'hint hidden',
+          textContent: opts.qrHint || 'Scan to sign in on a mobile client that supports QR login.',
+        });
         const showQr = h('button', { className: 'secondary qr-reveal-btn' });
         let qrShown = false, qrCanvas = null;
         const setQrLabel = () => {
@@ -1854,7 +1911,7 @@
           if (qrShown && !qrCanvas) {
             qrCanvas = document.createElement('canvas');
             qrCanvas.className = 'recv-qr modal-qr';
-            try { new window.QRious({ element: qrCanvas, value: opts.nsec, size: 220, level: 'M' }); } catch (_) {}
+            try { new window.QRious({ element: qrCanvas, value: secret, size: 220, level: 'M' }); } catch (_) {}
             qrCanvasWrap.append(qrCanvas);
           }
           qrCanvasWrap.classList.toggle('hidden', !qrShown);
@@ -1862,12 +1919,12 @@
           setQrLabel();
         });
 
-        const box = h('div', { className: 'secret-box', textContent: opts.nsec });
-        const copy = h('button', { className: 'secondary', textContent: 'Copy nsec' });
+        const box = h('div', { className: 'secret-box', textContent: secret });
+        const copy = h('button', { className: 'secondary', textContent: 'Copy ' + noun });
         copy.addEventListener('click', async () => {
           try {
-            await navigator.clipboard.writeText(opts.nsec);
-            toast('nsec copied', 'success');
+            await navigator.clipboard.writeText(secret);
+            toast(noun + ' copied', 'success');
           } catch (_) {}
         });
         const done = h('button', { className: 'primary', textContent: "I've saved it" });
@@ -1889,7 +1946,10 @@
           showQr,
           qrCanvasWrap,
           qrHint,
-          h('p', { className: 'hint warn', textContent: 'Anyone with this key fully controls the account. Store it somewhere safe and never share it.' }),
+          h('p', {
+            className: 'hint warn',
+            textContent: opts.warnText || 'Anyone with this key fully controls the account. Store it somewhere safe and never share it.',
+          }),
           countdown,
           h('div', { className: 'actions' }, [done])
         );
@@ -1933,6 +1993,95 @@
         h('p', { className: 'hint', textContent: 'Enter your PIN to reveal the nsec for ' + displayName(a) + '.' }),
         h('label', { textContent: 'PIN' }),
         pin,
+        err,
+        h('div', { className: 'actions' }, [go, cancel])
+      );
+    });
+  }
+
+  // Export an account as a NIP-49 ncryptsec — a password-encrypted key that's
+  // portable to any NIP-49-aware app without ever sharing the raw nsec. Step 1:
+  // PIN-gated reveal of the nsec (same step-up as backup). Step 2: choose an
+  // export password to encrypt it with.
+  function exportNcryptsecModal(a) {
+    openModal((modal) => {
+      const pin = h('input', { type: 'password', maxLength: 32 });
+      const err = h('div', { className: 'error' });
+      const go = h('button', { className: 'primary', textContent: 'Continue' });
+      go.addEventListener('click', async () => {
+        err.textContent = '';
+        if (!pin.value) return (err.textContent = 'Enter your PIN.');
+        go.disabled = true;
+        go.textContent = 'Verifying…';
+        try {
+          const r = await call({ type: 'SIDECAR_REVEAL_NSEC', pubkey: a.pubkey, pin: pin.value });
+          closeModal();
+          setTimeout(() => encryptNcryptsecModal(a, r.nsec), 0);
+        } catch (e) {
+          err.textContent = e.message;
+          go.disabled = false;
+          go.textContent = 'Continue';
+          toast(e.message, 'error');
+        }
+      });
+      const cancel = h('button', { className: 'ghost', textContent: 'Cancel' });
+      cancel.addEventListener('click', closeModal);
+      modal.append(
+        h('h3', { textContent: 'Export ncryptsec' }),
+        h('p', { className: 'hint', textContent: 'Enter your PIN to export an encrypted key for ' + displayName(a) + '.' }),
+        h('label', { textContent: 'PIN' }),
+        pin,
+        err,
+        h('div', { className: 'actions' }, [go, cancel])
+      );
+    });
+  }
+
+  function encryptNcryptsecModal(a, nsec) {
+    openModal((modal) => {
+      const pass = h('input', { type: 'password', placeholder: 'At least 8 characters' });
+      const pass2 = h('input', { type: 'password', placeholder: 'Confirm password' });
+      const err = h('div', { className: 'error' });
+      const go = h('button', { className: 'primary', textContent: 'Encrypt & show' });
+      go.addEventListener('click', () => {
+        err.textContent = '';
+        if (!pass.value || pass.value.length < 8) return (err.textContent = 'Use a password of at least 8 characters.');
+        if (pass.value !== pass2.value) return (err.textContent = 'Passwords do not match.');
+        let ncryptsec;
+        try {
+          const sk = NT.nip19.decode(nsec).data;
+          ncryptsec = window.SidecarNip49.encrypt(sk, pass.value);
+        } catch (e) {
+          err.textContent = 'Could not encrypt the key.';
+          return;
+        }
+        closeModal();
+        setTimeout(
+          () =>
+            nsecModal({
+              secret: ncryptsec,
+              noun: 'ncryptsec',
+              title: 'Encrypted private key',
+              intro: 'A password-protected key (NIP-49) you can import into Sidecar or another NIP-49-compatible app. You will need this exact password to unlock it.',
+              qrHint: 'Scan to import into another NIP-49-compatible app.',
+              warnText: 'Anyone with this ncryptsec and the password fully controls the account. Store them somewhere safe, separately from each other.',
+            }),
+          0
+        );
+      });
+      const cancel = h('button', { className: 'ghost', textContent: 'Cancel' });
+      cancel.addEventListener('click', closeModal);
+      modal.append(
+        h('h3', { textContent: 'Set an export password' }),
+        h('p', {
+          className: 'hint',
+          textContent:
+            "Choose a password to encrypt this key. Use something other than your Sidecar PIN — you'll need to give this exact password to wherever you import it.",
+        }),
+        h('label', { textContent: 'Password' }),
+        pass,
+        h('label', { textContent: 'Confirm password' }),
+        pass2,
         err,
         h('div', { className: 'actions' }, [go, cancel])
       );


### PR DESCRIPTION
Sidecar could only move a key in or out as a raw nsec. NIP-49 (ncryptsec) is the standard password-encrypted format for exactly this — moving a key between apps without the raw nsec ever touching a clipboard or screen unencrypted.

## What's included
- **Import** — "Import nsec" now also accepts an `ncryptsec1…` string. Pasting one reveals a password field; once both are filled in, the usual profile preview confirms the account before import. A wrong password fails clearly without crashing.
- **Export** — a new "Export ncryptsec" item in the account menu (between "Back up private key" and "Rename"). PIN-gated reveal, then choose an export password (min 8 chars, confirmed), then the result is shown through the same reveal modal used for nsec backups — copy, QR, 30s auto-hide.
- **Implementation** — ncryptsec is decrypted/encrypted entirely client-side via a small vendored `nostr-tools/nip49` bundle (`nip49.js`, scrypt + xchacha20poly1305). Import converts ncryptsec → nsec before handing off to the existing add-account path, so background.js/keystore.js don't need to know ncryptsec exists at all.

## Test
1. Export an existing account's ncryptsec with a password, then remove that account and re-import the saved ncryptsec + password — confirm it resolves to the exact same npub/profile.
2. Try importing with a wrong password — should show "Incorrect password, or not a valid ncryptsec key." with no crash.
3. Export with a password under 8 characters, or mismatched confirm — both should show inline errors.
4. Confirm the reveal modal's copy/QR/countdown behave the same as the existing "Back up private key" flow.

🍷 Chilled with [Claude Code](https://claude.com/claude-code)