### PR TITLE
Wire up the dev bug button's debug panel

### DIFF
--- a/background.js
+++ b/background.js
@@ -182,6 +182,23 @@ async function logActivity(entry) {
   await sset({ [ACTIVITY_KEY]: cur });
 }
 
+// ---- debug log (dev builds only) ----
+// An in-memory ring buffer for the dev bug button's debug panel — separate
+// from the user-facing Activity log above (which tracks signed events/
+// payments per account). This is internal diagnostics: message dispatch,
+// timings, and uncaught errors. In-memory only, so it resets on a service
+// worker restart (~30s idle) — same tradeoff as the keystore re-locking.
+const IS_DEV_BUILD = (() => {
+  try { return !chrome.runtime.getManifest().update_url; } catch (_) { return false; }
+})();
+const DEBUG_LOG_MAX = 300;
+const debugLog = [];
+function dlog(level, tag, msg, data) {
+  if (!IS_DEV_BUILD) return;
+  debugLog.push({ ts: Date.now(), level, tag, msg, data });
+  if (debugLog.length > DEBUG_LOG_MAX) debugLog.shift();
+  if (panelPort) { try { panelPort.postMessage({ type: 'SIDECAR_LOG_UPDATED' }); } catch (_) {} }
+}
 // ---- side panel open on toolbar click ----
 chrome.runtime.onInstalled.addListener((details) => {
   chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true }).catch(() => {});
@@ -220,6 +237,18 @@ const REQUEST_TTL = 175000;     // < content.js's 180s page timeout, so we never
 const TOMBSTONE_TTL = 600000;   // interrupted tombstones self-clear after 10 min
 const QUEUE_SESSION_KEY = 'sidecar_prompt_queue';
 const QUEUE_KEEPALIVE_ALARM = 'sidecar-queue-keepalive';
+
+// dlog() reads panelPort (declared above) to ping the panel on a new entry, so
+// this must run after that declaration — the log call below is synchronous.
+if (IS_DEV_BUILD) {
+  dlog('info', 'sw', 'Service worker started', { version: chrome.runtime.getManifest().version });
+  self.addEventListener('error', (e) => {
+    dlog('error', 'sw', 'Uncaught error', { message: e.message, filename: e.filename, lineno: e.lineno });
+  });
+  self.addEventListener('unhandledrejection', (e) => {
+    dlog('error', 'sw', 'Unhandled rejection', { reason: String((e.reason && e.reason.message) || e.reason) });
+  });
+}
 
 // ---- session mirror (metadata only — no callbacks, no signable material) ----
 function qGet() {
@@ -1679,6 +1708,26 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     return false;
   }
 
+  // ---- debug log: trace every dispatched message + its outcome/timing ----
+  // Central instrumentation point — covers page RPCs, control messages, and
+  // prompt/queue traffic alike. Deliberately logs only type/method/host/timing/
+  // error-message, never message bodies or response payloads, so PINs, nsecs,
+  // NWC strings, and signed event content never land in the log.
+  if (IS_DEV_BUILD && message.type !== 'SIDECAR_GET_DEBUG_LOG' && message.type !== 'SIDECAR_CLEAR_DEBUG_LOG') {
+    const t0 = Date.now();
+    const rawSendResponse = sendResponse;
+    sendResponse = (resp) => {
+      try {
+        dlog(resp && resp.ok === false ? 'error' : 'info', 'msg', message.type, {
+          method: message.method, host: message.host,
+          ms: Date.now() - t0,
+          error: resp && resp.ok === false ? resp.error : undefined,
+        });
+      } catch (_) {}
+      return rawSendResponse(resp);
+    };
+  }
+
   // The window the requesting page lives in — used to surface the approval on
   // the window the user is actually looking at (see driveOnce), not wherever a
   // pinned panel or the last-focused window happens to be.
@@ -1802,6 +1851,18 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     for (let i = queue.length - 1; i >= 0; i--) if (queue[i].state === 'interrupted') queue.splice(i, 1);
     qPersist(); broadcastQueue();
     sendResponse({ ok: true });
