### PR TITLE
Prep 1.4.1: version bump, changelog, What's new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ Release practice: the latest release's highlights are also summarized in-app, in
 guide's **What's new** section (`help.html#whats-new`, linked from Settings → Updates).
 Update that section alongside this file as part of every release.
 
+## [1.4.1] — 2026-07-16
+
+### Added
+- **Eight new apps in the welcome directory** — Flotilla, Tunestr, Wavlake, WaveFunc Radio, Boost Me Bitch, Cordn, Imwald, and ContextVM — and every app description got a copy pass for a consistent, scannable length. The same directory (and the wallet guide) is now published on the web at [sidecar.top/apps](https://sidecar.top/apps) and [sidecar.top/wallets](https://sidecar.top/wallets), generated from the extension's own list so the two never drift.
+
+### Changed
+- **Auto-lock now shows itself.** When the idle timer fires, the panel drops straight to the unlock screen with a "Locked due to inactivity" notice, instead of staying on whatever was open (a composer, a modal) and only failing on the next action. Typing in the composer now counts as activity, so auto-lock can't fire mid-draft.
+- Quoted-note notifications use a lighter ornamental quote mark; the previous speech-bubble emoji rendered nearly black on the dark panel.
+- The About screen's Privacy Policy and Support links use the site's extensionless URLs.
+
+### Fixed
+- **Revealing or exporting a key with the correct PIN now works even if auto-lock fired while the prompt was open.** The step-up prompt used to reject the correct PIN with "keystore is locked," forcing a manual lock/unlock; now it unlocks with that PIN and proceeds, exactly as the unlock screen would.
+
+### Security
+- **Every PIN prompt now shares the unlock screen's brute-force protection.** Step-up checks (verify PIN, reveal nsec/NWC, change PIN) previously had no throttle or wipe accounting, leaving an unthrottled path to guess the PIN around the 21-strike guard. They now use the same persisted guard: escalating delays between wrong attempts, the self-erase on the final strike, and a warning as it nears.
+
 ## [1.4.0] — 2026-07-11
 
 ### Added

--- a/help.html
+++ b/help.html
@@ -228,16 +228,13 @@
          the full history stays in CHANGELOG.md, linked below. -->
     <section class="guide-section" id="whats-new">
       <h2>What's new</h2>
-      <p class="whatsnew-version">Version 1.4.0</p>
+      <p class="whatsnew-version">Version 1.4.1</p>
       <ul class="whatsnew-list">
-        <li><strong>A clearer signing prompt.</strong> Event content shows in a compact, expandable preview with Formatted, Raw, and JSON views, and roughly 40 more event kinds are recognized by name — so routine actions no longer show the "unrecognized kind" caution.</li>
-        <li><strong>Readable identities.</strong> Encrypt and decrypt prompts show the other party by name, with their npub kept beneath it as a verifiable key — click the npub to reveal the full key.</li>
-        <li><strong>Auto-lock is on by default.</strong> Sidecar now locks after 15 minutes of inactivity — adjustable in Settings, including back to Never, and changes apply immediately. If you'd never chosen a value, a one-time notice tells you the first time you unlock.</li>
-        <li><strong>Save-your-PIN reminder.</strong> Right after you create a PIN, a one-time reminder prompts you to write it down or store it in a password manager — there's no recovery if it's forgotten.</li>
-        <li><strong>Tighter settings privacy.</strong> Websites can no longer read Sidecar's settings; pages see only the on-page pay-card toggle.</li>
-        <li><strong>Primal wallet strings detected.</strong> Primal's wallet connection only works inside Primal's own apps — Sidecar now explains that up front instead of hanging on connect.</li>
-        <li><strong>Security audit addressed.</strong> A community trust audit's recommendations are now in place: refreshed core libraries, tamper-detection for every bundled file, and a licensing fix so the whole project stays cleanly open source.</li>
-        <li><strong>Draft mentions fixed.</strong> Resuming a saved draft now shows the mentioned person's name, instead of their raw key.</li>
+        <li><strong>Auto-lock you can see.</strong> When the idle timer fires, the panel now drops straight to the unlock screen with a "Locked due to inactivity" notice, instead of staying on whatever was open and only failing on your next action. Typing in the composer counts as activity, so it can't lock mid-draft.</li>
+        <li><strong>Your correct PIN always works.</strong> Revealing or exporting a key with the right PIN now succeeds even if auto-lock beat you to it — it unlocks and proceeds, instead of rejecting the PIN and making you lock and unlock by hand.</li>
+        <li><strong>Every PIN prompt is brute-force-guarded.</strong> Reveals, exports, and PIN changes now share the unlock screen's protection — escalating delays between wrong tries and the self-erase on the final strike.</li>
+        <li><strong>More apps to explore.</strong> Eight new apps in the directory — Flotilla, Tunestr, Wavlake, WaveFunc Radio, Boost Me Bitch, Cordn, Imwald, and ContextVM — now also browsable on the web at sidecar.top/apps.</li>
+        <li><strong>A lighter quoted-note icon</strong> in notifications, easier to see on the dark panel.</li>
       </ul>
       <p>The full history, including earlier releases, is in the
       <a href="https://github.com/dmnyc/sidecar/blob/main/CHANGELOG.md" target="_blank" rel="noreferrer noopener" id="changelog-link">changelog on GitHub</a>.</p>

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Sidecar | A Classy Nostr Signer",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "minimum_chrome_version": "114",
   "description": "A multi-account NIP-07 Nostr signer with a built-in Lightning wallet, in your browser sidebar.",
   "permissions": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sidecar-nostr-signer",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "A multi-account NIP-07 nostr signer with a built-in Lightning wallet, in your browser sidebar",
   "scripts": {
     "dev": "echo 'Load this folder as an unpacked extension at chrome://extensions'",


### PR DESCRIPTION
Release-prep for **1.4.1**, a patch rolling up work already merged to main:

- **#110** — auto-lock surfaces in the UI + composer typing counts as activity
- **#111** — correct PIN accepted in step-up prompts while locked; all PIN prompts share the unlock guard's throttle/wipe (brute-force hardening)
- **#112** — eight new welcome apps + desc copy pass, ❝ quoted-note glyph, About links off `.php`, README testimonial

## Changes here

- `manifest.json` + `package.json` → **1.4.1** (in lockstep)
- `CHANGELOG.md` → `## [1.4.1]` section (Added / Changed / Fixed / Security)
- `help.html#whats-new` → mirrors the highlights, latest release only (per release practice)

No code changes — docs + version only. `verify-vendor` unaffected (no vendored files touched).

Companion sidecar.top deploy (catalog `/apps` + `/wallets` pages, review carousel, nav fixes) ships alongside this per the publish checklist.

🥂 Toasted with [Claude Code](https://claude.com/claude-code)
