### PR TITLE
Show auto-lock in the UI; count composer typing as activity

### DIFF
--- a/background.js
+++ b/background.js
@@ -1390,11 +1390,17 @@ async function loadUnlockGuard() {
 const saveUnlockGuard = (g) => sset({ sidecar_unlock_guard: g });
 const clearUnlockGuard = () => new Promise((res) => chrome.storage.local.remove('sidecar_unlock_guard', res));
 
-async function lockKeystore() {
+async function lockKeystore(auto = false) {
   await KS.lock();
   SIGNER.clearCache();
   closeSwNwc();
   chrome.alarms.clear(AUTO_LOCK_ALARM);
+  // Tell any open panel/popup to drop to the unlock screen immediately — otherwise
+  // it keeps showing whatever was open (e.g. the composer) and only discovers the
+  // lock on its next action, which then fails with a "locked" error. `auto` marks an
+  // idle-timeout lock (vs. manual lock / wipe / reset, which show their own message)
+  // so the panel can toast why it suddenly jumped to the unlock screen.
+  chrome.runtime.sendMessage({ type: 'SIDECAR_EVENT', event: 'locked', auto }).catch(() => {});
 }
 
 function bumpAutoLock() {
@@ -1411,7 +1417,7 @@ chrome.alarms.onAlarm.addListener((alarm) => {
     // Re-check the live setting at fire time: an alarm armed under an older
     // choice (before the user switched to Never) must not lock.
     sget('sidecar_settings').then(({ sidecar_settings }) => {
-      if (resolveSettings(sidecar_settings).autoLockMinutes > 0) lockKeystore();
+      if (resolveSettings(sidecar_settings).autoLockMinutes > 0) lockKeystore(true);
     });
   }
   // Best-effort heartbeat while the approval queue is non-empty: sweeps expired
@@ -1426,6 +1432,14 @@ async function handleControl(message, sendResponse) {
     switch (message.type) {
       case 'SIDECAR_GET_STATE':
         result = await KS.getState();
+        break;
+      case 'SIDECAR_ACTIVITY':
+        // Panel-side activity (e.g. actively composing a note) counts as use, so
+        // re-arm the idle auto-lock timer — otherwise it can fire mid-compose,
+        // since typing never round-trips to the background. No-ops when locked or
+        // when auto-lock is off/Never (bumpAutoLock guards both).
+        bumpAutoLock();
+        result = { ok: true };
         break;
       case 'SIDECAR_INIT': {
         result = await KS.initialize(message.pin);

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -272,7 +272,23 @@
       const active = document.querySelector('.tab.active');
       if (active && active.dataset.tab === 'wallet') renderWallet();
     }
+    // Auto-lock (or a lock from elsewhere) fired in the background — drop to the
+    // unlock screen now. refresh() closes any open modal and routes to view-lock.
+    // Only an idle-timeout lock (auto) toasts — the user didn't trigger it, so
+    // explain the sudden jump; manual lock / reset already show their own message.
+    if (msg.event === 'locked') { refresh(); if (msg.auto) toast('Locked due to inactivity'); }
   });
+
+  // Reset the background idle auto-lock timer on active panel use (composing),
+  // throttled so a burst of keystrokes doesn't spam the service worker — auto-lock
+  // is minutes, so one ping every ~20s keeps it alive while you're actively typing.
+  let lastActivityPing = 0;
+  function noteActivity() {
+    const now = Date.now();
+    if (now - lastActivityPing < 20000) return;
+    lastActivityPing = now;
+    chrome.runtime.sendMessage({ type: 'SIDECAR_ACTIVITY' }).catch(() => {});
+  }
 
   // ---- top-level routing ----
   async function refresh() {
@@ -302,6 +318,10 @@
       show($('view-onboarding'));
       setTimeout(() => $('ob-pin').focus(), 50);
     } else if (state.locked) {
+      // Lock is a security boundary and always wins: tear down any open modal
+      // (composer, wallet, key backup, …) so nothing sensitive sits over the lock
+      // screen. The composer draft is autosaved, so it's offered again on unlock.
+      closeModal();
       if (nwc) { try { nwc.close(); } catch (_) {} nwc = null; nwcPubkey = null; }
       balanceCache = { pubkey: null, sats: null };
       show($('view-lock'));
@@ -4280,6 +4300,7 @@
         updatePostState();
         updateAcDropdown();
         scheduleSave();
+        noteActivity(); // composing counts as activity — keep auto-lock at bay
       });
 
       editor.addEventListener('keydown', (e) => {


### PR DESCRIPTION
## Auto-lock UX fixes

**Bug:** with auto-lock on, leaving a draft in the composer past the idle timeout locked the keystore in the background — but the panel never heard about it, so the composer stayed on screen and you only hit the wall at "send" (a locked error).

**Root cause:** `lockKeystore()` locked silently (no broadcast), and `refresh()` didn't tear down open modals when routing to the lock screen.

### Fix
- `lockKeystore()` now broadcasts a `locked` event; the panel closes any open modal and drops to the unlock screen immediately.
- An **idle-timeout** lock shows a **"Locked due to inactivity"** toast. An `auto` flag distinguishes it from manual lock / the 21-fails wipe / reset-all (all `auto=false`), which show their own messages — so no double-toast.
- The composer draft is autosaved, so it's offered again ("Resume your draft?") on unlock — locking gates the work, never loses it.

### Also: composer typing counts as activity
`bumpAutoLock()` only reset on sign/pay/unlock, so typing a long note never counted — auto-lock could fire mid-compose. Composer input now sends a throttled `SIDECAR_ACTIVITY` ping (once / 20s) that re-arms the idle timer. No-ops when locked or when auto-lock is Never.

### Verification
Syntax + scope checked. This is service-worker↔panel messaging + `chrome.alarms` + DOM routing — runtime behavior I can't exercise without a browser. Manually verified by the maintainer: idle-with-composer flips to the unlock screen with the toast, and active typing doesn't lock.

🍸 Shaken with [Claude Code](https://claude.com/claude-code)