### PR TITLE
Collapse Generate/Import into a compact Add account link

### DIFF
--- a/sidepanel.html
+++ b/sidepanel.html
@@ -85,6 +85,10 @@
           <button class="secondary" id="add-generate">Generate new</button>
           <button class="secondary" id="add-import">Import nsec</button>
         </div>
+        <button class="add-account-link hidden" id="add-account-link">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>
+          <span>Add account</span>
+        </button>
         <div class="explore-link-wrap">
           <a class="explore-link" id="explore-apps-link" href="#">Explore Nostr apps →</a>
           <a class="explore-link share-link" id="share-sidecar-link" href="#"><span>Share Sidecar with a friend</span></a>

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -86,7 +86,9 @@
           <button class="secondary" id="add-import">Import nsec</button>
         </div>
         <button class="add-account-link hidden" id="add-account-link">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>
+          <span class="add-account-badge">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>
+          </span>
           <span>Add account</span>
         </button>
         <div class="explore-link-wrap">

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -87,7 +87,7 @@
         </div>
         <button class="add-account-link hidden" id="add-account-link">
           <span class="add-account-badge">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>
           </span>
           <span>Add account</span>
         </button>

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -1897,26 +1897,27 @@
   // same two choices without needing a full button each.
   function addAccountModal() {
     openModal((modal) => {
-      const menuItem = (label, name, onClick) => {
-        const b = h('button', { className: 'menu-item' });
-        b.appendChild(icon(name));
-        b.appendChild(h('span', { textContent: label }));
+      const optionButton = (label, name, onClick) => {
+        const b = h('button', { className: 'secondary' });
+        b.append(icon(name), h('span', { textContent: label }));
         b.addEventListener('click', onClick);
         return b;
       };
-      const list = h('div', { className: 'menu-list' }, [
-        menuItem('Generate new', 'user-plus', () => {
-          closeModal();
-          generateAccount();
-        }),
-        menuItem('Import nsec', 'download', () => {
-          closeModal();
-          importAccountModal();
-        }),
-      ]);
+      const generate = optionButton('Generate new', 'user-plus', () => {
+        closeModal();
+        generateAccount();
+      });
+      const importBtn = optionButton('Import nsec', 'download', () => {
+        closeModal();
+        importAccountModal();
+      });
       const cancel = h('button', { className: 'ghost', textContent: 'Cancel' });
       cancel.addEventListener('click', closeModal);
-      modal.append(h('h3', { textContent: 'Add account' }), list, h('div', { className: 'actions' }, [cancel]));
+      modal.append(
+        h('h3', { textContent: 'Add account' }),
+        h('div', { className: 'add-actions modal-add-actions' }, [generate, importBtn]),
+        h('div', { className: 'actions' }, [cancel])
+      );
     });
   }
 

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -1427,6 +1427,12 @@
     $('acct-btn').disabled = !hasAccounts;
     $('accounts-heading').classList.toggle('hidden', !hasAccounts);
 
+    // Once an account exists, the two full-size Generate/Import buttons are no
+    // longer the primary action on this tab — collapse them into a small link
+    // that opens the same two choices in a compact menu.
+    document.querySelector('#tab-accounts .add-actions').classList.toggle('hidden', hasAccounts);
+    $('add-account-link').classList.toggle('hidden', !hasAccounts);
+
     // "Pinned and open" tip sits below the add buttons (where it won't get lost),
     // shown only while onboarding.
     let tip = $('welcome-tip');
@@ -1614,6 +1620,7 @@
   labelButton('add-import', 'download', 'Import nsec');
   $('add-generate').addEventListener('click', () => generateAccount());
   $('add-import').addEventListener('click', () => importAccountModal());
+  $('add-account-link').addEventListener('click', () => addAccountModal());
   $('explore-apps-link').addEventListener('click', (e) => {
     e.preventDefault();
     chrome.tabs.create({ url: chrome.runtime.getURL('welcome.html') });
@@ -1882,6 +1889,34 @@
         list,
         h('div', { className: 'actions' }, [cancel])
       );
+    });
+  }
+
+  // Compact "+ Add account" menu — once an account already exists, the two
+  // full-size Generate/Import buttons collapse into this link, which opens the
+  // same two choices without needing a full button each.
+  function addAccountModal() {
+    openModal((modal) => {
+      const menuItem = (label, name, onClick) => {
+        const b = h('button', { className: 'menu-item' });
+        b.appendChild(icon(name));
+        b.appendChild(h('span', { textContent: label }));
+        b.addEventListener('click', onClick);
+        return b;
+      };
+      const list = h('div', { className: 'menu-list' }, [
+        menuItem('Generate new', 'user-plus', () => {
+          closeModal();
+          generateAccount();
+        }),
+        menuItem('Import nsec', 'download', () => {
+          closeModal();
+          importAccountModal();
+        }),
+      ]);
+      const cancel = h('button', { className: 'ghost', textContent: 'Cancel' });
+      cancel.addEventListener('click', closeModal);
+      modal.append(h('h3', { textContent: 'Add account' }), list, h('div', { className: 'actions' }, [cancel]));
     });
   }
 

