### PR TITLE
Filter Connected sites and Recent activity by site name; order by most recently used

### DIFF
--- a/sidepanel.html
+++ b/sidepanel.html
@@ -103,11 +103,13 @@
         <div class="setting">
           <h3>Connected sites</h3>
           <p class="hint">Each site stays pinned to the account it signed in with. To move a site to your active account, tap <b>Use</b> on it, then sign out and back in on that site.</p>
+          <input type="text" class="filter-input hidden" id="sites-filter" placeholder="Filter by site…" />
           <div id="sites-list" class="list flat"></div>
           <button class="ghost show-more-btn hidden" id="sites-more">Show more</button>
         </div>
         <div class="setting">
           <h3>Recent activity</h3>
+          <input type="text" class="filter-input hidden" id="activity-filter" placeholder="Filter by site…" />
           <div id="activity-list" class="list flat"></div>
           <button class="ghost show-more-btn hidden" id="activity-more">Show more</button>
           <button class="ghost" id="activity-clear">Clear history</button>

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -2379,56 +2379,90 @@
       call({ type: 'SIDECAR_GET_SITE_BINDINGS' }),
     ]);
     const sites = $('sites-list');
-    sites.innerHTML = '';
+    const sitesFilter = $('sites-filter');
+    const sitesMore = $('sites-more');
     // Union of the active account's permissioned hosts and every bound host, so
     // a site pinned to a different account still shows up (and can be switched).
     const hosts = [...new Set([...Object.keys(perms), ...Object.keys(bindings)])].sort();
