### PR TITLE
Point site links to sidecar.top

### DIFF
--- a/.claude/skills/update-sidecar-site/SKILL.md
+++ b/.claude/skills/update-sidecar-site/SKILL.md
@@ -1,30 +1,44 @@
 ---
 name: update-sidecar-site
-description: Keep sidecar.dmnyc.net (the official standalone site linked from the Chrome Web Store listing) in sync with this repo's README, FEATURES.md, and PRIVACY.md, and deploy it. Use when PRIVACY.md, FEATURES.md, or the README's Features section changes, when the Chrome Web Store URL changes, when app icons/logo assets change, or when explicitly asked to update or deploy sidecar.dmnyc.net.
+description: Keep sidecar.top (the official standalone site linked from the Chrome Web Store listing) in sync with this repo's README, FEATURES.md, and PRIVACY.md, and deploy it. Use when PRIVACY.md, FEATURES.md, or the README's Features section changes, when the Chrome Web Store URL changes, when app icons/logo assets change, or when explicitly asked to update or deploy sidecar.top.
 ---
 
-# Update sidecar.dmnyc.net
+# Update sidecar.top
 
-sidecar.dmnyc.net is Sidecar's official marketing/homepage site — the link the
-Chrome Web Store listing points to. Its source lives in a **separate repo**,
-`dmnycnet` (the dmnyc.net project showcase + this subdomain), not in this
-`sidecar` repo. Assume it's checked out at `/Users/daniel/GitHub/dmnycnet` — if
-it isn't there, stop and ask where it lives instead of guessing.
+sidecar.top is Sidecar's official marketing/homepage site — the link the Chrome
+Web Store listing points to. Its source lives in a **separate repo**,
+`sidecar-site`, not in this `sidecar` extension repo. Assume it's checked out at
+`/Users/daniel/GitHub/sidecar-site` — if it isn't there, stop and ask where it
+lives instead of guessing.
+
+(History: the site used to live in the `dmnycnet` repo under
+`public_sidecar_dmnyc_net/` and was served at `sidecar.dmnyc.net`. It was split
+into its own repo when the project moved to a dedicated domain. The old domain
+now 301-redirects to sidecar.top, so any lingering links still resolve — but new
+links should point at sidecar.top.)
 
 No build step: plain PHP, no framework. Edit files directly.
 
 ## Where things live
 
 ```
-dmnycnet/public_sidecar_dmnyc_net/
-  index.php        # hero + feature highlights + Chrome Web Store CTA
-  features.php      # full feature list
-  privacy.php        # privacy policy — must mirror sidecar's PRIVACY.md
-  includes/header.php  # nav, <title>, Chrome Web Store link lives in each page that needs it
-  includes/footer.php
-  assets/css/site.css  # accent color #FFA01B (from the martini glass icon), not dmnyc.net's yellow
-  assets/img/           # sidecar-logo.svg, icon128/48/32/16.png, social-card.png — copied from
-                        # this repo's assets/ and icons/ dirs, not generated
+sidecar-site/
+  public/                # web root (the rsync source)
+    index.php            # hero + screenshot slideshow + feature grid + testimonial
+    features.php         # full feature list
+    support.php          # Lightning tip: QR + copyable address (self-contained, no iframe)
+    privacy.php          # privacy policy — must mirror sidecar's PRIVACY.md
+    includes/header.php  # nav, <title>, canonical + OG/Twitter meta (all use https://sidecar.top)
+    includes/footer.php  # "Sidecar | dmnyc.net" attribution
+    assets/css/site.css  # velvet/gold palette + fonts, matched to the extension's welcome.css
+    assets/fonts/        # bundled OFL webfonts (Playfair Display, Manrope)
+    assets/img/          # sidecar-logo.svg, icon128/48/32/16.png, social-card.png,
+                         # car-gonzalez.jpg — copied from this repo's assets/ & icons/
+    assets/js/           # slideshow.js (homepage), qrious.min.js + support.js (support page)
+  deploy/
+    deploy.sh            # rsync public/ to the sidecar.top Dreamhost docroot (single target)
+    .env.example         # copy to .env (gitignored) and fill in credentials
+    askpass.sh           # feeds the SSH password to rsync non-interactively
 ```
 
 ## Keeping content in sync
@@ -50,35 +64,36 @@ Update if the listing URL ever changes (e.g. a new extension ID).
 **Assets** (`sidecar-logo.svg`, `icon128.png`, etc.) are copied byte-for-byte
 from this repo's `assets/` and `icons/` directories — if those are
 regenerated/redesigned here, re-copy the updated files into
