### PR TITLE
Default auto-lock to 15 minutes instead of never

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and [Semantic Versioning](https://semver.org/).
 - The standalone popup and the in-panel approval now share the same event-kind labels, so kinds — including the NIP-17 DM setup events — are recognized consistently in both places.
 - **Readable identities** — approval prompts show the encrypt/decrypt counterparty by name with its npub kept beneath as a verifiable key (a display name alone is spoofable). Click the npub to reveal the full, untruncated key; the raw hex is on hover. Other pubkey fallbacks now use npubs, not hex.
 
+### Security
+- **Auto-lock now defaults to 15 minutes of inactivity**, instead of never. It only counts down when nothing has been signed, paid, or unlocked in that window, so active use is unaffected — this only shrinks the window a decrypted keystore is left exposed on an unattended browser. Still adjustable (including back to Never) in Settings, and anyone who's already chosen a value there keeps it.
+
 ## [1.3.0] — 2026-07-09
 
 ### Added

--- a/background.js
+++ b/background.js
@@ -25,6 +25,15 @@ const DEFAULT_RELAYS = {
 };
 
 const AUTO_LOCK_ALARM = 'sidecar-auto-lock';
+// Idle auto-lock, in minutes. Applied only when the user has never touched the
+// Settings dropdown — an explicit choice (including "Never", stored as 0) is
+// always respected once saved. Keys shouldn't stay decrypted indefinitely in a
+// browser that's left open; this only fires on true inactivity (bumpAutoLock is
+// called on every sign/pay/unlock), so normal active use never hits it.
+const DEFAULT_AUTO_LOCK_MINUTES = 15;
+function resolveSettings(sidecar_settings) {
+  return { autoLockMinutes: DEFAULT_AUTO_LOCK_MINUTES, ...(sidecar_settings || {}) };
+}
 
 // ---- storage helpers ----
 function sget(keys) {
@@ -1361,7 +1370,7 @@ async function lockKeystore() {
 
 function bumpAutoLock() {
   sget('sidecar_settings').then(({ sidecar_settings }) => {
-    const minutes = (sidecar_settings && sidecar_settings.autoLockMinutes) || 0;
+    const minutes = resolveSettings(sidecar_settings).autoLockMinutes;
     if (minutes > 0 && !KS.isLocked()) {
       chrome.alarms.create(AUTO_LOCK_ALARM, { delayInMinutes: minutes });
     }
@@ -1554,7 +1563,7 @@ async function handleControl(message, sendResponse) {
         result = message.relays;
         break;
       case 'SIDECAR_GET_SETTINGS':
-        result = (await sget('sidecar_settings')).sidecar_settings || { autoLockMinutes: 0 };
+        result = resolveSettings((await sget('sidecar_settings')).sidecar_settings);
         break;
       case 'SIDECAR_SET_SETTINGS': {
         const prev = (await sget('sidecar_settings')).sidecar_settings || {};


### PR DESCRIPTION
## Default auto-lock to 15 minutes

Auto-lock (Settings → Auto-lock) has always defaulted to **Never** — a decrypted keystore in an open browser stayed unlocked indefinitely, with no time-based safeguard, until the browser itself fully closed.

New installs (and anyone who has never touched the Settings dropdown) now default to **15 minutes of inactivity**. Two things make this safe as a default:

- `bumpAutoLock()` already resets the timer on every sign, pay, and unlock — so it only fires on genuine idle time, never mid-session. Active use is unaffected.
- The migration is additive-only: the default is merged in *underneath* the saved settings object, so it only applies when `autoLockMinutes` was never explicitly saved. Anyone who's already picked a value in Settings — including explicitly choosing **Never** — keeps exactly that choice. Verified with the four relevant cases (unset, unrelated-setting-only, explicit 0, explicit non-zero).

Still fully adjustable in Settings (1 / 5 / 15 / 60 minutes / Never) — this only changes the out-of-the-box default.

🍷 Decanted with [Claude Code](https://claude.com/claude-code)