### PR TITLE
Refresh the notification bell's mute list on every open

### DIFF
--- a/sidepanel.js
+++ b/sidepanel.js
@@ -1065,8 +1065,13 @@
   // like Jumble) encrypted to self — try the format the ciphertext looks like,
   // then fall back to the other. Deduped per pubkey via a promise cache; when it
   // resolves it also drops any already-cached events from muted authors.
-  function loadMuteList(pubkey, relays) {
-    if (_muteListPromises.has(pubkey)) return _muteListPromises.get(pubkey);
+  //
+  // The promise cache never expired on its own, so a mute added elsewhere after
+  // the panel loaded (a long-lived pinned panel can run for hours) was invisible
+  // for the rest of the session — the bell kept using the pre-mute list forever.
+  // `force` (used when the bell is opened) bypasses the cache for a fresh fetch.
+  function loadMuteList(pubkey, relays, force) {
+    if (_muteListPromises.has(pubkey) && !force) return _muteListPromises.get(pubkey);
     const p = (async () => {
       const muted = new Set();
       try {
@@ -1092,7 +1097,9 @@
         }
       } catch (_) {}
       _muteLists.set(pubkey, muted);
-      // Drop any events that slipped into the cache before the list was ready.
+      // Drop any events that slipped into the cache before the list was ready
+      // (first load), or that arrived from a user muted after the fact (a
+      // later, force-triggered re-fetch when the bell is opened).
       const cache = _notifCache.get(pubkey);
       if (cache && muted.size) {
         const before = cache.events.length;
@@ -1204,8 +1211,10 @@
     const client = await preferredClient();
     const relays = await relayUrls(false);
 
-    // Final guard: ensure the mute list has resolved, then filter the view.
-    await Promise.race([loadMuteList(a.pubkey, relays), new Promise((r) => setTimeout(r, 3000))]);
+    // Final guard: force a fresh mute list (not the possibly hours-stale cached
+    // one — see loadMuteList) so a mute added since the panel opened takes
+    // effect the moment the bell is opened, then filter the view.
+    await Promise.race([loadMuteList(a.pubkey, relays, true), new Promise((r) => setTimeout(r, 3000))]);
     const muted = _muteLists.get(a.pubkey);
     const events = muted && muted.size ? cache.events.filter((e) => !muted.has(e.pubkey)) : cache.events;
     const PAGE = 25;


### PR DESCRIPTION
Reported: a muted user's reactions kept showing up in notifications even though they were muted.

Root cause: the mute list (kind 10000) was fetched once per panel session and cached in a promise map with no invalidation. If a mute happened (in Sidecar or any other client) after the panel had already loaded — easy to hit, since Sidecar's own onboarding tip encourages keeping the panel pinned and open — the notification bell kept using the pre-mute list for the rest of the session. Nothing ever re-fetched it.

## Fix
`loadMuteList()` takes an optional `force` flag that bypasses the cache. `showNotifModal()` now passes it, so opening the bell always checks the current mute list before filtering, instead of reusing a possibly hours-stale one. The first-load call in `initNotifSubs()` is unchanged.

## Test
Confirmed by the reporter. Workaround for anyone hitting this on an older build: close and reopen the side panel to force a fresh mute-list fetch.

🍸 Whisked with [Claude Code](https://claude.com/claude-code)