### PR TITLE
Add NoorNote to the 'Open notes in' client list

### DIFF
--- a/sidepanel.html
+++ b/sidepanel.html
@@ -197,6 +197,7 @@
           <option value="iris">Iris</option>
           <option value="zapcooking">zap.cooking</option>
           <option value="njump">njump</option>
+          <option value="noornote">NoorNote</option>
         </select>
         <label class="toggle-row"><input type="checkbox" id="reuse-tab-toggle" /> <span>Reuse an open client tab</span></label>
       </div>

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -189,15 +189,15 @@
         <p class="hint">Which web client to open your published notes in.</p>
         <select id="client-select">
           <option value="jumble">Jumble</option>
+          <option value="yakihonne">YakiHonne</option>
           <option value="primal">Primal</option>
+          <option value="iris">Iris</option>
           <option value="coracle">Coracle</option>
           <option value="nostrudel">noStrudel</option>
-          <option value="yakihonne">YakiHonne</option>
           <option value="snort">Snort</option>
-          <option value="iris">Iris</option>
           <option value="zapcooking">zap.cooking</option>
-          <option value="njump">njump</option>
           <option value="noornote">NoorNote</option>
+          <option value="njump">njump</option>
         </select>
         <label class="toggle-row"><input type="checkbox" id="reuse-tab-toggle" /> <span>Reuse an open client tab</span></label>
       </div>

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -3097,15 +3097,15 @@
   // Web clients that can open a single note. Each maps a NIP-19 nevent → a URL.
   const VIEW_CLIENTS = {
     jumble: { label: 'Jumble', url: (ne) => 'https://jumble.social/notes/' + ne, profile: (np) => 'https://jumble.social/users/' + np },
+    yakihonne: { label: 'YakiHonne', url: (ne) => 'https://yakihonne.com/note/' + ne, profile: (np) => 'https://yakihonne.com/profile/' + np },
     primal: { label: 'Primal', url: (ne) => 'https://primal.net/e/' + ne, profile: (np) => 'https://primal.net/p/' + np },
+    iris: { label: 'Iris', url: (ne) => 'https://iris.to/' + ne, profile: (np) => 'https://iris.to/' + np },
     coracle: { label: 'Coracle', url: (ne) => 'https://coracle.social/' + ne, profile: (np) => 'https://coracle.social/' + np },
     nostrudel: { label: 'noStrudel', url: (ne) => 'https://nostrudel.ninja/#/n/' + ne, profile: (np) => 'https://nostrudel.ninja/#/u/' + np },
-    yakihonne: { label: 'YakiHonne', url: (ne) => 'https://yakihonne.com/note/' + ne, profile: (np) => 'https://yakihonne.com/profile/' + np },
     snort: { label: 'Snort', url: (ne) => 'https://snort.social/' + ne, profile: (np) => 'https://snort.social/' + np },
-    iris: { label: 'Iris', url: (ne) => 'https://iris.to/' + ne, profile: (np) => 'https://iris.to/' + np },
     zapcooking: { label: 'zap.cooking', url: (ne) => 'https://zap.cooking/' + ne, profile: (np) => 'https://zap.cooking/user/' + np },
-    njump: { label: 'njump', url: (ne) => 'https://njump.me/' + ne, profile: (np) => 'https://njump.me/' + np },
     noornote: { label: 'NoorNote', url: (ne) => 'https://noornote.app/note/' + ne, profile: (np) => 'https://noornote.app/profile/' + np },
+    njump: { label: 'njump', url: (ne) => 'https://njump.me/' + ne, profile: (np) => 'https://njump.me/' + np },
   };
   const DEFAULT_CLIENT = 'jumble';
 

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -3105,6 +3105,7 @@
     iris: { label: 'Iris', url: (ne) => 'https://iris.to/' + ne, profile: (np) => 'https://iris.to/' + np },
     zapcooking: { label: 'zap.cooking', url: (ne) => 'https://zap.cooking/' + ne, profile: (np) => 'https://zap.cooking/user/' + np },
     njump: { label: 'njump', url: (ne) => 'https://njump.me/' + ne, profile: (np) => 'https://njump.me/' + np },
+    noornote: { label: 'NoorNote', url: (ne) => 'https://noornote.app/note/' + ne, profile: (np) => 'https://noornote.app/profile/' + np },
   };
   const DEFAULT_CLIENT = 'jumble';
 

--- a/welcome.js
+++ b/welcome.js
@@ -200,7 +200,7 @@ const APPS = [
     domain: 'noornote.app',
     cat: 'social',
     icon: 'https://t3.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=https://noornote.app/&size=256',
-    desc: 'Feature-rich client with guided onboarding, marketplace, Zap Streams, follow packs, and dozens of built-in addons.',
+    desc: 'Feature-rich client with guided onboarding and dozens of built-in addons.',
   },
   {
     name: 'Ghostr',

--- a/welcome.js
+++ b/welcome.js
@@ -195,6 +195,14 @@ const APPS = [
     desc: 'A focused social client — “social without the noise,” built for real human connections.',
   },
   {
+    name: 'NoorNote',
+    url: 'https://noornote.app',
+    domain: 'noornote.app',
+    cat: 'social',
+    icon: 'https://t3.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=https://noornote.app/&size=256',
+    desc: 'Feature-rich client with guided onboarding, marketplace, Zap Streams, follow packs, and dozens of built-in addons.',
+  },
+  {
     name: 'Ghostr',
     url: 'https://ghostr.org',
     domain: 'ghostr.org',


### PR DESCRIPTION
Adds NoorNote as an option for where notification taps / "view note" links open.

Route shape confirmed from NoorNote's own source (\`SingleNoteView.ts\`) rather than guessed: \`/note/<nevent1|note1|hex>\` for a note, \`/profile/<npub>\` for a profile — same pattern the other clients in this list already use. Verified both routes return 200 on the live site.

## Test
Settings → Open notes in → NoorNote, then tap a notification or a "view note" link → opens correctly on noornote.app.

🧉 Blended with [Claude Code](https://claude.com/claude-code)