### PR TITLE
Keep the counterparty key visible under the resolved name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and [Semantic Versioning](https://semver.org/).
 
 ### Changed
 - The standalone popup and the in-panel approval now share the same event-kind labels, so kinds — including the NIP-17 DM setup events — are recognized consistently in both places.
-- **Readable identities** — approval prompts show the encrypt/decrypt counterparty as an @name (resolved in the panel) or an npub instead of a raw hex public key; other pubkey fallbacks now use npubs, not hex.
+- **Readable identities** — approval prompts show the encrypt/decrypt counterparty by name with its npub kept beneath as a verifiable key (a display name alone is spoofable; the full npub and hex are shown on hover), instead of a raw hex public key. Other pubkey fallbacks now use npubs, not hex.
 
 ## [1.3.0] — 2026-07-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and [Semantic Versioning](https://semver.org/).
 
 ### Changed
 - The standalone popup and the in-panel approval now share the same event-kind labels, so kinds — including the NIP-17 DM setup events — are recognized consistently in both places.
-- **Readable identities** — approval prompts show the encrypt/decrypt counterparty by name with its npub kept beneath as a verifiable key (a display name alone is spoofable; the full npub and hex are shown on hover), instead of a raw hex public key. Other pubkey fallbacks now use npubs, not hex.
+- **Readable identities** — approval prompts show the encrypt/decrypt counterparty by name with its npub kept beneath as a verifiable key (a display name alone is spoofable). Click the npub to reveal the full, untruncated key; the raw hex is on hover. Other pubkey fallbacks now use npubs, not hex.
 
 ## [1.3.0] — 2026-07-09
 

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -7143,11 +7143,25 @@
       let npub = '';
       try { npub = pubkey ? NT.nip19.npubEncode(pubkey) : ''; } catch (_) {}
       const cached = pubkey ? cachedProfile(pubkey) : null;
-      const val = h('span', {
-        textContent: (cached && cached.name) ? '@' + cached.name : (npub ? shortNpub(npub) : (pubkey || '—')),
-      });
+      const idText = npub ? shortNpub(npub) : (pubkey || '—');
+      // Full npub + raw hex on hover, so the exact key is always verifiable.
+      const idTitle = [npub && ('npub: ' + npub), pubkey && ('hex: ' + pubkey)].filter(Boolean).join('\n');
+      const val = h('span', { className: 'peer-val' });
+      // Show the resolved @name when we have one, but ALWAYS keep the npub visible
+      // beneath it as a verifiable key — a display name on its own is spoofable.
+      // With no name, the npub is the only line.
+      const paint = (name) => {
+        val.innerHTML = '';
+        if (name) {
+          val.append(h('span', { className: 'peer-name', textContent: '@' + name }));
+          val.append(h('span', { className: 'peer-npub', textContent: idText, title: idTitle }));
+        } else {
+          val.append(h('span', { textContent: idText, title: idTitle }));
+        }
+      };
+      paint(cached && cached.name);
       if (pubkey && !(cached && cached.name)) {
-        fetchPreviewProfile(pubkey).then((p) => { if (p && p.name) val.textContent = '@' + p.name; });
+        fetchPreviewProfile(pubkey).then((p) => { if (p && p.name) paint(p.name); });
       }
       return h('div', { className: 'row' }, [h('span', { textContent: label }), val]);
     };

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -7143,9 +7143,24 @@
       let npub = '';
       try { npub = pubkey ? NT.nip19.npubEncode(pubkey) : ''; } catch (_) {}
       const cached = pubkey ? cachedProfile(pubkey) : null;
-      const idText = npub ? shortNpub(npub) : (pubkey || '—');
-      // Full npub + raw hex on hover, so the exact key is always verifiable.
+      const idFull = npub || pubkey || '';
+      const idShort = npub ? shortNpub(npub) : (pubkey || '—');
+      // Raw hex on hover; click the npub to reveal (and select) the full key.
       const idTitle = [npub && ('npub: ' + npub), pubkey && ('hex: ' + pubkey)].filter(Boolean).join('\n');
