### PR TITLE
Link sidecar.dmnyc.net; refresh README hero image

### DIFF
--- a/.claude/skills/update-sidecar-site/SKILL.md
+++ b/.claude/skills/update-sidecar-site/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: update-sidecar-site
+description: Keep sidecar.dmnyc.net (the official standalone site linked from the Chrome Web Store listing) in sync with this repo's README, FEATURES.md, and PRIVACY.md, and deploy it. Use when PRIVACY.md, FEATURES.md, or the README's Features section changes, when the Chrome Web Store URL changes, when app icons/logo assets change, or when explicitly asked to update or deploy sidecar.dmnyc.net.
+---
+
+# Update sidecar.dmnyc.net
+
+sidecar.dmnyc.net is Sidecar's official marketing/homepage site — the link the
+Chrome Web Store listing points to. Its source lives in a **separate repo**,
+`dmnycnet` (the dmnyc.net project showcase + this subdomain), not in this
+`sidecar` repo. Assume it's checked out at `/Users/daniel/GitHub/dmnycnet` — if
+it isn't there, stop and ask where it lives instead of guessing.
+
+No build step: plain PHP, no framework. Edit files directly.
+
+## Where things live
+
+```
+dmnycnet/public_sidecar_dmnyc_net/
+  index.php        # hero + feature highlights + Chrome Web Store CTA
+  features.php      # full feature list
+  privacy.php        # privacy policy — must mirror sidecar's PRIVACY.md
+  includes/header.php  # nav, <title>, Chrome Web Store link lives in each page that needs it
+  includes/footer.php
+  assets/css/site.css  # accent color #FFA01B (from the martini glass icon), not dmnyc.net's yellow
+  assets/img/           # sidecar-logo.svg, icon128/48/32/16.png, social-card.png — copied from
+                        # this repo's assets/ and icons/ dirs, not generated
+```
+
+## Keeping content in sync
+
+**privacy.php must match PRIVACY.md.** This is a legal document referenced by
+the Chrome Web Store, not marketing copy — when `PRIVACY.md` in this repo
+changes, transcribe the changes into `privacy.php` verbatim (convert Markdown
+to the existing HTML structure, don't paraphrase), and update the "Last
+updated" date to match.
+
+**features.php is written from README.md's "Features" section, not
+FEATURES.md.** `FEATURES.md` in this repo is internal tester/beta notes
+("Please test & report", "early tester build" caveats) — not public-facing
+copy. When the feature set changes, pull the polished description from
+`README.md`'s Features section and adapt it into `features.php`'s existing
+category structure (Accounts & keys, Signing, Lightning wallet, Profile &
+backups, Note composer, Settings & safety), not from FEATURES.md.
+
+**Chrome Web Store URL** lives in `index.php` (`$chromeStoreUrl`) — currently
+`https://chromewebstore.google.com/detail/sidecar-a-classy-nostr-si/moimlikilhheabdafocpmneehpblhiln`.
+Update if the listing URL ever changes (e.g. a new extension ID).
+
+**Assets** (`sidecar-logo.svg`, `icon128.png`, etc.) are copied byte-for-byte
+from this repo's `assets/` and `icons/` directories — if those are
+regenerated/redesigned here, re-copy the updated files into
+`dmnycnet/public_sidecar_dmnyc_net/assets/img/` under the same filenames.
+
+## Verify before deploying
+
+No build step, so just serve it locally and click through:
+
+```bash
+cd /Users/daniel/GitHub/dmnycnet
+php -S localhost:8011 -t public_sidecar_dmnyc_net
+```
+
+Check `http://localhost:8011/`, `/features.php`, and `/privacy.php` render
+with no PHP warnings and all images resolve.
+
+## Deploy
+
+```bash
+cd /Users/daniel/GitHub/dmnycnet
+./deploy/deploy.sh sidecar
+```
+
+This rsyncs `public_sidecar_dmnyc_net/` to the `sidecar.dmnyc.net` Dreamhost
+docroot over SSH, using credentials in `dmnycnet/deploy/.env` (gitignored,
+not part of this repo). If that file or its `SIDECAR_*` credentials are
+missing, the script will say so — ask the user for them rather than guessing
+paths or reconstructing credentials.
+
+After deploying, spot-check the live site:
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" https://sidecar.dmnyc.net/
+```

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ web apps you use, so you can sign in and sign events across Nostr clients withou
 pasting your nsec anywhere. It also has a built-in Lightning wallet (Nostr Wallet
 Connect) and a composer for posting notes directly from the panel.
 
+**[Website](https://sidecar.dmnyc.net)** · **[Chrome Web Store](https://chromewebstore.google.com/detail/sidecar-a-classy-nostr-si/moimlikilhheabdafocpmneehpblhiln)** · **[Privacy Policy](https://sidecar.dmnyc.net/privacy.php)**
+
 <img width="2816" height="1566" alt="Sidecar" src="https://i.nostr.build/Sr11DBpz7pVITHoS.png" />
 
 > "Best Nostr Extension ever! Every Nostr app should take notes on this onboarding flow. This makes me want to use Nostr."

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Connect) and a composer for posting notes directly from the panel.
 
 **[Website](https://sidecar.dmnyc.net)** · **[Chrome Web Store](https://chromewebstore.google.com/detail/sidecar-a-classy-nostr-si/moimlikilhheabdafocpmneehpblhiln)** · **[Privacy Policy](https://sidecar.dmnyc.net/privacy.php)**
 
-<img width="2816" height="1566" alt="Sidecar" src="https://i.nostr.build/Sr11DBpz7pVITHoS.png" />
+<img width="3456" height="1944" alt="Sidecar" src="https://i.nostr.build/jCcJyt3Jb5HDTUhK.jpg" />
 
 > "Best Nostr Extension ever! Every Nostr app should take notes on this onboarding flow. This makes me want to use Nostr."
 >

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -3279,6 +3279,7 @@
   const CLIENT_TAG = ['client', 'Sidecar'];
   // ---- About / zap-the-creator ----
   const GITHUB_URL = 'https://github.com/dmnyc/sidecar';
+  const SIDECAR_SITE_URL = 'https://sidecar.dmnyc.net';
   const CREATOR_NPUB = 'npub1aeh2zw4elewy5682lxc6xnlqzjnxksq303gwu2npfaxd49vmde6qcq4nwx';
   const CREATOR_LN = 'daniel@breez.tips';
   const IMG_EXT = /\.(jpg|jpeg|png|gif|webp|svg|bmp|avif)(\?.*)?$/i;
@@ -6438,6 +6439,8 @@
       preferredClient().then((client) => { creator.href = client.profile(CREATOR_NPUB); }).catch(() => {});
       fetchProfileName(CREATOR_NPUB).then((name) => { if (name) creator.textContent = '@' + name.replace(/^@/, ''); });
 
+      const website = h('a', { className: 'about-link', textContent: 'Website', href: SIDECAR_SITE_URL, target: '_blank', rel: 'noopener noreferrer' });
+      const privacy = h('a', { className: 'about-link', textContent: 'Privacy Policy', href: SIDECAR_SITE_URL + '/privacy.php', target: '_blank', rel: 'noopener noreferrer' });
       const repo = h('a', { className: 'about-link', textContent: 'GitHub', href: GITHUB_URL, target: '_blank', rel: 'noopener noreferrer' });
       const issues = h('a', { className: 'about-link', textContent: 'Report an issue', href: GITHUB_URL + '/issues', target: '_blank', rel: 'noopener noreferrer' });
       const zap = h('button', { className: 'about-link about-link-btn' }, [document.createTextNode('Zap the creator '), boltIcon()]);
@@ -6456,7 +6459,7 @@
           ver ? h('div', { className: 'about-version', textContent: verText }) : document.createTextNode(''),
           updateBtn,
           updateStatus,
-          h('div', { className: 'about-links' }, [repo, issues, zap]),
+          h('div', { className: 'about-links' }, [website, repo, issues, privacy, zap]),
         ])
       );
     });

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -6443,7 +6443,7 @@
       const privacy = h('a', { className: 'about-link', textContent: 'Privacy Policy', href: SIDECAR_SITE_URL + '/privacy.php', target: '_blank', rel: 'noopener noreferrer' });
       const repo = h('a', { className: 'about-link', textContent: 'GitHub', href: GITHUB_URL, target: '_blank', rel: 'noopener noreferrer' });
       const issues = h('a', { className: 'about-link', textContent: 'Report an issue', href: GITHUB_URL + '/issues', target: '_blank', rel: 'noopener noreferrer' });
-      const zap = h('button', { className: 'about-link about-link-btn' }, [document.createTextNode('Zap the creator '), boltIcon()]);
+      const zap = h('button', { className: 'about-link about-link-btn' }, [document.createTextNode('Support Sidecar '), boltIcon()]);
       zap.addEventListener('click', () => { closeModal(); creatorZapModal(); });
 
       const updateBtn = h('button', { className: 'about-update-btn', textContent: 'Check for updates' });


### PR DESCRIPTION
## Summary
- Link the new sidecar.dmnyc.net website and its Privacy Policy from the README and the extension's About modal
- Track the `update-sidecar-site` Claude skill in-repo (was previously excluded by a global gitignore rule and had never actually been committed)
- Refresh the README hero image with a new screenshot (Pay-with-Sidecar prompt + Profile panel)
- Rename the About modal's "Zap the creator" button to "Support Sidecar"

## Test plan
- [x] Verified sidecar.dmnyc.net and its /privacy.php page resolve (200)
- [x] Verified new hero image URL resolves and confirmed dimensions
- [x] Loaded the extension in Chrome via Puppeteer and confirmed the About modal renders Website / GitHub / Report an issue / Privacy Policy / Support Sidecar links correctly

🍷 Poured with [Claude Code](https://claude.com/claude-code)