### PR TITLE
Bump version to 1.3.0

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Sidecar | A Classy Nostr Signer",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A multi-account NIP-07 Nostr signer with a built-in Lightning wallet, in your browser sidebar.",
   "permissions": [
     "storage",


### PR DESCRIPTION
main has accumulated a full round of features since the 1.2.0 tag (NIP-49 import/export, full vault backup, NIP-05 verification, the login-time account switcher, dev build indicator, activity filters, and more) — time for the next Chrome Web Store build.

🍷 Decanted with [Claude Code](https://claude.com/claude-code)