### PR TITLE
Account switching that works the way users expect

### DIFF
--- a/background.js
+++ b/background.js
@@ -345,14 +345,37 @@ async function handleNostrRpc(method, params, host, sendResponse) {
     await KS.ensureLoaded(); // rehydrate unlocked session if the SW was restarted
     if (!(await KS.isInitialized())) throw new Error('Sidecar has no accounts set up yet');
 
+    let signKind = null;
+    let signEvent = null;
+    if (method === 'signEvent') {
+      signEvent = params && (params.event || params);
+      signKind = signEvent && signEvent.kind;
+    }
+
     // The identity this request signs as. getPublicKey is a login: it
     // establishes identity, so it follows the globally-active account (and, on
     // success, re-pairs the host to it below). Everything session-shaped —
     // signEvent, nip04/nip44, relay auth — stays pinned to the account the host
     // logged in with, so open sessions never desync on a panel account switch.
-    let activePubkey = method === 'getPublicKey'
-      ? await KS.getActivePubkey()
-      : await resolveSiteAccount(host);
+    //
+    // One exception: applesauce-based clients (noStrudel and friends) stamp the
+    // intended author's pubkey on the event template. That's the client
+    // explicitly naming which identity it wants, so when it names another
+    // account we hold, honor it — the requested account's own per-site
+    // permissions still gate the signature below, so a site can never quietly
+    // reach an identity that hasn't approved it.
+    let activePubkey;
+    let authorSwitched = false;
+    if (method === 'getPublicKey') {
+      activePubkey = await KS.getActivePubkey();
+    } else {
+      activePubkey = await resolveSiteAccount(host);
+      const requestedAuthor = signEvent && typeof signEvent.pubkey === 'string' ? signEvent.pubkey : null;
+      if (requestedAuthor && requestedAuthor !== activePubkey && (await KS.hasAccount(requestedAuthor))) {
+        activePubkey = requestedAuthor;
+        authorSwitched = true;
+      }
+    }
     if (!activePubkey) throw new Error('No active Sidecar account');
 
     const status = await PERMS.getPermissionStatus(activePubkey, host, method); // allow | reject | ask
@@ -365,14 +388,11 @@ async function handleNostrRpc(method, params, host, sendResponse) {
     // But the exemption is a silent signing oracle if abused, so we only skip the
     // prompt when the event is a *well-formed* auth event (see isNip42AuthEvent):
     // relay + challenge tags only, near-current timestamp, no arbitrary payload.
-    // Anything else falls back to the normal approval prompt.
-    let signKind = null;
-    let signEvent = null;
-    if (method === 'signEvent') {
-      signEvent = params && (params.event || params);
-      signKind = signEvent && signEvent.kind;
-    }
-    const isRelayAuth = method === 'signEvent' && isNip42AuthEvent(signEvent);
+    // Anything else falls back to the normal approval prompt. An auth event that
+    // names a DIFFERENT account than the site's binding never gets the exemption:
+    // silently relay-authing as an identity that hasn't approved this site would
+    // let a page link the user's accounts without any consent moment.
+    const isRelayAuth = method === 'signEvent' && !authorSwitched && isNip42AuthEvent(signEvent);
 
     const needsKey = SIGNER.needsPrivateKey(method);
     const needUnlock = needsKey && KS.isLocked();
@@ -447,12 +467,15 @@ async function handleNostrRpc(method, params, host, sendResponse) {
       result = await SIGNER.perform(method, params, privBytes, activePubkey);
     }
 
-    // Pin this host to the account it just successfully used. Only a login
-    // (getPublicKey) may MOVE an existing binding — a session-shaped request
+    // Pin this host to the account it just successfully used. Only an explicit
+    // identity choice may MOVE an existing binding: a login (getPublicKey) or a
+    // template that named its author (authorSwitched). A session-shaped request
     // that resolved against the old binding but completed after a re-login
     // (a pending approval, an in-flight batch of DM decrypts) must not write
-    // the old account back over the new one.
-    if (method === 'getPublicKey' || !(await getSiteAccount(host))) {
+    // the old account back over the new one. Following an honored author keeps
+    // the site's implicit requests (nip04/nip44) on the identity the client
+    // last exercised.
+    if (method === 'getPublicKey' || authorSwitched || !(await getSiteAccount(host))) {
       await setSiteAccount(host, activePubkey);
     }
 

--- a/background.js
+++ b/background.js
@@ -76,10 +76,14 @@ function safeFetchUrl(raw) {
 }
 
 // ---- per-site account binding ----
-// A web client caches the pubkey from its first getPublicKey() and has no way to
+// A web client caches the pubkey from its last getPublicKey() and has no way to
 // learn about an account switch. So we PIN each host to the account it logged in
-// with: that host keeps signing as its bound identity regardless of which account
-// is globally active. The global active account only drives new logins + the panel UI.
+// with: session-shaped requests (signEvent, nip04/nip44, relay auth) keep signing
+// as the bound identity regardless of which account is globally active.
+// getPublicKey() is the exception: it's a login — the site is asking "who are you
+// now?" — so it follows the globally-active account and re-pairs the host to it
+// (see handleNostrRpc). Log out of a site, switch accounts in the panel, log back
+// in, and the site follows; open sessions on other sites never desync.
 const SITE_ACCTS_KEY = 'sidecar_site_accounts';
 
 async function getSiteAccount(host) {
@@ -341,10 +345,14 @@ async function handleNostrRpc(method, params, host, sendResponse) {
     await KS.ensureLoaded(); // rehydrate unlocked session if the SW was restarted
     if (!(await KS.isInitialized())) throw new Error('Sidecar has no accounts set up yet');
 
-    // The identity this host signs as — pinned to whatever it logged in with,
-    // independent of the globally-active account (prevents NIP-07 desync).
-    const boundPubkey = await getSiteAccount(host);
-    let activePubkey = await resolveSiteAccount(host);
+    // The identity this request signs as. getPublicKey is a login: it
+    // establishes identity, so it follows the globally-active account (and, on
+    // success, re-pairs the host to it below). Everything session-shaped —
+    // signEvent, nip04/nip44, relay auth — stays pinned to the account the host
+    // logged in with, so open sessions never desync on a panel account switch.
+    let activePubkey = method === 'getPublicKey'
+      ? await KS.getActivePubkey()
+      : await resolveSiteAccount(host);
     if (!activePubkey) throw new Error('No active Sidecar account');
 
     const status = await PERMS.getPermissionStatus(activePubkey, host, method); // allow | reject | ask
@@ -370,13 +378,12 @@ async function handleNostrRpc(method, params, host, sendResponse) {
     const needUnlock = needsKey && KS.isLocked();
     const needApproval = status === 'ask' && !isRelayAuth;
 
-    // A brand-new site (no binding yet) is the one safe moment to offer switching
-    // identity right in the prompt: nothing on the site has cached a pubkey yet,
-    // so there's no desync risk. Once a site is bound, its signing identity can
-    // only change via the deliberate "Use <account>" + re-login flow in the
-    // Activity tab — swapping mid-session here would silently break NIP-07 sync
-    // the same way the binding itself was built to prevent.
-    const canOfferAccountSwitch = method === 'getPublicKey' && !boundPubkey;
+    // Every getPublicKey is a login, and a login is the safe moment to pick an
+    // identity: whatever pubkey we return is the identity the site adopts from
+    // here on, so offering the account switcher in the prompt can't desync
+    // anything. Session-shaped methods never offer it — their identity is fixed
+    // by the host's binding.
+    const canOfferAccountSwitch = method === 'getPublicKey';
 
     // Once unlocked, signing only needs site approval — no PIN re-entry.
     if (needApproval || needUnlock) {
@@ -440,8 +447,14 @@ async function handleNostrRpc(method, params, host, sendResponse) {
       result = await SIGNER.perform(method, params, privBytes, activePubkey);
     }
 
-    // Pin this host to the account it just successfully used (idempotent).
-    await setSiteAccount(host, activePubkey);
+    // Pin this host to the account it just successfully used. Only a login
+    // (getPublicKey) may MOVE an existing binding — a session-shaped request
+    // that resolved against the old binding but completed after a re-login
+    // (a pending approval, an in-flight batch of DM decrypts) must not write
+    // the old account back over the new one.
+    if (method === 'getPublicKey' || !(await getSiteAccount(host))) {
+      await setSiteAccount(host, activePubkey);
+    }
 
     logActivity({ ts: Date.now(), host, method, kind: signKind, pubkey: activePubkey });
 

--- a/prompt.js
+++ b/prompt.js
@@ -45,7 +45,7 @@
 
   let data = null;
   let isPayment = false;
-  let chosenPubkey = null; // fresh-login prompts only — see canOfferAccountSwitch in background.js
+  let chosenPubkey = null; // login (getPublicKey) prompts only — see canOfferAccountSwitch in background.js
 
   function fmtSats(n) {
     return Number(n).toLocaleString('en-US');
@@ -189,7 +189,7 @@
   }
 
   // All accounts selectable in this prompt: the one it opened with, plus (only
-  // for a fresh-site login — see canOfferAccountSwitch in background.js) any
+  // for a login prompt — see canOfferAccountSwitch in background.js) any
   // others the user could switch to before approving.
   function accountList() {
     return [

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -2590,6 +2590,26 @@
     renderActivity();
   });
 
+  // Live-refresh the Activity tab when the background records new signing
+  // activity, a site binding moves (e.g. a login re-pairs a host), or a
+  // permission changes — otherwise the visible list goes stale until the user
+  // leaves and re-enters the tab. Skipped while either filter is in use, since
+  // a re-render resets filter text and pagination.
+  let activityRefreshTimer = null;
+  chrome.storage.onChanged.addListener((changes, area) => {
+    if (area !== 'local') return;
+    if (!('sidecar_activity' in changes) && !('sidecar_site_accounts' in changes) && !('sidecar_permissions' in changes)) return;
+    if (!state || state.locked) return;
+    const activeTab = document.querySelector('.tab.active');
+    if (!activeTab || activeTab.dataset.tab !== 'activity') return;
+    const sitesFilter = $('sites-filter');
+    const actFilter = $('activity-filter');
+    const filterBusy = (el) => el && !el.classList.contains('hidden') && (el.value.trim() || document.activeElement === el);
+    if (filterBusy(sitesFilter) || filterBusy(actFilter)) return;
+    clearTimeout(activityRefreshTimer);
+    activityRefreshTimer = setTimeout(() => renderActivity(), 400);
+  });
+
   // ---- profile (active account): view + edit + publish kind 0 ----
   // Fetch the active account's latest kind:0 (used for both display and edit-merge).
   async function fetchActiveProfile() {

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -539,6 +539,36 @@
     show($('view-main'));
   });
 
+  // One-time tip shown on the first account switch: sites keep the identity
+  // they logged in with, so users switching to post elsewhere need to know the
+  // log-out → switch → log-in dance (and that in-client account menus can't
+  // reach Sidecar). Banner sits below the tab bar so it's visible from any tab;
+  // dismissing it persists forever.
+  function maybeShowSwitchTip() {
+    chrome.storage.local.get('switchTipDismissed', ({ switchTipDismissed }) => {
+      if (switchTipDismissed || $('switch-tip')) return;
+      const x = h('button', { className: 'switch-tip-x', title: 'Dismiss' });
+      x.append(icon('x'));
+      x.addEventListener('click', () => {
+        chrome.storage.local.set({ switchTipDismissed: true });
+        tip.remove();
+      });
+      const tip = h('div', { id: 'switch-tip', className: 'switch-tip' }, [
+        h('div', { className: 'switch-tip-title' }, [
+          icon('refresh'),
+          h('span', { textContent: 'Switching accounts?' }),
+        ]),
+        h('p', {
+          className: 'switch-tip-body',
+          textContent:
+            'Clients keep signing with the account you logged in with. To post as a different user, log out there, switch here, then log back in. Multi-account switchers in clients don’t talk to Sidecar.',
+        }),
+        x,
+      ]);
+      document.querySelector('nav.tabs').insertAdjacentElement('afterend', tip);
+    });
+  }
+
   // ---- header account switcher (dropdown) ----
   function buildAcctMenu() {
     const menu = $('acct-menu');
@@ -575,6 +605,7 @@
             await call({ type: 'SIDECAR_SET_ACTIVE', pubkey: a.pubkey });
             await refresh();
             toast('Switched to ' + displayName(a), 'success');
+            maybeShowSwitchTip();
           } else {
             row.classList.add('acct-row-pending');
             row.querySelector('.acct-row-name').textContent = 'Switch to ' + displayName(a) + '?';
@@ -1643,6 +1674,7 @@
           await call({ type: 'SIDECAR_SET_ACTIVE', pubkey: a.pubkey });
           await refresh();
           toast('Switched to ' + displayName(a), 'success');
+          maybeShowSwitchTip();
         } else {
           row.classList.add('item-pending');
           label.textContent = 'Set as active?';

--- a/styles.css
+++ b/styles.css
@@ -586,6 +586,33 @@ button:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(203, 161, 78, 0
   color: var(--text-2); font-size: 12px; line-height: 1.45; text-wrap: pretty;
 }
 .welcome-tip svg { width: 16px; height: 16px; flex-shrink: 0; color: var(--gold); }
+
+/* one-time "switching accounts" tip — banner below the tab bar, gold like the
+   welcome tip but dismissible and visible from any tab */
+.switch-tip {
+  position: relative;
+  text-align: left;
+  margin: 10px 14px 0; padding: 11px 30px 12px 13px;
+  border: 1px solid var(--gold-soft); border-radius: 12px;
+  background: rgba(203, 161, 78, 0.08);
+  text-wrap: pretty;
+}
+.switch-tip-title {
+  display: flex; align-items: center; gap: 7px;
+  color: var(--gold); font-weight: 700; font-size: 12.5px;
+  margin-bottom: 5px;
+}
+.switch-tip-title svg { width: 15px; height: 15px; flex-shrink: 0; }
+.switch-tip-body {
+  margin: 0; color: var(--muted); font-size: 12px; line-height: 1.55;
+}
+.switch-tip-x {
+  position: absolute; top: 6px; right: 6px;
+  background: none; border: none; padding: 2px;
+  color: var(--faint); cursor: pointer;
+}
+.switch-tip-x svg { width: 13px; height: 13px; display: block; }
+.switch-tip-x:hover { color: var(--text); }
 .spark { position: absolute; color: var(--gold); opacity: 0; animation: spark-twinkle 3s ease-in-out infinite; }
 .spark svg { display: block; width: 100%; height: 100%; }
 @keyframes spark-twinkle {


### PR DESCRIPTION
## Summary

The signature change for 1.3.0. Users who logged into a site, logged out, and switched accounts in Sidecar still got the old identity back — the per-site binding pinned logins as well as sessions, and the only way out was detaching the site in the Activity tab.

**The new rule: logins follow the switcher; sessions keep their pairing.**

- `getPublicKey()` is a login — it now returns the globally-active account and re-pairs the site on success. Log out, switch in Sidecar, log back in: the site follows. Open sessions on other sites keep signing as the account they logged in with, so nothing desyncs.
- The login prompt offers the account switcher on every login, not just a site's first.
- Only an explicit identity choice (a login, or a template that names its author) can move an existing binding — an in-flight session request completing after a re-login can no longer clobber the new binding back to the old account.
- **Honor explicit template authors:** applesauce-based clients (noStrudel and friends) stamp the intended author's pubkey on signEvent templates and verify the result. When a template names another held account, Sidecar signs with it — gated by that account's own per-site permissions, so a site can never quietly reach an identity that hasn't approved it. NIP-42 relay-auth events lose their silent exemption across an author switch (no consent-free account linkage).
- **One-time switch tip:** a dismissible callout on the first account switch explains that clients keep signing with the account they logged in with, and that multi-account switchers inside clients don't talk to Sidecar.
- The Activity tab live-refreshes when bindings, permissions, or signing activity change while it's open.

## Test plan
- [x] Three Puppeteer e2e suites against the real extension (real prompt popups + inline panel approvals):
  - re-login follows the active account; other sites' sessions keep signing as their bound account; prompt offers the switcher; rebind takes effect
  - binding write-back race: a stale pending approval completing after a re-login no longer flips the binding back
  - template.pubkey honoring: honored for held accounts (with prompt when unapproved), unknown authors fall back to the binding, bound-account relay auth stays silent, author-switched relay auth requires consent, rejection yields no signature; switch tip appears once with final copy and stays dismissed
- [x] Manual walkthrough on Primal/Jumble/noStrudel (login switching, session stability, wrong-key detection on noStrudel)

🥂 Toasted with [Claude Code](https://claude.com/claude-code)