### PR TITLE
Release 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to Sidecar. This project follows [Keep a Changelog](https://keepachangelog.com/)
 and [Semantic Versioning](https://semver.org/).
 
+## [1.4.0] — 2026-07-11
+
+### Added
+- **Expandable signing preview** — the approval prompt now shows event content in a compact, expandable pane with **Formatted / Raw / JSON** views and a Show more / less toggle in every view. "Formatted" renders a note the way a client would (mentions as @-names, media, and note/nevent/naddr embeds), so long content — like a repost whose content is an embedded event — no longer pushes the "Signing as" account card off-screen.
+- **Wider event-kind recognition** — the signing prompt now labels roughly 40 more event kinds (Blossom upload authorization, polls, user status, zap goals, labels, communities, wiki articles, starter packs, voice messages, and many NIP-51 lists and sets), so routine actions no longer show the "unrecognized kind" caution. A **request to vanish** (kind 62) now carries a delete-style heads-up.
+
+### Changed
+- The standalone popup and the in-panel approval now share the same event-kind labels, so kinds — including the NIP-17 DM setup events — are recognized consistently in both places.
+
 ## [1.3.0] — 2026-07-09
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Sidecar | A Classy Nostr Signer",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "A multi-account NIP-07 Nostr signer with a built-in Lightning wallet, in your browser sidebar.",
   "permissions": [
     "storage",


### PR DESCRIPTION
## Release 1.4.0

Bumps `manifest.json` to **1.4.0** and adds the CHANGELOG entry.

Ships two feature PRs:
- #93 — Expandable Formatted/Raw/JSON preview in signing approvals
- #94 — Recognize ~40 more event kinds in the signing prompt

**Merge order:** merge #93 and #94 first, then this PR, then tag `v1.4.0`.

🍷 Decanted with [Claude Code](https://claude.com/claude-code)