--- a/styles.css
+++ b/styles.css
@@ -774,12 +774,17 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
 /* full-width stacked account actions with breathing room above */
 .add-actions { display: flex; flex-direction: column; gap: 10px; margin-top: 30px; }
 .add-account-link {
-  display: flex; align-items: center; justify-content: center; gap: 6px;
+  display: flex; align-items: center; justify-content: center; gap: 8px;
   width: 100%; margin-top: 18px; padding: 6px; background: none; border: none;
   cursor: pointer; color: var(--muted); font-size: 13px; font-family: inherit;
 }
-.add-account-link svg { width: 15px; height: 15px; }
+.add-account-badge {
+  display: flex; align-items: center; justify-content: center; flex-shrink: 0;
+  width: 20px; height: 20px; border-radius: 50%; background: var(--purple); color: #fff;
+}
+.add-account-badge svg { width: 12px; height: 12px; }
 .add-account-link:hover { color: var(--lav); }
+.add-account-link:hover .add-account-badge { background: var(--lav); }
 .explore-link-wrap { display: flex; flex-direction: column; gap: 8px; margin-top: 24px; padding: 0 4px; }
 .explore-link { font-size: 13px; color: var(--muted); text-decoration: none; text-align: center; display: block; }
 .explore-link:hover { color: var(--lav); }

--- a/styles.css
+++ b/styles.css
@@ -773,17 +773,17 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
 
 /* full-width stacked account actions with breathing room above */
 .add-actions { display: flex; flex-direction: column; gap: 10px; margin-top: 30px; }
+.modal-add-actions { margin-top: 6px; margin-bottom: 4px; }
 .add-account-link {
   display: flex; align-items: center; justify-content: center; gap: 8px;
   width: 100%; margin-top: 18px; padding: 6px; background: none; border: none;
-  cursor: pointer; color: var(--muted); font-size: 13px; font-family: inherit;
+  cursor: pointer; color: var(--lav); font-size: 13px; font-weight: 700; font-family: inherit;
 }
 .add-account-badge {
   display: flex; align-items: center; justify-content: center; flex-shrink: 0;
-  width: 20px; height: 20px; border-radius: 50%; background: var(--purple); color: #fff;
+  width: 20px; height: 20px; border-radius: 50%; background: var(--purple); color: #2a1257;
 }
 .add-account-badge svg { width: 12px; height: 12px; }
-.add-account-link:hover { color: var(--lav); }
 .add-account-link:hover .add-account-badge { background: var(--lav); }
 .explore-link-wrap { display: flex; flex-direction: column; gap: 8px; margin-top: 24px; padding: 0 4px; }
 .explore-link { font-size: 13px; color: var(--muted); text-decoration: none; text-align: center; display: block; }

--- a/styles.css
+++ b/styles.css
@@ -773,6 +773,13 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
 
 /* full-width stacked account actions with breathing room above */
 .add-actions { display: flex; flex-direction: column; gap: 10px; margin-top: 30px; }
+.add-account-link {
+  display: flex; align-items: center; justify-content: center; gap: 6px;
+  width: 100%; margin-top: 18px; padding: 6px; background: none; border: none;
+  cursor: pointer; color: var(--muted); font-size: 13px; font-family: inherit;
+}
+.add-account-link svg { width: 15px; height: 15px; }
+.add-account-link:hover { color: var(--lav); }
 .explore-link-wrap { display: flex; flex-direction: column; gap: 8px; margin-top: 24px; padding: 0 4px; }
 .explore-link { font-size: 13px; color: var(--muted); text-decoration: none; text-align: center; display: block; }
 .explore-link:hover { color: var(--lav); }


### PR DESCRIPTION
Once you already have an account, two full-width "Generate new" / "Import nsec" buttons sitting permanently on the Accounts tab is more visual weight than the action deserves.

## What's included
- Once at least one account exists, those two buttons collapse into a small **"+ Add account"** link (no full button shape) — a purple circle badge with a bold dark-purple plus, lavender bold text.
- Tapping it opens a compact modal with the same two options, styled as real buttons (matching the original look) rather than a sparse menu list.
- The onboarding view (zero accounts) is unchanged — full-size buttons stay as the primary call to action there.

## Test
1. Fresh install (no accounts) → full-size Generate/Import buttons, no compact link.
2. Create the first account → buttons collapse into "+ Add account".
3. Tap it → modal opens with button-styled Generate new / Import nsec options, both working as before.

🍸 Garnished with [Claude Code](https://claude.com/claude-code)