-    sites.classList.toggle('empty', !hosts.length);
-    const sitesMore = $('sites-more');
+
     if (!hosts.length) {
+      sites.innerHTML = '';
+      sites.classList.add('empty');
       listState(sites, 'No sites have connected yet.');
       hide(sitesMore);
+      hide(sitesFilter);
     } else {
-      // The list can get long — show a handful, then paginate (like the log below).
-      const SITES_PAGE = 6;
-      let shownSites = 0;
-      const renderSitesPage = () => {
-        hosts.slice(shownSites, shownSites + SITES_PAGE).forEach((host) =>
-          sites.append(siteRow(host, perms[host] ? perms[host].level : 'ask', bindings[host] || null))
-        );
-        shownSites = Math.min(shownSites + SITES_PAGE, hosts.length);
-        if (shownSites >= hosts.length) hide(sitesMore);
-        else {
-          show(sitesMore);
-          sitesMore.textContent = 'Show more (' + (hosts.length - shownSites) + ')';
+      show(sitesFilter);
+      sitesFilter.value = '';
+      const renderSites = () => {
+        sites.innerHTML = '';
+        const q = sitesFilter.value.trim().toLowerCase();
+        const filtered = q ? hosts.filter((host) => host.toLowerCase().includes(q)) : hosts;
+        sites.classList.toggle('empty', !filtered.length);
+        if (!filtered.length) {
+          listState(sites, 'No sites match "' + sitesFilter.value.trim() + '".');
+          hide(sitesMore);
+          return;
         }
+        // The list can get long — show a handful, then paginate (like the log below).
+        const SITES_PAGE = 6;
+        let shownSites = 0;
+        const renderSitesPage = () => {
+          filtered.slice(shownSites, shownSites + SITES_PAGE).forEach((host) =>
+            sites.append(siteRow(host, perms[host] ? perms[host].level : 'ask', bindings[host] || null))
+          );
+          shownSites = Math.min(shownSites + SITES_PAGE, filtered.length);
+          if (shownSites >= filtered.length) hide(sitesMore);
+          else {
+            show(sitesMore);
+            sitesMore.textContent = 'Show more (' + (filtered.length - shownSites) + ')';
+          }
+        };
+        sitesMore.onclick = renderSitesPage;
+        renderSitesPage();
       };
-      sitesMore.onclick = renderSitesPage;
-      renderSitesPage();
+      sitesFilter.oninput = renderSites;
+      renderSites();
     }
 
     const log = await call({ type: 'SIDECAR_GET_ACTIVITY' });
     const list = $('activity-list');
-    list.innerHTML = '';
+    const activityFilter = $('activity-filter');
+    const more = $('activity-more');
     if (!log.length) {
+      list.innerHTML = '';
       listState(list, 'No signing activity yet.');
-      hide($('activity-more'));
+      hide(more);
+      hide(activityFilter);
       return;
     }
-    const PAGE = 30;
-    let shown = 0;
-    const more = $('activity-more');
-    function renderPage() {
-      log.slice(shown, shown + PAGE).forEach((e) => list.append(activityRow(e)));
-      shown = Math.min(shown + PAGE, log.length);
-      if (shown >= log.length) hide(more);
-      else {
-        show(more);
-        more.textContent = 'Show more (' + (log.length - shown) + ')';
+    show(activityFilter);
+    activityFilter.value = '';
+    const renderActivityLog = () => {
+      list.innerHTML = '';
+      const q = activityFilter.value.trim().toLowerCase();
+      const filtered = q ? log.filter((e) => (e.host || '').toLowerCase().includes(q)) : log;
+      if (!filtered.length) {
+        listState(list, 'No activity matches "' + activityFilter.value.trim() + '".');
+        hide(more);
+        return;
       }
-    }
-    more.onclick = renderPage;
-    renderPage();
+      const PAGE = 30;
+      let shown = 0;
+      function renderPage() {
+        filtered.slice(shown, shown + PAGE).forEach((e) => list.append(activityRow(e)));
+        shown = Math.min(shown + PAGE, filtered.length);
+        if (shown >= filtered.length) hide(more);
+        else {
+          show(more);
+          more.textContent = 'Show more (' + (filtered.length - shown) + ')';
+        }
+      }
+      more.onclick = renderPage;
+      renderPage();
+    };
+    activityFilter.oninput = renderActivityLog;
+    renderActivityLog();
   }
 
   $('activity-clear').addEventListener('click', async () => {

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -2374,16 +2374,28 @@
   }
 
   async function renderActivity() {
-    const [perms, bindings] = await Promise.all([
+    const [perms, bindings, log] = await Promise.all([
       call({ type: 'SIDECAR_GET_PERMISSIONS' }),
       call({ type: 'SIDECAR_GET_SITE_BINDINGS' }),
+      call({ type: 'SIDECAR_GET_ACTIVITY' }),
     ]);
     const sites = $('sites-list');
     const sitesFilter = $('sites-filter');
     const sitesMore = $('sites-more');
     // Union of the active account's permissioned hosts and every bound host, so
     // a site pinned to a different account still shows up (and can be switched).
-    const hosts = [...new Set([...Object.keys(perms), ...Object.keys(bindings)])].sort();
+    // Ordered by most-recently-used first (per the activity log, which is already
+    // newest-first) so an active site isn't buried pages deep behind stale ones;
+    // sites with no logged activity yet sort after, alphabetically among themselves.
+    const lastUsed = new Map();
+    for (const e of log) if (e.host && !lastUsed.has(e.host)) lastUsed.set(e.host, e.ts);
+    const hosts = [...new Set([...Object.keys(perms), ...Object.keys(bindings)])].sort((a, b) => {
+      const ta = lastUsed.get(a), tb = lastUsed.get(b);
+      if (ta != null && tb != null) return tb - ta;
+      if (ta != null) return -1;
+      if (tb != null) return 1;
+      return a.localeCompare(b);
+    });
 
     if (!hosts.length) {
       sites.innerHTML = '';
@@ -2425,7 +2437,6 @@
       renderSites();
     }
 
-    const log = await call({ type: 'SIDECAR_GET_ACTIVITY' });
     const list = $('activity-list');
     const activityFilter = $('activity-filter');
     const more = $('activity-more');

--- a/styles.css
+++ b/styles.css
@@ -615,6 +615,7 @@ button:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(203, 161, 78, 0
 .avatar-ph img { width: 64%; height: 64%; margin: 18%; object-fit: contain; opacity: 0.72; }
 
 /* lists */
+.filter-input { margin-bottom: 10px; font-size: 13.5px; padding: 9px 12px; }
 .list { display: flex; flex-direction: column; gap: 9px; margin-bottom: 14px; }
 .item {
   display: flex;


### PR DESCRIPTION
Both lists in the Activity tab can grow long over time — an actively-used site could end up pages deep behind ones you haven't touched in months, with no way to jump straight to it.

## What's included
- A live text filter above both **Connected sites** and **Recent activity**, matching by hostname substring. Clearing it restores the full (still-paginated) list; a clear "No sites/activity match" empty state shows when nothing matches.
- **Connected sites** is now ordered by most-recently-used first (based on each host's latest activity-log timestamp), instead of alphabetically. Sites with no logged activity yet sort after, alphabetically among themselves.

## Test
1. With several connected sites, type into the new filter field above "Connected sites" → list narrows to matching hostnames; clear it → full list returns.
2. Same for "Recent activity."
3. Use a site, then use a different one more recently → confirm the more-recently-used site moves to the top of Connected sites on next visit to the Activity tab.

🍺 Tapped with [Claude Code](https://claude.com/claude-code)