### PR TITLE
Auto-lock hardening, settings-read clamp, migration notice, and in-app release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,13 @@ and [Semantic Versioning](https://semver.org/).
 - **Reject Primal's NWC string** — Primal's wallet is Spark-based and only works inside Primal's own apps, so its Nostr Wallet Connect string can't drive an external wallet. Sidecar now detects it and explains why, instead of hanging on connect.
 
 ### Security
-- **Auto-lock now defaults to 15 minutes of inactivity**, instead of never. It only counts down when nothing has been signed, paid, or unlocked in that window, so active use is unaffected — this only shrinks the window a decrypted keystore is left exposed on an unattended browser. Still adjustable (including back to Never) in Settings, and anyone who's already chosen a value there keeps it.
+- **Auto-lock now defaults to 15 minutes of inactivity**, instead of never. It only counts down when nothing has been signed, paid, or unlocked in that window, so active use is unaffected — this only shrinks the window a decrypted keystore is left exposed on an unattended browser. Still adjustable (including back to Never) in Settings, and anyone who's already chosen a value there keeps it. Existing users who'd never chosen a value get a one-time notice that auto-lock is now on — with a reminder that the unlock PIN is unrecoverable — the first time the panel opens unlocked.
+- **Auto-lock changes apply immediately.** Changing the timer in Settings now re-arms (or clears) the countdown on the spot; previously the new value only took effect after the next sign, payment, or unlock — so enabling auto-lock and walking away would never actually lock.
+- **Web pages can no longer read Sidecar's full settings.** The settings read available to visited pages is now clamped to the pay-card toggle, matching the existing clamp on writes — a page could previously see the auto-lock timing, budget, and auto-zap configuration.
 
 ### Fixed
 - The PIN/confirm fields on the "create a keystore" screen no longer show a stale green checkmark next to an empty box after a reset (erase-everything, or the 21-failed-unlock auto-wipe) — the validity indicators now recompute when the fields are cleared, instead of only on typing.
+- Turning the on-page "Pay with Sidecar" card off now sticks across page loads — the content script was reading the saved setting from the wrong spot in the reply, so only the live toggle push ever applied.
 
 ## [1.3.0] — 2026-07-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to Sidecar. This project follows [Keep a Changelog](https://keepachangelog.com/)
 and [Semantic Versioning](https://semver.org/).
 
+Release practice: the latest release's highlights are also summarized in-app, in the help
+guide's **What's new** section (`help.html#whats-new`, linked from Settings → Updates).
+Update that section alongside this file as part of every release.
+
 ## [1.4.0] — 2026-07-11
 
 ### Added

--- a/background.js
+++ b/background.js
@@ -1407,7 +1407,13 @@ function bumpAutoLock() {
 }
 
 chrome.alarms.onAlarm.addListener((alarm) => {
-  if (alarm.name === AUTO_LOCK_ALARM) lockKeystore();
+  if (alarm.name === AUTO_LOCK_ALARM) {
+    // Re-check the live setting at fire time: an alarm armed under an older
+    // choice (before the user switched to Never) must not lock.
+    sget('sidecar_settings').then(({ sidecar_settings }) => {
+      if (resolveSettings(sidecar_settings).autoLockMinutes > 0) lockKeystore();
+    });
+  }
   // Best-effort heartbeat while the approval queue is non-empty: sweeps expired
   // requests and re-drives the display so nothing stalls if the SW was napping.
   else if (alarm.name === QUEUE_KEEPALIVE_ALARM) driveDisplay();
@@ -1421,10 +1427,18 @@ async function handleControl(message, sendResponse) {
       case 'SIDECAR_GET_STATE':
         result = await KS.getState();
         break;
-      case 'SIDECAR_INIT':
+      case 'SIDECAR_INIT': {
         result = await KS.initialize(message.pin);
+        // A new keystore adopts the current auto-lock default as an explicit
+        // setting (and needs no migration notice) — the "no stored value" state
+        // is reserved for keystores that predate the 15-minute default.
+        const prev = (await sget('sidecar_settings')).sidecar_settings || {};
+        await sset({
+          sidecar_settings: { autoLockMinutes: DEFAULT_AUTO_LOCK_MINUTES, autoLockNoticeShown: true, ...prev },
+        });
         bumpAutoLock();
         break;
+      }
       case 'SIDECAR_UNLOCK': {
         // CONTRACT: resolves { ok:true, result:{ status } } — it does NOT throw
         // ok:false for a wrong PIN. `status` is one of:
@@ -1591,13 +1605,26 @@ async function handleControl(message, sendResponse) {
         await sset({ sidecar_relays: message.relays });
         result = message.relays;
         break;
-      case 'SIDECAR_GET_SETTINGS':
-        result = resolveSettings((await sget('sidecar_settings')).sidecar_settings);
+      case 'SIDECAR_GET_SETTINGS': {
+        const raw = (await sget('sidecar_settings')).sidecar_settings || {};
+        // autoLockDefaulted: the user has never chosen an auto-lock value, so the
+        // resolved 15 minutes is the migration default. The panel uses this to
+        // show existing users a one-time notice that auto-lock is now on.
+        result = { ...resolveSettings(raw), autoLockDefaulted: !('autoLockMinutes' in raw) };
         break;
+      }
       case 'SIDECAR_SET_SETTINGS': {
         const prev = (await sget('sidecar_settings')).sidecar_settings || {};
         const merged = { ...prev, ...message.settings };
         await sset({ sidecar_settings: merged });
+        // Apply an auto-lock change immediately: drop any alarm armed under the
+        // old value, then re-arm from the new one (no-op when Never or locked).
+        // Without this the change only took effect on the next sign/pay/unlock —
+        // enabling auto-lock and walking away would never actually lock.
+        if (message.settings && 'autoLockMinutes' in message.settings) {
+          await chrome.alarms.clear(AUTO_LOCK_ALARM);
+          bumpAutoLock();
+        }
         // Push the pay-pill setting to content scripts so it toggles live.
         if (chrome.tabs) {
           chrome.tabs.query({}, (tabs) => {
@@ -1771,6 +1798,16 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     // autozap, budgets, autolock, or any other setting.
     const s = message.settings || {};
     message = { type: 'SIDECAR_SET_SETTINGS', settings: 'showPayButton' in s ? { showPayButton: !!s.showPayButton } : {} };
+  }
+  if (!fromExtPage && message.type === 'SIDECAR_GET_SETTINGS') {
+    // Clamp the read side the same way: a visited page gets the pay-card toggle
+    // and nothing else. The full object would tell it the auto-lock timing (how
+    // long an unattended unlocked keystore stays warm) plus budget/autozap
+    // config it has no business fingerprinting.
+    sget('sidecar_settings').then(({ sidecar_settings }) => {
+      sendResponse({ ok: true, result: { showPayButton: (sidecar_settings || {}).showPayButton } });
+    });
+    return true;
   }
 
   // Page RPC from content script.

--- a/content.js
+++ b/content.js
@@ -520,7 +520,11 @@
   try {
     chrome.runtime.sendMessage({ type: 'SIDECAR_GET_SETTINGS' }, (s) => {
       if (chrome.runtime.lastError) return; // keep the default (on)
-      showCard = !(s && s.showPayButton === false);
+      // Control replies are { ok, result } envelopes — the setting is inside
+      // result. (Reading it off the top level meant a saved "off" never applied
+      // on page load, only via the live settings push.)
+      const settings = (s && s.result) || {};
+      showCard = settings.showPayButton !== false;
       scanForInvoice();
     });
   } catch (_) {}

--- a/help.css
+++ b/help.css
@@ -176,6 +176,12 @@ html { scroll-behavior: smooth; }
   border-radius: 0 10px 10px 0;
 }
 
+/* ===== What's new (release-notes list; mirrors the CHANGELOG.md highlights) ===== */
+
+.guide-section .whatsnew-version { color: var(--gold); font-size: 15px; margin-bottom: 4px; }
+.whatsnew-list { margin: 0 0 14px; padding-left: 22px; }
+.whatsnew-list li { font-size: 15px; color: var(--text-2); line-height: 1.7; margin: 8px 0; }
+
 /* ===== Resources grid (reuses welcome.css .card) ===== */
 
 .resources-grid { grid-template-columns: 1fr 1fr; }

--- a/help.html
+++ b/help.html
@@ -26,6 +26,7 @@
         <a href="#switching">Switching</a>
         <a href="#clients">Clients compared</a>
         <a href="#wallet">Wallet</a>
+        <a href="#whats-new">What's new</a>
       </div>
       <div class="helpnav-pages">
         <a href="welcome.html">Nostr apps</a>
@@ -218,6 +219,26 @@
       connection.</p>
       <p>If you don't have a wallet that speaks NWC yet, the wallet directory below has
       good options for every taste, custodial to self-custodial.</p>
+    </section>
+
+    <!-- ===== What's new ===== -->
+    <!-- RELEASE PRACTICE: update this section as part of every release. Replace the
+         version line and highlights with the new release's user-facing notes
+         (mirroring the CHANGELOG.md entry) — keep only the latest release here;
+         the full history stays in CHANGELOG.md, linked below. -->
+    <section class="guide-section" id="whats-new">
+      <h2>What's new</h2>
+      <p class="whatsnew-version">Version 1.4.0</p>
+      <ul class="whatsnew-list">
+        <li><strong>A clearer signing prompt.</strong> Event content shows in a compact, expandable preview with Formatted, Raw, and JSON views, and roughly 40 more event kinds are recognized by name — so routine actions no longer show the "unrecognized kind" caution.</li>
+        <li><strong>Readable identities.</strong> Encrypt and decrypt prompts show the other party by name, with their npub kept beneath it as a verifiable key — click the npub to reveal the full key.</li>
+        <li><strong>Auto-lock is on by default.</strong> Sidecar now locks after 15 minutes of inactivity — adjustable in Settings, including back to Never, and changes apply immediately. If you'd never chosen a value, a one-time notice tells you the first time you unlock.</li>
+        <li><strong>Save-your-PIN reminder.</strong> Right after you create a PIN, a one-time reminder prompts you to write it down or store it in a password manager — there's no recovery if it's forgotten.</li>
+        <li><strong>Tighter settings privacy.</strong> Websites can no longer read Sidecar's settings; pages see only the on-page pay-card toggle.</li>
+        <li><strong>Primal wallet strings detected.</strong> Primal's wallet connection only works inside Primal's own apps — Sidecar now explains that up front instead of hanging on connect.</li>
+      </ul>
+      <p>The full history, including earlier releases, is in the
+      <a href="https://github.com/dmnyc/sidecar/blob/main/CHANGELOG.md" target="_blank" rel="noreferrer noopener">changelog on GitHub</a>.</p>
     </section>
 
     <!-- ===== More resources ===== -->

--- a/help.html
+++ b/help.html
@@ -238,7 +238,7 @@
         <li><strong>Primal wallet strings detected.</strong> Primal's wallet connection only works inside Primal's own apps — Sidecar now explains that up front instead of hanging on connect.</li>
       </ul>
       <p>The full history, including earlier releases, is in the
-      <a href="https://github.com/dmnyc/sidecar/blob/main/CHANGELOG.md" target="_blank" rel="noreferrer noopener">changelog on GitHub</a>.</p>
+      <a href="https://github.com/dmnyc/sidecar/blob/main/CHANGELOG.md" target="_blank" rel="noreferrer noopener" id="changelog-link">changelog on GitHub</a>.</p>
     </section>
 
     <!-- ===== More resources ===== -->
@@ -299,6 +299,7 @@
 
   </div>
 
+  <script src="version.js"></script>
   <script src="help.js"></script>
 </body>
 </html>

--- a/help.js
+++ b/help.js
@@ -4,6 +4,17 @@
 (() => {
   'use strict';
 
+  // Pin the "full history" link to this exact build's tag, not main — main can
+  // legitimately be ahead of what's installed (PRs merge well before a release
+  // is tagged/shipped), and a hotfix branched from an older tag must link to its
+  // own snapshot, not whatever's newest on main. Falls back to the static main
+  // link in the markup if the build stamp is ever missing.
+  const changelogLink = document.getElementById('changelog-link');
+  const build = window.SIDECAR_BUILD;
+  if (changelogLink && build && build.version) {
+    changelogLink.href = 'https://github.com/dmnyc/sidecar/blob/v' + build.version + '/CHANGELOG.md';
+  }
+
   const links = Array.from(document.querySelectorAll('#helpnav-links a'));
   if (!links.length) return;
 

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -266,6 +266,7 @@
       <div class="setting">
         <h3>Updates</h3>
         <p class="hint" id="settings-version"></p>
+        <a href="#" id="whats-new-link" class="whats-new-link">What&#8217;s new in this version &rarr;</a>
         <button class="secondary" id="check-update-btn">Check for updates</button>
         <p class="hint" id="check-update-status"></p>
       </div>

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -547,6 +547,12 @@
   $('help-btn').addEventListener('click', () => {
     chrome.tabs.create({ url: chrome.runtime.getURL('help.html') });
   });
+  // Release notes live in the help guide's "What's new" section — the guide is
+  // updated as part of every release (see the RELEASE PRACTICE note in help.html).
+  $('whats-new-link').addEventListener('click', (e) => {
+    e.preventDefault();
+    chrome.tabs.create({ url: chrome.runtime.getURL('help.html') + '#whats-new' });
+  });
 
   // ---- settings (gear icon ↔ overlay view) ----
   $('settings-btn').addEventListener('click', () => {

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -311,6 +311,7 @@
       dismissPostBanner(); // a note link is account-specific; clear on any state change
       renderMain();
       initNotifSubs();
+      maybeShowAutoLockNotice(settings);
       // Re-render the visible tab so account-scoped views (Activity/Profile) follow the switch.
       const activeTab = document.querySelector('.tab.active');
       const name = activeTab && activeTab.dataset.tab;
@@ -2267,6 +2268,55 @@
       },
       () => { if (onDone) setTimeout(onDone, 0); }
     );
+  }
+
+  // One-time notice for keystores that predate the 15-minute auto-lock default:
+  // their Settings were never touched, so 1.4 turned auto-lock on for them
+  // silently. Tell them — and remind them the unlock PIN is unrecoverable, since
+  // they also predate the save-your-PIN reminder above. New keystores never see
+  // this (SIDECAR_INIT stores the default explicitly). Writing the resolved value
+  // back as their explicit setting also means a future default change can't
+  // silently move it again.
+  let autoLockNoticePending = false;
+  async function maybeShowAutoLockNotice(settings) {
+    if (autoLockNoticePending) return;
+    if (!settings || !settings.autoLockDefaulted || settings.autoLockNoticeShown) return;
+    autoLockNoticePending = true;
+    try {
+      await call({
+        type: 'SIDECAR_SET_SETTINGS',
+        settings: { autoLockMinutes: settings.autoLockMinutes, autoLockNoticeShown: true },
+      });
+    } catch (_) {
+      autoLockNoticePending = false; // couldn't persist; try again next refresh
+      return;
+    }
+    autoLockNoticeModal(settings.autoLockMinutes);
+  }
+
+  function autoLockNoticeModal(minutes) {
+    openModal((modal) => {
+      const body = h('p', { className: 'hint pin-reminder-body' });
+      body.append(
+        document.createTextNode('Sidecar now locks itself after ' + minutes + ' minutes of inactivity. Unlocking uses the PIN you chose when you set up Sidecar — '),
+        h('strong', { className: 'pin-reminder-warn', textContent: "it can't be recovered" }),
+        document.createTextNode(", so make sure it's written down or in a password manager. You can adjust or turn off auto-lock in Settings.")
+      );
+      const settingsBtn = h('button', { className: 'ghost', textContent: 'Auto-lock settings' });
+      settingsBtn.addEventListener('click', () => {
+        closeModal();
+        hide($('view-main'));
+        show($('view-settings'));
+        renderSettings();
+      });
+      const ok = h('button', { className: 'primary', textContent: 'OK, got it' });
+      ok.addEventListener('click', closeModal);
+      modal.append(
+        h('h3', { className: 'pin-reminder-title', textContent: 'Sidecar now locks automatically' }),
+        body,
+        h('div', { className: 'actions' }, [settingsBtn, ok])
+      );
+    });
   }
 
   // PIN-gated step-up, then the tabbed nsec/ncryptsec backup view below.

--- a/styles.css
+++ b/styles.css
@@ -1610,6 +1610,10 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
 .debug-log-error .item-label { color: var(--red); }
 .debug-log-warn .item-label { color: var(--gold); }
 
+/* Settings → Updates: link to the help guide's "What's new" release notes. */
+.whats-new-link { display: inline-block; margin-bottom: 10px; font-size: 13px; color: var(--lav); text-decoration: none; }
+.whats-new-link:hover { text-decoration: underline; }
+
 /* ===== toasts ===== */
 .toasts {
   position: fixed;


### PR DESCRIPTION
Pre-release hardening for the 1.4.0 auto-lock default, plus a new standing practice of publishing release notes inside the app.

## Security

- **Auto-lock changes apply immediately.** `SIDECAR_SET_SETTINGS` now clears and re-arms the alarm whenever `autoLockMinutes` is written — previously the new value only took effect on the next sign/pay/unlock, so enabling auto-lock and walking away never actually locked. The alarm handler also re-checks the live setting at fire time, so an alarm armed under an older choice can't lock after the user switches to Never.
- **Web-origin settings reads clamped.** Visited pages now get only `{ showPayButton }` from `SIDECAR_GET_SETTINGS`, matching the existing clamp on writes. A page could previously read the full settings object, including the auto-lock timing (how long an unattended unlocked keystore stays warm) and budget/auto-zap configuration.
- **One-time migration notice.** Keystores that predate the 15-minute default (Settings never touched) get a one-time modal the first time the panel opens unlocked: auto-lock is now on, and the unlock PIN is unrecoverable — these users also predate the new save-your-PIN reminder. Showing it persists the resolved value as their explicit setting, so a future default change can't silently move them again. New keystores store the default explicitly at `SIDECAR_INIT` and never see the notice; users who ever chose a value (including Never) keep it and see nothing.

## Fixed

- The saved "Pay with Sidecar" card toggle now applies on page load — the content script read the setting off the top level of the reply instead of inside the `{ ok, result }` envelope, so only the live settings push ever applied.

## In-app release notes

- The help guide gains a **What's new** section (`help.html#whats-new`) summarizing the latest release's user-facing highlights, linked from the help nav and from a new "What's new in this version" link in Settings → Updates. The section carries only the latest release, with a link to the full CHANGELOG on GitHub, and is updated alongside CHANGELOG.md as part of every release (practice noted in the changelog header and in a comment on the section).
- Follow-up: that "full history" link is pinned to the exact build's tag (via the already-stamped `version.js`, itself derived from `manifest.json` on every commit) instead of `main` — `main` can legitimately be ahead of what's installed, and a hotfix branched from an older tag needs to link to its own snapshot, not whatever's newest on `main`. Static markup keeps `main` as a fallback if the build stamp is ever missing.

## Verification

- `node --check` passes on all modified scripts.
- Hand-traced each settings cohort: legacy-unset (notice + explicit 15), explicit Never (no notice, no lock), explicit value (kept, no notice), new keystore (explicit default at init, no notice), erase-then-restart (settings cleared by reset, takes the new-keystore path).
- Recommended manual pass before release: load the update over a profile with a pre-1.4 keystore and untouched settings, unlock, confirm the notice appears exactly once and Settings shows 15 minutes afterward.

🍸 Strained with [Claude Code](https://claude.com/claude-code)