### PR TITLE
Reject Primal NWC strings on wallet connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and [Semantic Versioning](https://semver.org/).
 ### Changed
 - The standalone popup and the in-panel approval now share the same event-kind labels, so kinds — including the NIP-17 DM setup events — are recognized consistently in both places.
 - **Readable identities** — approval prompts show the encrypt/decrypt counterparty by name with its npub kept beneath as a verifiable key (a display name alone is spoofable). Click the npub to reveal the full, untruncated key; the raw hex is on hover. Other pubkey fallbacks now use npubs, not hex.
+- **Reject Primal's NWC string** — Primal's wallet is Spark-based and only works inside Primal's own apps, so its Nostr Wallet Connect string can't drive an external wallet. Sidecar now detects it and explains why, instead of hanging on connect.
 
 ## [1.3.0] — 2026-07-09
 

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -5734,6 +5734,21 @@
       return v && v.includes('@') ? v.trim() : null;
     } catch (_) { return null; }
   }
+  // Primal's wallet is Spark-based and only works inside Primal's own apps, over their
+  // own nostrconnect session — the NWC string it hands out (routed through a primal.net
+  // relay) can't be driven as a standalone NWC wallet, so a getInfo round-trip just
+  // hangs. Detect it from the relay host and reject up front with a clear reason.
+  function isPrimalNwc(connection) {
+    try {
+      const q = connection.split('?')[1];
+      if (!q) return false;
+      return new URLSearchParams(q).getAll('relay').some((r) => {
+        let host;
+        try { host = new URL(r).hostname; } catch (_) { host = String(r); }
+        return /(^|\.)primal\.net$/i.test(host);
+      });
+    } catch (_) { return false; }
+  }
   async function getLightningAddress() {
     try {
       const { connection } = await call({ type: 'SIDECAR_GET_NWC' });
@@ -5810,6 +5825,7 @@
       const conn = input.value.trim();
       if (!conn) return (err.textContent = 'Paste a connection string.');
       if (!conn.startsWith('nostr+walletconnect://')) return (err.textContent = "That doesn't look like an NWC string.");
+      if (isPrimalNwc(conn)) return (err.textContent = "Primal's wallet only works inside Primal's own apps — it doesn't support external Nostr Wallet Connect. Connect a different NWC wallet, like Alby Hub, Coinos, or YakiHonne.");
       err.textContent = '';
       connect.disabled = true;
       connect.textContent = 'Connecting…';


### PR DESCRIPTION
## Block Primal NWC connection strings

Primal's built-in wallet is Spark-based and only works **inside Primal's own apps**, over their own nostrconnect session. The NWC string it hands out routes through a `primal.net` relay and can't be driven as a standalone Nostr Wallet Connect wallet — so pasting it into Sidecar previously **hung on the `getInfo` round-trip** before failing with a confusing "could not reach" error.

Now the connect form detects a `primal.net` relay host up front and rejects with a clear reason:

> Primal's wallet only works inside Primal's own apps — it doesn't support external Nostr Wallet Connect. Connect a different NWC wallet, like Alby Hub, Coinos, or YakiHonne.

Detection is on the **relay host** (the definitive NWC routing signal), matching `primal.net` / `*.primal.net`. Verified it catches the reported string, trailing-slash and multi-relay variants, while leaving Alby/Coinos and a spoofed `primal.net.evil.com` lookalike alone.

`restoreNwcFromRelays` needs no change — it only restores wallets that previously connected, which a Primal string can't.

Rides into 1.4.0 (untagged).

🍹 Muddled with [Claude Code](https://claude.com/claude-code)