-`dmnycnet/public_sidecar_dmnyc_net/assets/img/` under the same filenames.
+`sidecar-site/public/assets/img/` under the same filenames.
 
 ## Verify before deploying
 
 No build step, so just serve it locally and click through:
 
 ```bash
-cd /Users/daniel/GitHub/dmnycnet
-php -S localhost:8011 -t public_sidecar_dmnyc_net
+cd /Users/daniel/GitHub/sidecar-site
+php -S localhost:8011 -t public
 ```
 
-Check `http://localhost:8011/`, `/features.php`, and `/privacy.php` render
-with no PHP warnings and all images resolve.
+Check `http://localhost:8011/`, `/features.php`, `/support.php`, and
+`/privacy.php` render with no PHP warnings and all images resolve.
 
 ## Deploy
 
 ```bash
-cd /Users/daniel/GitHub/dmnycnet
-./deploy/deploy.sh sidecar
+cd /Users/daniel/GitHub/sidecar-site
+./deploy/deploy.sh
 ```
 
-This rsyncs `public_sidecar_dmnyc_net/` to the `sidecar.dmnyc.net` Dreamhost
-docroot over SSH, using credentials in `dmnycnet/deploy/.env` (gitignored,
-not part of this repo). If that file or its `SIDECAR_*` credentials are
-missing, the script will say so — ask the user for them rather than guessing
-paths or reconstructing credentials.
+This rsyncs `public/` to the sidecar.top Dreamhost docroot over SSH, using
+credentials in `sidecar-site/deploy/.env` (gitignored, not part of this repo).
+If that file or its `SIDECAR_TOP_*` credentials are missing, the script says so
+— ask the user for them rather than guessing paths or reconstructing
+credentials. (Deploy uses `rsync --delete`; a dry run — `rsync ... --dry-run` —
+is a good idea before the first deploy to a fresh docroot.)
 
 After deploying, spot-check the live site:
 
 ```bash
-curl -s -o /dev/null -w "%{http_code}\n" https://sidecar.dmnyc.net/
+curl -s -o /dev/null -w "%{http_code}\n" https://sidecar.top/
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ web apps you use, so you can sign in and sign events across Nostr clients withou
 pasting your nsec anywhere. It also has a built-in Lightning wallet (Nostr Wallet
 Connect) and a composer for posting notes directly from the panel.
 
-**[Website](https://sidecar.dmnyc.net)** · **[Chrome Web Store](https://chromewebstore.google.com/detail/sidecar-a-classy-nostr-si/moimlikilhheabdafocpmneehpblhiln)** · **[Privacy Policy](https://sidecar.dmnyc.net/privacy.php)**
+**[Website](https://sidecar.top)** · **[Chrome Web Store](https://chromewebstore.google.com/detail/sidecar-a-classy-nostr-si/moimlikilhheabdafocpmneehpblhiln)** · **[Privacy Policy](https://sidecar.top/privacy.php)**
 
 <img width="3456" height="1944" alt="Sidecar" src="https://i.nostr.build/jCcJyt3Jb5HDTUhK.jpg" />
 

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -3279,7 +3279,7 @@
   const CLIENT_TAG = ['client', 'Sidecar'];
   // ---- About / zap-the-creator ----
   const GITHUB_URL = 'https://github.com/dmnyc/sidecar';
-  const SIDECAR_SITE_URL = 'https://sidecar.dmnyc.net';
+  const SIDECAR_SITE_URL = 'https://sidecar.top';
   const CREATOR_NPUB = 'npub1aeh2zw4elewy5682lxc6xnlqzjnxksq303gwu2npfaxd49vmde6qcq4nwx';
   const CREATOR_LN = 'daniel@breez.tips';
   const IMG_EXT = /\.(jpg|jpeg|png|gif|webp|svg|bmp|avif)(\?.*)?$/i;


### PR DESCRIPTION
The project moved to a dedicated domain, **sidecar.top**. This repoints everything that referenced the old `sidecar.dmnyc.net`:

- **About modal** (`SIDECAR_SITE_URL`) — Website and Privacy Policy links → sidecar.top
- **README** — Website and Privacy Policy links → sidecar.top
- **`update-sidecar-site` skill** — rewritten for the site's new home: it was split out of the `dmnycnet` repo into its own `sidecar-site` repo (`public/` docroot + `deploy/` tooling) and now deploys to sidecar.top. Paths, layout, local-preview, and deploy commands updated to match.

The old domain 301-redirects to sidecar.top, so existing links keep working — this just makes them direct. Not yet submitted to the Web Store, so it's safe to land before the next release.

🥂 Clinked with [Claude Code](https://claude.com/claude-code)