+      // Truncated by default; click toggles to the full, untruncated key and back.
+      const idSpan = (cls) => {
+        const s = h('span', { className: cls, textContent: idShort, title: idTitle });
+        if (idFull && idFull !== idShort) {
+          let full = false;
+          s.classList.add('peer-npub-toggle');
+          s.addEventListener('click', () => {
+            full = !full;
+            s.textContent = full ? idFull : idShort;
+            s.classList.toggle('full', full);
+          });
+        }
+        return s;
+      };
       const val = h('span', { className: 'peer-val' });
       // Show the resolved @name when we have one, but ALWAYS keep the npub visible
       // beneath it as a verifiable key — a display name on its own is spoofable.
@@ -7154,9 +7169,9 @@
         val.innerHTML = '';
         if (name) {
           val.append(h('span', { className: 'peer-name', textContent: '@' + name }));
-          val.append(h('span', { className: 'peer-npub', textContent: idText, title: idTitle }));
+          val.append(idSpan('peer-npub'));
         } else {
-          val.append(h('span', { textContent: idText, title: idTitle }));
+          val.append(idSpan('peer-id'));
         }
       };
       paint(cached && cached.name);

--- a/styles.css
+++ b/styles.css
@@ -1677,6 +1677,10 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
 .card .row { display: flex; justify-content: space-between; gap: 8px; padding: 3px 0; }
 .card .row span:first-child { color: var(--muted); }
 .card .row span:last-child { word-break: break-all; text-align: right; font-family: var(--font-mono); font-size: 12px; }
+/* Encrypt/decrypt counterparty: @name on top, npub beneath as a verifiable key. */
+.card .row .peer-val { display: flex; flex-direction: column; align-items: flex-end; gap: 2px; }
+.card .row .peer-val .peer-name { font-family: var(--font-ui); font-weight: 600; }
+.card .row .peer-val .peer-npub { font-size: 11px; color: var(--muted); cursor: help; }
 .card pre {
   background: rgba(8, 2, 20, 0.6); border-radius: 8px; padding: 10px; margin: 8px 0 0;
   font-family: var(--font-mono);

--- a/styles.css
+++ b/styles.css
@@ -1680,7 +1680,9 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
 /* Encrypt/decrypt counterparty: @name on top, npub beneath as a verifiable key. */
 .card .row .peer-val { display: flex; flex-direction: column; align-items: flex-end; gap: 2px; }
 .card .row .peer-val .peer-name { font-family: var(--font-ui); font-weight: 600; }
-.card .row .peer-val .peer-npub { font-size: 11px; color: var(--muted); cursor: help; }
+.card .row .peer-val .peer-npub { font-size: 11px; color: var(--muted); }
+.card .row .peer-val .peer-npub-toggle { cursor: pointer; }
+.card .row .peer-val .peer-npub-toggle:hover { color: var(--text); }
 .card pre {
   background: rgba(8, 2, 20, 0.6); border-radius: 8px; padding: 10px; margin: 8px 0 0;
   font-family: var(--font-mono);


### PR DESCRIPTION
## Keep the key visible under the resolved name

Following up on #97: the in-panel approval resolves the encrypt/decrypt counterparty to an `@name`, but a display name on its own is **spoofable** — any profile can claim "The Daniel". Showing only the name hid the actual key.

Now the counterparty renders as **name over npub**: the resolved `@name` on top, the npub kept beneath as a muted, verifiable subtitle. Hovering the npub reveals the **full npub and the raw hex** for exact verification. With no name resolved, the npub is the only line (unchanged).

- `sidepanel.js` — `peerRow` renders name + npub subtitle; `title` carries the full npub + hex.
- `styles.css` — `.peer-val` stacks the two lines, npub muted/mono.
- `CHANGELOG.md` — 1.4.0 line refined.

The popup is unaffected (it already shows the npub, no name). Rides into 1.4.0 (untagged).

🥂 Raised with [Claude Code](https://claude.com/claude-code)