+    return false;
+  }
+  // Dev bug button's debug panel — reads the in-memory trace log. Gated to
+  // extension pages only (not in CONTENT_OK above), and IS_DEV_BUILD means
+  // debugLog is always empty on a Web Store install anyway.
+  if (message.type === 'SIDECAR_GET_DEBUG_LOG') {
+    sendResponse({ ok: true, result: debugLog });
+    return false;
+  }
+  if (message.type === 'SIDECAR_CLEAR_DEBUG_LOG') {
+    debugLog.length = 0;
+    sendResponse({ ok: true, result: [] });
     return false;
   }
 

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -7590,6 +7590,7 @@
     } catch (_) {}
     port.onMessage.addListener((msg) => {
       if (msg && msg.type === 'SIDECAR_QUEUE_UPDATED') refreshApproval();
+      if (msg && msg.type === 'SIDECAR_LOG_UPDATED' && debugPanelRefresh) debugPanelRefresh();
     });
     port.onDisconnect.addListener(() => {
       // Not a failure: the background keeps pending requests alive and re-surfaces
@@ -7624,11 +7625,99 @@
     if (!isDevBuild()) return; // belt-and-suspenders: never show on a store build
     $('dev-badge').classList.toggle('hidden', !on);
   }
-  let devBadgeToast = null;
-  $('dev-badge').addEventListener('click', () => {
-    if (devBadgeToast && devBadgeToast.isConnected) devBadgeToast.remove();
-    devBadgeToast = toast('Debug panel coming soon.', 'success');
-  });
+
+  // ---- debug panel ----
+  // Reads the in-memory trace log the background keeps (message dispatch,
+  // timings, uncaught SW errors — see background.js). Dev builds only, same
+  // gate as the badge itself.
+  let debugPanelRefresh = null; // set while the panel is open; re-pulls on SIDECAR_LOG_UPDATED
+
+  function debugLogRow(e) {
+    const row = h('div', { className: 'item debug-log-row debug-log-' + e.level });
+    const parts = [];
+    if (e.data) {
+      if (e.data.method) parts.push(e.data.method);
+      if (e.data.host) parts.push(e.data.host);
+      if (e.data.ms != null) parts.push(e.data.ms + 'ms');
+      if (e.data.version) parts.push('v' + e.data.version);
+      if (e.data.error) parts.push(e.data.error);
+      if (e.data.message) parts.push(e.data.message);
+      if (e.data.reason) parts.push(e.data.reason);
+      if (e.data.filename) parts.push(e.data.filename + (e.data.lineno != null ? ':' + e.data.lineno : ''));
+    }
+    row.append(h('div', { className: 'item-main' }, [
+      h('div', { className: 'item-label', textContent: '[' + e.tag + '] ' + e.msg }),
+      h('div', { className: 'item-sub', textContent: [new Date(e.ts).toLocaleTimeString(), ...parts].join(' · ') }),
+    ]));
+    return row;
+  }
+
+  function debugLogText(entries) {
+    return entries.map((e) => {
+      const meta = e.data ? ' ' + JSON.stringify(e.data) : '';
+      return '[' + new Date(e.ts).toISOString() + '] ' + e.level.toUpperCase() + ' ' + e.tag + ': ' + e.msg + meta;
+    }).join('\n');
+  }
+
+  async function openDebugPanel() {
+    let entries = [];
+    try { entries = await call({ type: 'SIDECAR_GET_DEBUG_LOG' }); } catch (_) {}
+
+    openModal((modal) => {
+      modal.classList.add('modal-sheet');
+
+      const xBtn = h('button', { className: 'modal-x', title: 'Close' });
+      xBtn.appendChild(icon('x'));
+      xBtn.addEventListener('click', closeModal);
+      modal.appendChild(xBtn);
+
+      const build = window.SIDECAR_BUILD || {};
+      const ver = build.version || (chrome.runtime.getManifest && chrome.runtime.getManifest().version) || '';
+      const verText = ver + (build.commit && build.commit !== 'dev' ? ' (' + build.commit + ')' : '');
+      modal.append(
+        h('div', {}, [
+          h('div', { className: 'notif-modal-title', textContent: 'Debug log' }),
+          h('div', { className: 'hint', textContent: 'Sidecar ' + verText + ' · dev build' }),
+        ])
+      );
+
+      const scroll = h('div', { className: 'notif-scroll' });
+      const list = h('div', { className: 'list' });
+      scroll.appendChild(list);
+      modal.appendChild(scroll);
+
+      function render() {
+        if (!entries.length) {
+          listState(list, 'No log entries yet — use the app and they’ll appear here.');
+          return;
+        }
+        list.innerHTML = '';
+        entries.slice().reverse().forEach((e) => list.append(debugLogRow(e)));
+      }
+      render();
+      debugPanelRefresh = async () => {
+        try { entries = await call({ type: 'SIDECAR_GET_DEBUG_LOG' }); } catch (_) { return; }
+        render();
+      };
+
+      const copyBtn = h('button', { className: 'secondary', textContent: 'Copy' });
+      copyBtn.addEventListener('click', async () => {
+        try {
+          await navigator.clipboard.writeText(debugLogText(entries) || '(empty)');
+          copyBtn.textContent = 'Copied ✓';
+          setTimeout(() => (copyBtn.textContent = 'Copy'), 1200);
+        } catch (_) {}
+      });
+      const clearBtn = h('button', { className: 'ghost', textContent: 'Clear' });
+      clearBtn.addEventListener('click', async () => {
+        try { entries = await call({ type: 'SIDECAR_CLEAR_DEBUG_LOG' }); } catch (_) { return; }
+        render();
+      });
+      modal.append(h('div', { className: 'actions' }, [clearBtn, copyBtn]));
+    }, () => { debugPanelRefresh = null; });
+  }
+
+  $('dev-badge').addEventListener('click', openDebugPanel);
   $('dev-badge').appendChild(icon('bug'));
 
   // ---- boot ----

--- a/styles.css
+++ b/styles.css
@@ -1601,6 +1601,11 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
 .dev-badge svg { width: 16px; height: 16px; }
 .dev-badge:hover { background: rgba(234, 119, 47, 0.28); }
 
+/* ===== debug log panel ===== */
+.debug-log-row .item-sub { font-family: var(--font-mono); font-size: 11px; }
+.debug-log-error .item-label { color: var(--red); }
+.debug-log-warn .item-label { color: var(--gold); }
+
 /* ===== toasts ===== */
 .toasts {
   position: fixed;


### PR DESCRIPTION
## Dev debug panel

Replaces the "Debug panel coming soon" toast (the dev-badge bug icon) with a real panel — dev builds only, same gate as the badge itself (`IS_DEV_BUILD` checks for a missing `update_url`, so this is always inert on a Web Store install).

- An in-memory ring buffer (`background.js`, 300-entry cap) traces message dispatch — type, method, host, timing, and outcome — plus uncaught service-worker errors and unhandled rejections.
- Deliberately logs only non-sensitive fields (method/host/timing/error text) — never message bodies or response payloads, so PINs, nsecs, NWC strings, and signed event content never land in the log.
- `SIDECAR_GET_DEBUG_LOG`/`SIDECAR_CLEAR_DEBUG_LOG` sit behind the existing `fromExtPage`/`CONTENT_OK` sender gate and aren't in the `CONTENT_OK` whitelist — not reachable from a web page, only from the extension's own pages. Verified against the current gate in `background.js`.
- Panel UI: a modal list (newest first), Copy (plain-text dump) and Clear, live-refreshing while open via a `SIDECAR_LOG_UPDATED` port message.

No CHANGELOG entry — this is dev-only tooling, invisible on production builds, matching how the existing dev badge itself was never documented there either.

🍹 Poured with [Claude Code](https://claude.com/claude-code)