### PR TITLE
Humanize exposed pubkeys in approvals & notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and [Semantic Versioning](https://semver.org/).
 
 ### Changed
 - The standalone popup and the in-panel approval now share the same event-kind labels, so kinds — including the NIP-17 DM setup events — are recognized consistently in both places.
+- **Readable identities** — approval prompts show the encrypt/decrypt counterparty as an @name (resolved in the panel) or an npub instead of a raw hex public key; other pubkey fallbacks now use npubs, not hex.
 
 ## [1.3.0] — 2026-07-09
 

--- a/background.js
+++ b/background.js
@@ -855,10 +855,18 @@ async function handleNostrRpc(method, params, host, sendResponse, originWindowId
               picture: a.picture || '',
             }))
         : null;
+      // For encrypt/decrypt, translate the counterparty's hex pubkey to an npub so
+      // the prompt can show a recognizable identity instead of raw hex. Pure offline
+      // encoding — no relay lookup. Falls back to the raw hex if it isn't valid.
+      let peerNpub = null;
+      if (params && params.pubkey && /\.(encrypt|decrypt)$/.test(method)) {
+        try { peerNpub = self.NostrTools.nip19.npubEncode(params.pubkey); } catch (_) {}
+      }
       const decision = await openPrompt({
         host,
         method,
         params,
+        peerNpub,
         activePubkey,
         npub: self.NostrTools.nip19.npubEncode(activePubkey),
         accountName: (acct && acct.name) || '',

--- a/prompt.js
+++ b/prompt.js
@@ -257,14 +257,20 @@
       if (ev.content) appendEventContent(els.preview, ev);
       els.preview.classList.remove('hidden');
     } else if (data.method === 'nip04.decrypt' || data.method === 'nip44.decrypt') {
-      els.preview.innerHTML = row('From', (data.params && data.params.pubkey) || '—');
+      els.preview.innerHTML = row('From', peerLabel());
       els.preview.classList.remove('hidden');
     } else if (data.method === 'nip04.encrypt' || data.method === 'nip44.encrypt') {
-      els.preview.innerHTML = row('To', (data.params && data.params.pubkey) || '—');
+      els.preview.innerHTML = row('To', peerLabel());
       els.preview.classList.remove('hidden');
     }
   }
 
+  // The encrypt/decrypt counterparty as a recognizable npub (translated by the
+  // background), truncated like the account capsule; falls back to the raw hex.
+  function peerLabel() {
+    if (data.peerNpub) return shortNpub(data.peerNpub);
+    return (data.params && data.params.pubkey) || '—';
+  }
   function row(k, v) {
     return `<div class="row"><span>${k}</span><span>${escapeHtml(v)}</span></div>`;
   }

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -1084,7 +1084,7 @@
   function notifAuthorName(pubkey) {
     const cached = _notifProfiles.get(pubkey);
     if (typeof cached === 'string' && cached) return cached;
-    try { return NT.nip19.npubEncode(pubkey).slice(0, 12) + '…'; } catch (_) { return pubkey.slice(0, 8) + '…'; }
+    try { return shortNpub(NT.nip19.npubEncode(pubkey)); } catch (_) { return '—'; }
   }
 
   function prefetchNotifProfile(pubkey, relays) {
@@ -7137,6 +7137,20 @@
     box.innerHTML = '';
     const row = (k, v) =>
       h('div', { className: 'row' }, [h('span', { textContent: k }), h('span', { textContent: v })]);
+    // Counterparty for encrypt/decrypt — never raw hex. Show an @name when we can
+    // resolve one (cached now, or fetched to upgrade in place), otherwise an npub.
+    const peerRow = (label, pubkey) => {
+      let npub = '';
+      try { npub = pubkey ? NT.nip19.npubEncode(pubkey) : ''; } catch (_) {}
+      const cached = pubkey ? cachedProfile(pubkey) : null;
+      const val = h('span', {
+        textContent: (cached && cached.name) ? '@' + cached.name : (npub ? shortNpub(npub) : (pubkey || '—')),
+      });
+      if (pubkey && !(cached && cached.name)) {
+        fetchPreviewProfile(pubkey).then((p) => { if (p && p.name) val.textContent = '@' + p.name; });
+      }
+      return h('div', { className: 'row' }, [h('span', { textContent: label }), val]);
+    };
     if (isPaymentApproval(data)) {
       box.append(row('Amount', data.amountSats != null ? fmtSats(data.amountSats) + ' sats' : 'set by invoice'));
       if (data.memo) box.append(row('Memo', String(data.memo)));
@@ -7148,9 +7162,9 @@
       if (warning) box.append(h('div', { className: 'kind-warn', textContent: warning }));
       if (ev.content) appendEventContent(box, ev);
     } else if (data.method === 'nip04.decrypt' || data.method === 'nip44.decrypt') {
-      box.append(row('From', (data.params && data.params.pubkey) || '—'));
+      box.append(peerRow('From', data.params && data.params.pubkey));
     } else if (data.method === 'nip04.encrypt' || data.method === 'nip44.encrypt') {
-      box.append(row('To', (data.params && data.params.pubkey) || '—'));
+      box.append(peerRow('To', data.params && data.params.pubkey));
     } else {
       hide(box);
       return;


### PR DESCRIPTION
## Humanize exposed pubkeys — "a classy signer" pass

Raw 64-char hex pubkeys should essentially never be user-visible. This makes the encrypt/decrypt counterparty (and a notification fallback) human-readable across **both** approval surfaces.

I ran a read-only audit of the whole extension for pubkey exposure; the only true raw-hex-to-DOM paths were the ones fixed here. Everything else already resolves to an @name or degrades to an npub.

### Changes
- **Popup approval To/From** (`prompt.js` + `background.js`) — the background translates the counterparty hex → npub (reusing `nip19.npubEncode`, offline); the popup shows it truncated with a hex fallback.
- **In-panel approval To/From** (`sidepanel.js`) — same gap, but the panel has a profile cache, so it shows an **@name** when resolvable (cached instantly, or fetched to upgrade in place), else a short npub, never raw hex. Mirrors the existing `renderEmbedCard` pattern.
- **Notification sender fallback** (`sidepanel.js`) — `shortNpub` (head+tail) instead of a head-only npub, and drop the raw-hex catch.

### Audit result (no change needed)
Account cards, activity rows, connected-site cards, mentions, embed authors, and the About credit already show a name-or-npub and self-upgrade from caches; they degrade to a truncated npub only when no profile name is available. The "Raw"/"Formatted"/JSON event previews are intentionally raw.

Rides into 1.4.0 (untagged). No relay lookups added to the popup (stays no-network); the panel already resolves profiles for content.

🥃 Stirred with [Claude Code](https://claude.com/claude-code)