### PR TITLE
Switch accounts inline when a site logs in for the first time

### DIFF
--- a/background.js
+++ b/background.js
@@ -343,7 +343,8 @@ async function handleNostrRpc(method, params, host, sendResponse) {
 
     // The identity this host signs as — pinned to whatever it logged in with,
     // independent of the globally-active account (prevents NIP-07 desync).
-    const activePubkey = await resolveSiteAccount(host);
+    const boundPubkey = await getSiteAccount(host);
+    let activePubkey = await resolveSiteAccount(host);
     if (!activePubkey) throw new Error('No active Sidecar account');
 
     const status = await PERMS.getPermissionStatus(activePubkey, host, method); // allow | reject | ask
@@ -369,10 +370,28 @@ async function handleNostrRpc(method, params, host, sendResponse) {
     const needUnlock = needsKey && KS.isLocked();
     const needApproval = status === 'ask' && !isRelayAuth;
 
+    // A brand-new site (no binding yet) is the one safe moment to offer switching
+    // identity right in the prompt: nothing on the site has cached a pubkey yet,
+    // so there's no desync risk. Once a site is bound, its signing identity can
+    // only change via the deliberate "Use <account>" + re-login flow in the
+    // Activity tab — swapping mid-session here would silently break NIP-07 sync
+    // the same way the binding itself was built to prevent.
+    const canOfferAccountSwitch = method === 'getPublicKey' && !boundPubkey;
+
     // Once unlocked, signing only needs site approval — no PIN re-entry.
     if (needApproval || needUnlock) {
       const st = await KS.getState();
       const acct = st.accounts.find((a) => a.pubkey === activePubkey);
+      const otherAccounts = canOfferAccountSwitch
+        ? st.accounts
+            .filter((a) => a.pubkey !== activePubkey)
+            .map((a) => ({
+              pubkey: a.pubkey,
+              npub: self.NostrTools.nip19.npubEncode(a.pubkey),
+              name: a.name || '',
+              picture: a.picture || '',
+            }))
+        : null;
       const decision = await openPrompt({
         host,
         method,
@@ -384,8 +403,25 @@ async function handleNostrRpc(method, params, host, sendResponse) {
         needUnlock,
         needApproval,
         level: await PERMS.getLevel(activePubkey, host),
+        otherAccounts: otherAccounts && otherAccounts.length ? otherAccounts : null,
       });
       if (decision.action === 'reject') throw new Error('You rejected this request');
+
+      // Resolve a chosen switch-to account BEFORE block/trust, so those apply to
+      // the account actually signing, not the one the prompt originally opened with.
+      if (
+        canOfferAccountSwitch &&
+        decision.switchToPubkey &&
+        decision.switchToPubkey !== activePubkey &&
+        otherAccounts &&
+        otherAccounts.some((a) => a.pubkey === decision.switchToPubkey)
+      ) {
+        const switchedStatus = await PERMS.getPermissionStatus(decision.switchToPubkey, host, method);
+        if (switchedStatus === 'reject') throw new Error('This site is blocked in Sidecar for that account');
+        activePubkey = decision.switchToPubkey;
+        await KS.setActive(activePubkey);
+      }
+
       if (decision.action === 'block') {
         await PERMS.setLevel(activePubkey, host, 'blocked');
         throw new Error('This site is now blocked');

--- a/prompt.html
+++ b/prompt.html
@@ -69,6 +69,29 @@
       max-height: 160px; overflow: auto; color: var(--text);
     }
     .account { margin-bottom: 18px; }
+    .switch-toggle {
+      display: block; width: 100%; background: none; border: none; cursor: pointer;
+      color: var(--lav); font-size: 12.5px; text-align: center; margin: -10px 0 14px; padding: 4px;
+    }
+    .switch-toggle:hover { color: var(--text); }
+    .switch-menu {
+      text-align: left;
+      background: linear-gradient(180deg, var(--velvet-1), var(--velvet-2));
+      border: 1px solid var(--border-strong); border-radius: 14px;
+      padding: 6px; margin: -6px 0 14px; box-shadow: var(--sheen);
+    }
+    .switch-row {
+      display: flex; align-items: center; gap: 10px; width: 100%; text-align: left;
+      background: transparent; border: none; cursor: pointer; color: var(--text);
+      padding: 9px 10px; border-radius: 10px; font-family: inherit; font-weight: 400;
+    }
+    .switch-row:hover { background: rgba(167, 139, 250, 0.1); }
+    .switch-row.active { background: rgba(203, 161, 78, 0.08); }
+    .switch-row-av { width: 34px; height: 34px; border-radius: 50%; object-fit: cover; flex-shrink: 0; background: #2a1257; }
+    .switch-row-info { flex: 1; min-width: 0; }
+    .switch-row-name { font-weight: 600; font-size: 13.5px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .switch-row-npub { font-family: var(--font-mono); font-size: 11px; color: var(--muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .switch-row-check { width: 16px; height: 16px; color: var(--gold); flex-shrink: 0; }
     .as-label { font-size: 10.5px; color: var(--muted); margin-bottom: 8px; text-transform: uppercase; letter-spacing: 0.22em; }
     .acct-capsule {
       display: flex; align-items: center; justify-content: center; gap: 12px;
@@ -134,6 +157,8 @@
   <div id="preview" class="card hidden"></div>
 
   <div class="account" id="account"></div>
+  <button class="switch-toggle hidden" id="switch-toggle">Not you? Switch account</button>
+  <div class="switch-menu hidden" id="switch-menu"></div>
 
   <div id="unlock" class="hidden">
     <label for="pin">Enter your PIN to unlock</label>

--- a/prompt.html
+++ b/prompt.html
@@ -157,7 +157,7 @@
   <div id="preview" class="card hidden"></div>
 
   <div class="account" id="account"></div>
-  <button class="switch-toggle hidden" id="switch-toggle">Not you? Switch account</button>
+  <button class="switch-toggle hidden" id="switch-toggle">Sign in with a different account</button>
   <div class="switch-menu hidden" id="switch-menu"></div>
 
   <div id="unlock" class="hidden">

--- a/prompt.js
+++ b/prompt.js
@@ -13,6 +13,8 @@
     ask: $('ask'),
     preview: $('preview'),
     account: $('account'),
+    switchToggle: $('switch-toggle'),
+    switchMenu: $('switch-menu'),
     unlock: $('unlock'),
     pin: $('pin'),
     error: $('error'),
@@ -43,6 +45,7 @@
 
   let data = null;
   let isPayment = false;
+  let chosenPubkey = null; // fresh-login prompts only — see canOfferAccountSwitch in background.js
 
   function fmtSats(n) {
     return Number(n).toLocaleString('en-US');
@@ -98,6 +101,7 @@
     }
     data = resp.data;
     isPayment = data.scope === 'webln' && data.method === 'sendPayment';
+    chosenPubkey = data.activePubkey;
 
     els.host.textContent = data.host;
     const verb = isPayment ? 'wants to send a Lightning payment' : 'wants to ' + (METHOD_LABELS[data.method] || data.method);
@@ -140,8 +144,24 @@
     return npub.length > 20 ? npub.slice(0, 12) + '…' + npub.slice(-6) : npub;
   }
 
+  // All accounts selectable in this prompt: the one it opened with, plus (only
+  // for a fresh-site login — see canOfferAccountSwitch in background.js) any
+  // others the user could switch to before approving.
+  function accountList() {
+    return [
+      { pubkey: data.activePubkey, npub: data.npub, name: data.accountName, picture: data.accountPicture },
+      ...(data.otherAccounts || []),
+    ];
+  }
+
+  const CHECK_SVG =
+    '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="switch-row-check"><polyline points="20 6 9 17 4 12"></polyline></svg>';
+
   // Account capsule (pfp + name + npub), matching the side panel's account card.
   function buildAccountCapsule() {
+    const list = accountList();
+    const chosen = list.find((a) => a.pubkey === chosenPubkey) || list[0];
+
     els.account.innerHTML = '';
     const label = document.createElement('div');
     label.className = 'as-label';
@@ -150,13 +170,13 @@
     av.className = 'acct-av';
     av.referrerPolicy = 'no-referrer';
     av.onerror = () => { av.onerror = null; av.src = 'icons/avatar-default.svg'; };
-    av.src = data.accountPicture || 'icons/avatar-default.svg';
+    av.src = chosen.picture || 'icons/avatar-default.svg';
     const name = document.createElement('div');
     name.className = 'acct-name';
-    name.textContent = data.accountName || shortNpub(data.npub);
+    name.textContent = chosen.name || shortNpub(chosen.npub);
     const np = document.createElement('div');
     np.className = 'acct-np';
-    np.textContent = shortNpub(data.npub);
+    np.textContent = shortNpub(chosen.npub);
     const meta = document.createElement('div');
     meta.className = 'acct-meta';
     meta.append(name, np);
@@ -164,6 +184,54 @@
     cap.className = 'acct-capsule';
     cap.append(av, meta);
     els.account.append(label, cap);
+
+    els.switchMenu.innerHTML = '';
+    els.switchMenu.classList.add('hidden');
+    const canSwitch = !isPayment && Array.isArray(data.otherAccounts) && data.otherAccounts.length > 0;
+    if (!canSwitch) {
+      els.switchToggle.classList.add('hidden');
+      return;
+    }
+    els.switchToggle.classList.remove('hidden');
+    els.switchToggle.onclick = () => {
+      if (els.switchMenu.classList.contains('hidden')) {
+        buildSwitchMenu(list, chosen.pubkey);
+        els.switchMenu.classList.remove('hidden');
+      } else {
+        els.switchMenu.classList.add('hidden');
+      }
+    };
+  }
+
+  function buildSwitchMenu(list, chosenPk) {
+    els.switchMenu.innerHTML = '';
+    list.forEach((a) => {
+      const isChosen = a.pubkey === chosenPk;
+      const row = document.createElement('button');
+      row.className = 'switch-row' + (isChosen ? ' active' : '');
+      const av = document.createElement('img');
+      av.className = 'switch-row-av';
+      av.referrerPolicy = 'no-referrer';
+      av.onerror = () => { av.onerror = null; av.src = 'icons/avatar-default.svg'; };
+      av.src = a.picture || 'icons/avatar-default.svg';
+      const info = document.createElement('div');
+      info.className = 'switch-row-info';
+      const name = document.createElement('div');
+      name.className = 'switch-row-name';
+      name.textContent = a.name || shortNpub(a.npub);
+      const np = document.createElement('div');
+      np.className = 'switch-row-npub';
+      np.textContent = shortNpub(a.npub);
+      info.append(name, np);
+      row.append(av, info);
+      if (isChosen) row.insertAdjacentHTML('beforeend', CHECK_SVG);
+      row.addEventListener('click', () => {
+        chosenPubkey = a.pubkey;
+        els.switchMenu.classList.add('hidden');
+        buildAccountCapsule();
+      });
+      els.switchMenu.append(row);
+    });
   }
 
   async function decide(action) {
@@ -200,6 +268,10 @@
       }
       action = 'budget';
       extra = { budgetSats, perPaymentSats: 0 };
+    }
+    // Picked a different account in the switcher (fresh-login prompts only).
+    if (chosenPubkey && chosenPubkey !== data.activePubkey) {
+      extra = Object.assign({}, extra, { switchToPubkey: chosenPubkey });
     }
 
     els.allow.disabled = true;

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -283,6 +283,8 @@
       <div id="approval-preview" class="card hidden"></div>
 
       <div class="approval-account" id="approval-account"></div>
+      <button class="approval-switch-toggle hidden" id="approval-switch-toggle">Not you? Switch account</button>
+      <div class="approval-switch-menu hidden" id="approval-switch-menu"></div>
 
       <div id="approval-unlock" class="hidden stack">
         <label for="approval-pin">Enter your PIN to unlock</label>

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -283,7 +283,7 @@
       <div id="approval-preview" class="card hidden"></div>
 
       <div class="approval-account" id="approval-account"></div>
-      <button class="approval-switch-toggle hidden" id="approval-switch-toggle">Not you? Switch account</button>
+      <button class="approval-switch-toggle hidden" id="approval-switch-toggle">Sign in with a different account</button>
       <div class="approval-switch-menu hidden" id="approval-switch-menu"></div>
 
       <div id="approval-unlock" class="hidden stack">

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -6542,9 +6542,91 @@
     show(box);
   }
 
+  // All accounts selectable in this prompt: the one it opened with, plus (only
+  // for a fresh-site login — see canOfferAccountSwitch in background.js) any
+  // others the user could switch to before approving.
+  function approvalAccountList(data) {
+    return [
+      { pubkey: data.activePubkey, npub: data.npub, name: data.accountName, picture: data.accountPicture },
+      ...(data.otherAccounts || []),
+    ];
+  }
+
+  function renderApprovalAccountCapsule(data) {
+    const payment = isPaymentApproval(data);
+    const list = approvalAccountList(data);
+    const chosen = list.find((a) => a.pubkey === pendingApproval.chosenPubkey) || list[0];
+
+    const acct = $('approval-account');
+    acct.innerHTML = '';
+    acct.append(h('div', { className: 'approval-as', textContent: payment ? 'Paying from' : 'Signing as' }));
+    acct.append(
+      h('div', { className: 'active-account approval-capsule' }, [
+        avatarEl({ picture: chosen.picture }, 'aa-avatar'),
+        h('div', { className: 'aa-info' }, [
+          h('div', { className: 'aa-label', textContent: chosen.name || shortNpub(chosen.npub) }),
+          h('div', { className: 'aa-npub', textContent: shortNpub(chosen.npub) }),
+        ]),
+      ])
+    );
+
+    const toggle = $('approval-switch-toggle');
+    const menu = $('approval-switch-menu');
+    const canSwitch = !payment && Array.isArray(data.otherAccounts) && data.otherAccounts.length > 0;
+    menu.innerHTML = '';
+    hide(menu);
+    if (!canSwitch) {
+      hide(toggle);
+      return;
+    }
+    show(toggle);
+    toggle.onclick = () => {
+      if (menu.classList.contains('hidden')) {
+        buildApprovalSwitchMenu(data, list, chosen.pubkey);
+        show(menu);
+      } else {
+        hide(menu);
+      }
+    };
+  }
+
+  function buildApprovalSwitchMenu(data, list, chosenPubkey) {
+    const menu = $('approval-switch-menu');
+    menu.innerHTML = '';
+    list.forEach((a) => {
+      const isChosen = a.pubkey === chosenPubkey;
+      const row = h('button', { className: 'acct-row' + (isChosen ? ' active' : '') });
+      const av = document.createElement('span');
+      av.className = 'acct-row-av';
+      applyAvatar(av, a);
+      row.append(
+        av,
+        h('div', { className: 'acct-row-info' }, [
+          h('div', { className: 'acct-row-name', textContent: a.name || shortNpub(a.npub) }),
+          h('div', { className: 'acct-row-npub', textContent: shortNpub(a.npub) }),
+        ])
+      );
+      if (isChosen) {
+        const c = icon('check');
+        c.classList.add('acct-row-check');
+        row.append(c);
+      }
+      row.addEventListener('click', () => {
+        pendingApproval.chosenPubkey = a.pubkey;
+        hide(menu);
+        renderApprovalAccountCapsule(data);
+      });
+      menu.append(row);
+    });
+  }
+
   function showApproval() {
     if (!pendingApproval) return;
     const data = pendingApproval.data;
+    // Only initialize once per prompt — an incidental refresh() re-render (the
+    // panel treats a pending approval as modal and re-shows it) must not stomp
+    // a switch the user already picked.
+    if (pendingApproval.chosenPubkey == null) pendingApproval.chosenPubkey = data.activePubkey;
     closeAcctMenu();
     // Overlay on top of whatever's showing — don't hide the base view.
     show($('view-approval'));
@@ -6555,18 +6637,7 @@
       ? 'wants to send a Lightning payment'
       : 'wants to ' + (APPROVAL_METHOD_LABELS[data.method] || data.method);
 
-    const acct = $('approval-account');
-    acct.innerHTML = '';
-    acct.append(h('div', { className: 'approval-as', textContent: payment ? 'Paying from' : 'Signing as' }));
-    acct.append(
-      h('div', { className: 'active-account approval-capsule' }, [
-        avatarEl({ picture: data.accountPicture }, 'aa-avatar'),
-        h('div', { className: 'aa-info' }, [
-          h('div', { className: 'aa-label', textContent: data.accountName || shortNpub(data.npub) }),
-          h('div', { className: 'aa-npub', textContent: shortNpub(data.npub) }),
-        ]),
-      ])
-    );
+    renderApprovalAccountCapsule(data);
 
     renderApprovalPreview(data);
 
@@ -6647,6 +6718,10 @@
       }
       action = 'budget';
       extra = { budgetSats, perPaymentSats: 0 };
+    }
+    // Picked a different account in the switcher (fresh-login prompts only).
+    if (pendingApproval.chosenPubkey && pendingApproval.chosenPubkey !== data.activePubkey) {
+      extra = Object.assign({}, extra, { switchToPubkey: pendingApproval.chosenPubkey });
     }
     await bg({ type: 'SIDECAR_PROMPT_RESULT', id, action, extra });
     pendingApproval = null;

--- a/styles.css
+++ b/styles.css
@@ -1537,6 +1537,17 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
   max-height: 160px; overflow: auto; color: var(--text);
 }
 .approval-account { margin: 4px 0 18px; }
+.approval-switch-toggle {
+  display: block; width: 100%; background: none; border: none; cursor: pointer;
+  color: var(--lav); font-size: 12.5px; text-align: center; margin: -10px 0 14px; padding: 4px;
+}
+.approval-switch-toggle:hover { color: var(--text); }
+.approval-switch-menu {
+  text-align: left;
+  background: linear-gradient(180deg, var(--velvet-1), var(--velvet-2));
+  border: 1px solid var(--border-strong); border-radius: 14px;
+  padding: 6px; margin: -6px 0 14px; box-shadow: var(--sheen);
+}
 .approval-as {
   font-size: 10.5px; color: var(--muted); margin-bottom: 8px;
   text-transform: uppercase; letter-spacing: 0.22em; text-align: center;


### PR DESCRIPTION
When Sidecar has multiple accounts, the only way to log into a *new* site as a specific one was to switch the active account in the panel first, then go sign in — easy to forget, and you'd end up logged into the site as whatever was already active.

## What's included
- A **"Sign in with a different account"** picker in the approval prompt (both the in-panel overlay and the standalone popup), shown only on a site's *first* `getPublicKey()` call — i.e. before any account is bound to that host yet.
- Picking a different account there sets it active, binds the new site to it, and signs with it. Block/trust are applied to whichever account you actually land on, not the one the prompt originally opened with.

## Deliberately scoped to first-contact logins only
Once a site is bound (any request after its first), the switcher does **not** appear — by design. The per-site account binding exists specifically to stop a NIP-07 desync where the site thinks it's account A but Sidecar signs as account B. A site's first `getPublicKey()` is the one moment nothing is cached yet, so switching there is free. After that, the site has already cached a pubkey from login — hot-swapping identity on a later `signEvent` would silently recreate the exact desync problem the binding prevents, since NIP-07 has no "account changed" signal the site could react to.

Changing an *already-bound* site's account still goes through the existing **Activity → Connected sites → "Use [account]"** flow, which correctly requires signing out and back into the site. A same-prompt shortcut for that case (rebind + tell the user to re-login, without hot-swapping the current signature) is a reasonable follow-up, not part of this change.

## Test
1. With 2+ accounts, visit a site you've never used with Sidecar and trigger login (`getPublicKey`) → the prompt shows "Sign in with a different account."
2. Pick a different account → the "Signing as" capsule updates → approve → confirm the site actually receives that account's pubkey, and it's now the active account in the panel.
3. Trigger a second request from that same site → the switcher no longer appears, and it still signs as the bound account.
4. Verified on both the in-panel overlay and the standalone popup window.

🍾 Popped with [Claude Code](https://claude.com/claude-code)