### PR TITLE
Fix stale green checkmark on empty PIN fields after a reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and [Semantic Versioning](https://semver.org/).
 - The standalone popup and the in-panel approval now share the same event-kind labels, so kinds — including the NIP-17 DM setup events — are recognized consistently in both places.
 - **Readable identities** — approval prompts show the encrypt/decrypt counterparty by name with its npub kept beneath as a verifiable key (a display name alone is spoofable). Click the npub to reveal the full, untruncated key; the raw hex is on hover. Other pubkey fallbacks now use npubs, not hex.
 
+### Fixed
+- The PIN/confirm fields on the "create a keystore" screen no longer show a stale green checkmark next to an empty box after a reset (erase-everything, or the 21-failed-unlock auto-wipe) — the validity indicators now recompute when the fields are cleared, instead of only on typing.
+
 ## [1.3.0] — 2026-07-09
 
 ### Added

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -291,10 +291,14 @@
     [$('view-onboarding'), $('view-lock'), $('view-main'), $('view-settings'), $('view-profile-edit'), $('view-approval')].forEach(hide);
     if (!state.initialized) {
       // Clear any stale PIN left in the inputs (e.g. after a reset) — the panel is
-      // an SPA, so values would otherwise persist across the view switch.
+      // an SPA, so values would otherwise persist across the view switch. Setting
+      // .value doesn't fire an 'input' event, so the validity checkmarks won't
+      // recompute on their own — re-validate explicitly or they'd keep showing
+      // green next to now-empty fields.
       $('ob-pin').value = '';
       $('ob-pin2').value = '';
       $('ob-error').textContent = '';
+      validateOnboardingPin();
       show($('view-onboarding'));
       setTimeout(() => $('ob-pin').focus(), 50);
     } else if (state.locked) {
@@ -323,7 +327,7 @@
 
 
   // ---- onboarding ----
-  attachPinValidation($('ob-pin'), $('ob-pin2'), $('ob-submit'));
+  const validateOnboardingPin = attachPinValidation($('ob-pin'), $('ob-pin2'), $('ob-submit'));
   $('onboarding-form').addEventListener('submit', async (e) => {
     e.preventDefault();
     const err = $('ob-error');


### PR DESCRIPTION
## Stale validity checkmark after a reset

After erasing everything (or the 21-failed-unlock auto-wipe) sends the panel back to onboarding, the PIN and Confirm fields could show a green checkmark next to an **empty** box.

Root cause: `refresh()` clears the onboarding fields with `$('ob-pin').value = ''` — but setting `.value` programmatically doesn't fire an `input` event, and the validity checkmarks (`attachPinValidation`) only recompute on that event. So the indicators kept showing whatever they were last set to (typically green, from a valid PIN typed before the reset) even though the boxes were now visibly empty.

Fix: capture `attachPinValidation`'s returned `validate()` function and call it right after the fields are cleared, so the indicators recompute against the actual (empty) values — same fix point covers every path back to onboarding (erase-everything, auto-wipe, and initial load), since they all funnel through the same `refresh()` routing function.

Branched directly off `main` — no dependency on the still-open PIN-reminder-modal PR (#101).

🍺 Brewed with [Claude Code](https://claude.com/claude-code)