### PR TITLE
1.5.0: Firefox support, three themes, dual-store packaging

### DIFF
--- a/BROWSER_PARITY.md
+++ b/BROWSER_PARITY.md
@@ -13,15 +13,17 @@ skips Firefox (or vice versa).
 | Background        | MV3 `background.service_worker`       | event page: `background.scripts`                     |
 | Side UI           | `side_panel` (`chrome.sidePanel`)     | `sidebar_action`                                     |
 | Store metadata    | —                                     | requires `browser_specific_settings.gecko`           |
-| Lives on          | `main`                                | `feat/firefox-port` (+ `fix/firefox-message-origin`) |
+| Lives on          | `main`                                | `feat/firefox-port` (origin fix folded in)           |
 
 The Firefox port is kept on its own branch(es) until it's ready for AMO. Merging a
 release to `main` updates the Chrome build; the Firefox branch must be brought up to
 the same version separately (see the checklist).
 
-**Current status:** paused as of 1.4.0 — Chrome is the active priority. Resume by
-rebasing `feat/firefox-port` onto `main`, folding in `fix/firefox-message-origin`, and
-running the checklist below.
+**Current status:** resumed. `feat/firefox-port` is rebased onto 1.4.0 `main`
+(including the post-1.4.0 auto-lock UI work), `fix/firefox-message-origin` is folded
+in, and the port implementation is complete through the shims/permission-UX phase
+(see FIREFOX_PORT.md → Status). Next: the Firefox smoke test below, then the full
+parity benchmark, then AMO.
 
 ## Shared vs. browser-specific
 
@@ -58,7 +60,7 @@ running the checklist below.
 ## Known cross-browser gotchas
 
 - **Origin gate** (`background.js`) — use `runtime.getURL('/')`, not a hardcoded scheme.
-  Fixed on `fix/firefox-message-origin`; fold that into the Firefox branch.
+  Fixed on `feat/firefox-port` (the old `fix/firefox-message-origin` commit, folded in).
 - **Side UI** — `chrome.sidePanel` (Chrome) vs `sidebar_action` (Firefox); the manifest
   key and the open/close behavior both differ.
 - **Background** — MV3 service worker (Chrome) vs event page `background.scripts` (Firefox).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Update that section alongside this file as part of every release.
 
 ### Fixed
 - **Art Deco legibility pass.** On the light theme, several elements colored for a dark backdrop were washing out: the key-backup box and its warning text, the signing-approval event preview and caution banner, the wallet balance and transaction colors, the NIP-05 verification badges, and the "Pay with Sidecar" card's logo, error, and paid states. All now read clearly against the eggshell background.
+- **The Close button on an expired standalone approval popup now works.** Previously, when a request timed out in the popup shown with the sidebar closed, "Close" did nothing — the request had already been purged, so the approval message had nothing to act on and the window never closed. Close now dismisses the popup directly.
 
 ## [1.4.1] — 2026-07-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ Release practice: the latest release's highlights are also summarized in-app, in
 guide's **What's new** section (`help.html#whats-new`, linked from Settings → Updates).
 Update that section alongside this file as part of every release.
 
+## [1.5.0] — Unreleased
+
+### Added
+- **Firefox support.** The full signer — multi-account, NIP-07, the built-in Lightning wallet, and the approval flow — now runs on Firefox 128+ at parity with the Chrome build, from a single shared codebase. On Firefox, Sidecar lives in the sidebar rather than the side panel, and (because Firefox lets you decline site access at install) offers a one-click grant from the panel if you skipped it. Distributed through Firefox Add-ons (AMO).
+- **Three themes, selectable in Settings.** **Speakeasy** (the original after-hours velvet) stays the default, joined by **Film Noir** (matte black-on-black with silver accents) and **Art Deco** (a daylight eggshell-and-bronze palette with a geometric pattern background). Your choice persists across sessions, and the injected "Pay with Sidecar" card on web pages adopts the same theme.
+
+### Changed
+- **Toasts now appear at the bottom** of the panel instead of dropping over the top menu, so a confirmation like "Unlocked" no longer covers the account switcher and toolbar for a few seconds.
+- The follow-list recovery button is now labeled **"Follow List Recovery"**, matching what Mutable — the service that powers it — calls the feature.
+
+### Fixed
+- **Art Deco legibility pass.** On the light theme, several elements colored for a dark backdrop were washing out: the key-backup box and its warning text, the signing-approval event preview and caution banner, the wallet balance and transaction colors, the NIP-05 verification badges, and the "Pay with Sidecar" card's logo, error, and paid states. All now read clearly against the eggshell background.
+
 ## [1.4.1] — 2026-07-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Release practice: the latest release's highlights are also summarized in-app, in
 guide's **What's new** section (`help.html#whats-new`, linked from Settings → Updates).
 Update that section alongside this file as part of every release.
 
-## [1.5.0] — Unreleased
+## [1.5.0] — 2026-07-21
 
 ### Added
 - **Firefox support.** The full signer — multi-account, NIP-07, the built-in Lightning wallet, and the approval flow — now runs on Firefox 128+ at parity with the Chrome build, from a single shared codebase. On Firefox, Sidecar lives in the sidebar rather than the side panel, and (because Firefox lets you decline site access at install) offers a one-click grant from the panel if you skipped it. Distributed through Firefox Add-ons (AMO).

--- a/FIREFOX_PORT.md
+++ b/FIREFOX_PORT.md
@@ -140,10 +140,11 @@ one place parity requires *new* surface:
    `contains` simply always returns true — the code can be unconditional, which
    keeps one code path).
 
-For development, the manifest flag `"granted_host_permissions": true` auto-grants
-hosts on temporary loads via `about:debugging` (it has no effect on installed
-builds) — worth adding so the dev workflow isn't gated on manual grants, and worth
-a line in the README dev-install section.
+For development: temporary loads via `about:debugging` grant install-time
+permission requests silently on current Firefox (the `granted_host_permissions`
+manifest key is privileged-only and ignored for ordinary add-ons — don't ship it).
+If a dev build still lacks site access, it can be toggled at
+`about:addons` → Permissions; the README dev-install section documents this.
 
 ### W5 — Sidebar wiring
 

--- a/FIREFOX_PORT.md
+++ b/FIREFOX_PORT.md
@@ -1,11 +1,47 @@
 # Firefox Port Plan
 
 Plan for porting Sidecar to Firefox at **1:1 feature parity** with the Chrome build,
-from a full audit of the codebase (v1.3.0). The good news up front: Sidecar's
-architecture (plain JS, no build step, `chrome.*` callback style, `storage.session`
-for lock state, a persisted request queue that already assumes the background can die
-at any moment) is unusually Firefox-friendly. The port is a handful of surgical
-changes plus one genuinely new piece of UX (host-permission granting), not a rewrite.
+from a full audit of the codebase (v1.3.0, refreshed against v1.4.0 — see Status).
+The good news up front: Sidecar's architecture (plain JS, no build step, `chrome.*`
+callback style, `storage.session` for lock state, a persisted request queue that
+already assumes the background can die at any moment) is unusually Firefox-friendly.
+The port is a handful of surgical changes plus one genuinely new piece of UX
+(host-permission granting), not a rewrite.
+
+## Status — resumed post-1.4.0
+
+The port paused while 1.4.0 shipped to Chrome. The branch has since been rebased
+onto 1.4.0 (plus the auto-lock UI follow-up), the cross-browser origin-gate fix is
+folded in, and implementation is complete through W6:
+
+| Workstream | State |
+|---|---|
+| W1 manifest (one file, both browsers) | ✅ done |
+| W2 background event page | ✅ done (lifetime tests remain — see W2 item 4) |
+| W3 MAIN-world provider injection | ✅ done — Chrome benefits too (CSP-proof, race-free) |
+| W4 host-permission recovery UX | ✅ done — panel banner, welcome-page gate, live grant/revoke listeners |
+| W5 sidebar wiring | ✅ done |
+| W6 shims | ✅ done in code (update check, scrollbars, pay-menu fallback); popup sizing + clipboard are QA items |
+| W7 docs | README + help notes done; PRIVACY.md line deferred to AMO submission |
+| W8 AMO listing | not started — holds until the parity benchmark passes |
+
+**1.4.0 audit deltas** — features added since the original v1.3.0 audit, all
+Firefox-clean: the debug panel (#103), auto-lock hardening + settings UI +
+composer-typing activity (#105/#110), the What's-new help section pinned to the
+build's tag, draft @-mention rehydration (#108), and the supply-chain refresh
+(#107: nostr-tools 2.23.11, MIT QR encoder — panel-side only). None add
+Chrome-only API surface, and the background's `importScripts` list — and therefore
+the manifest `background.scripts` list — is unchanged.
+
+One real parity bug was found and fixed during the refresh: **dev-build detection**
+keyed off a missing manifest `update_url`, which Chrome's Web Store injects at
+packaging time but AMO never does — so every production Firefox install would have
+been treated as a dev build (bug button, debug-log buffering). Detection now asks
+`management.getSelf()` for `installType === 'development'` on Firefox and fails
+closed while that async answer is pending.
+
+**Next:** run the parity benchmark below on Firefox 128 ESR + current release,
+then W8.
 
 ## Target baseline
 
@@ -43,9 +79,10 @@ polyfill needed):
 | `chrome.runtime.onInstalled/onStartup` | `background.js` | ✅ Works as-is |
 | **`background.service_worker` + `importScripts`** | `manifest.json`, `background.js:11`, `background.js:1272` | ❌ Firefox MV3 has no SW background — event page instead |
 | **`chrome.sidePanel.*`** (`setPanelBehavior`, `open`) | `background.js:187,195` | ❌ Firefox uses `sidebar_action` / `sidebarAction` |
-| **`chrome.runtime.requestUpdateCheck`** | `sidepanel.js:6669` | ❌ Not on Firefox (AMO auto-updates) — feature-detect and hide |
-| **`<script src>` provider injection** | `content.js:10–15` | ⚠️ Page CSP can block it on Firefox (unlike Chrome) — root-cause fix in W3 |
-| **`host_permissions: ["https://*/*"]` granted at install** | `manifest.json` | ⚠️ On Firefox MV3 the user can decline/revoke — needs a grant-recovery UX (W4) |
+| **`chrome.runtime.requestUpdateCheck`** | `sidepanel.js` (About + Settings) | ✅ Feature-detected and hidden on Firefox (done; AMO auto-updates) |
+| **`<script src>` provider injection** | was `content.js` | ✅ Replaced by a `world: "MAIN"` content script (W3, done — Chrome too) |
+| **`host_permissions: ["https://*/*"]` granted at install** | `manifest.json` | ✅ Grant-recovery UX shipped (W4, done): panel banner + welcome gate |
+| **`update_url` absent ⇒ dev build** heuristic | `background.js`, `sidepanel.js` | ✅ Fixed — AMO never injects `update_url`; Firefox now uses `management.getSelf().installType` |
 | `navigator.clipboard.writeText` (copy npub/invoice/etc.) | `sidepanel.js` (8 call sites) | ✅ Works in user-gesture handlers; QA item |
 | `::-webkit-scrollbar*`, `::-webkit-details-marker` | `styles.css` | ⚠️ Cosmetic — add Firefox equivalents (W6) |
 
@@ -232,6 +269,11 @@ same wallet, and must behave identically. The matrix lives as a checklist
 | 22 | Auto-approve zaps: under-limit silent, over-limit/daily-cap/non-zap/locked all prompt | identical thresholds |
 | 23 | Help & welcome pages, About dialog | correct browser-specific copy (allowed variance) |
 | 24 | Reset Sidecar (type-to-confirm wipe) | storage fully cleared |
+| 25 | *(1.4.0)* Auto-lock settings UI: timer change applies immediately, migration notice, composer typing counts as activity | identical behavior + wording |
+| 26 | *(1.4.0)* Debug panel & dev badge: appear on a temporary/unpacked load, NEVER on a store install (Chrome: `update_url`; Firefox: `management.getSelf`) | AMO-signed build shows no bug button |
+| 27 | *(1.4.0)* Settings → What's new opens `help.html#whats-new` pinned to this build's tag | correct tag on both |
+| 28 | *(1.4.0)* Composer draft resume rehydrates @-mention pills | identical |
+| 29 | *(1.4.0)* Pay-with-Sidecar toggle persists and applies on page load (settings envelope fix) | saved "off" respected after reload |
 
 ### Firefox-specific adversarial tests
 
@@ -246,7 +288,7 @@ same wallet, and must behave identically. The matrix lives as a checklist
 
 ### Exit criteria
 
-- 24/24 matrix rows pass on Firefox 128 ESR and current Firefox release.
+- 29/29 matrix rows pass on Firefox 128 ESR and current Firefox release.
 - The only permitted deltas are the four **declared platform variances**:
   (1) sidebar is per-window not per-tab; (2) update-check button hidden (AMO
   auto-updates); (3) install-time host-permission prompt + recovery banner exists;
@@ -258,14 +300,15 @@ same wallet, and must behave identically. The matrix lives as a checklist
 
 | Phase | Work | Estimate |
 |---|---|---|
-| 1 | W1 + W2 (manifest, background loading, first boot in Firefox) | 1–2 days |
-| 2 | W3 + W5 (MAIN-world injection, sidebar wiring) — signer usable end-to-end | 1–2 days |
-| 3 | W4 + W6 (permission UX, shims, CSS) | 2–3 days |
-| 4 | Full parity benchmark on both browsers + fixes it shakes out | 3–5 days |
-| 5 | W7 + W8 (docs, site, AMO listing + review) | 1 day work + review wait |
+| 1 | W1 + W2 (manifest, background loading, first boot in Firefox) | ✅ done |
+| 2 | W3 + W5 (MAIN-world injection, sidebar wiring) — signer usable end-to-end | ✅ done |
+| 3 | W4 + W6 (permission UX, shims, CSS) | ✅ done |
+| 4 | Full parity benchmark on both browsers + fixes it shakes out | 3–5 days — **next** |
+| 5 | W7 + W8 (docs, site, AMO listing + review) | docs mostly done; AMO = 1 day work + review wait |
 
-Roughly **8–13 working days** plus AMO review latency. Phases 1–2 produce a
-temporarily-loadable Firefox build worth putting in testers' hands early.
+Phases 1–3 are implemented; what remains is testing latency, not build work. The
+current branch is a temporarily-loadable Firefox build worth putting in testers'
+hands now.
 
 ## Risks
 

--- a/FIREFOX_PORT.md
+++ b/FIREFOX_PORT.md
@@ -1,0 +1,277 @@
+# Firefox Port Plan
+
+Plan for porting Sidecar to Firefox at **1:1 feature parity** with the Chrome build,
+from a full audit of the codebase (v1.3.0). The good news up front: Sidecar's
+architecture (plain JS, no build step, `chrome.*` callback style, `storage.session`
+for lock state, a persisted request queue that already assumes the background can die
+at any moment) is unusually Firefox-friendly. The port is a handful of surgical
+changes plus one genuinely new piece of UX (host-permission granting), not a rewrite.
+
+## Target baseline
+
+**Firefox 128 (ESR) or later**, because 128 is the first release with everything we
+need in one place:
+
+| Capability we rely on | Minimum Firefox |
+|---|---|
+| `storage.session` | 115 |
+| `background.scripts` + `background.service_worker` coexisting in one manifest | 121 |
+| Host permissions shown in the MV3 install prompt | 127 |
+| `world: "MAIN"` in `content_scripts` (CSP-proof provider injection) | **128** |
+| `optional_host_permissions` | **128** |
+
+Set `browser_specific_settings.gecko.strict_min_version: "128.0"`.
+
+**Out of scope:** Firefox for Android (no `sidebar_action` there — the whole UI has
+no home). Revisit as a separate project if there's demand.
+
+## Compatibility audit
+
+Everything `chrome.*` the code touches, and its fate on Firefox (the `chrome.`
+namespace itself works in Firefox, callbacks and `runtime.lastError` included — no
+polyfill needed):
+
+| API surface | Where | Firefox status |
+|---|---|---|
+| `storage.local`, `storage.session`, `storage.onChanged` | keystore, crypto, permissions, budgets, panel | ✅ Works as-is |
+| `runtime.sendMessage/onMessage/connect/onConnect/getURL/getManifest/reload/id` | all layers | ✅ Works as-is |
+| `tabs.query/create/update/reload/sendMessage` | panel, background | ✅ Works as-is |
+| `windows.create/get/getCurrent/update/remove/onRemoved` (prompt popup placement) | `background.js:384–430` | ✅ Works as-is |
+| `alarms` (auto-lock, queue keepalive) | `background.js` | ✅ Works; verify sub-minute clamping (see W2) |
+| `notifications.create` (`type: 'basic'`) | `background.js:1220` | ✅ Works as-is |
+| `contextMenus` (link/selection/image pay menus) | `background.js:1293–1298` | ✅ Works; verify `targetUrlPatterns: ['lightning:*']` (see W6) |
+| `chrome.runtime.onInstalled/onStartup` | `background.js` | ✅ Works as-is |
+| **`background.service_worker` + `importScripts`** | `manifest.json`, `background.js:11`, `background.js:1272` | ❌ Firefox MV3 has no SW background — event page instead |
+| **`chrome.sidePanel.*`** (`setPanelBehavior`, `open`) | `background.js:187,195` | ❌ Firefox uses `sidebar_action` / `sidebarAction` |
+| **`chrome.runtime.requestUpdateCheck`** | `sidepanel.js:6669` | ❌ Not on Firefox (AMO auto-updates) — feature-detect and hide |
+| **`<script src>` provider injection** | `content.js:10–15` | ⚠️ Page CSP can block it on Firefox (unlike Chrome) — root-cause fix in W3 |
+| **`host_permissions: ["https://*/*"]` granted at install** | `manifest.json` | ⚠️ On Firefox MV3 the user can decline/revoke — needs a grant-recovery UX (W4) |
+| `navigator.clipboard.writeText` (copy npub/invoice/etc.) | `sidepanel.js` (8 call sites) | ✅ Works in user-gesture handlers; QA item |
+| `::-webkit-scrollbar*`, `::-webkit-details-marker` | `styles.css` | ⚠️ Cosmetic — add Firefox equivalents (W6) |
+
+Everything else — WebCrypto (PBKDF2/AES-GCM), WebSocket relay + NWC connections,
+`fetch` from background and panel (CORS-exempt for granted hosts), fonts, QR libs —
+is standard web platform and carries over unchanged.
+
+## Workstreams
+
+### W1 — Manifest: one file, both browsers (no build step added)
+
+Chrome ≥121 and Firefox ≥121 each ignore the other's keys, so a single
+`manifest.json` serves both and preserves the "no build step" property:
+
+- `background`: keep `service_worker: "background.js"`, **add**
+  `scripts: ["nostr-tools.js", "crypto.js", "keystore.js", "permissions.js", "signer.js", "wallet-budgets.js", "nwc-client.js", "jsqr.js", "background.js"]`.
+  Chrome uses the worker; Firefox loads the scripts list into an event page.
+- **Add** `sidebar_action`: `{ "default_panel": "sidepanel.html", "default_title": "Sidecar", "default_icon": "icons/icon48.png", "open_at_install": false }`
+  alongside the existing `side_panel` key.
+- **Add** `browser_specific_settings.gecko`: `{ "id": "sidecar@sidecar.top", "strict_min_version": "128.0" }`
+  (an explicit ID is mandatory for MV3 on AMO; Chrome ignores the key with a console warning).
+- Content-script change per W3 below.
+
+Fallback if the Chrome Web Store ever rejects the extra keys (it currently only
+warns): a ~10-line `scripts/package-firefox.sh` that strips/patches the manifest
+into a `dist-firefox/` zip. Plan A is the single manifest; keep the script in the
+back pocket.
+
+### W2 — Background: service worker → event page
+
+Firefox runs the background as a non-persistent **event page** (a hidden window,
+not a worker). It suspends after ~30s idle just like Chrome's SW, so Sidecar's
+existing survival machinery — keystore state mirrored to `storage.session`, the
+persisted request queue + reconcile, alarms for auto-lock — is exactly the right
+design already. Changes:
+
+1. `background.js:11` — guard the eager load:
+   `if (typeof importScripts === 'function') importScripts(...)`.
+   In Chrome the SW loads its deps as today; in Firefox the manifest `scripts`
+   list (W1) has already loaded them in the same order. No other code motion.
+2. `background.js:1272` — the lazy `importScripts('jsqr.js')` for QR-image paying:
+   same guard. Firefox gets `jsqr.js` from the manifest list (256 KB parsed once
+   per event-page start; acceptable, and only when the background wakes).
+3. `self.SidecarKeystore` etc. — `self` exists on both a worker and a window; no change.
+4. **Lifetime verification (test, not code):** confirm on Firefox that
+   (a) the 0.5-minute queue-keepalive alarm actually fires at 30s or is clamped to
+   60s — either is fine since correctness rests on the queue, but we should know;
+   (b) an in-flight NWC payment over WebSocket completes if the event page is
+   near its idle limit; (c) `about:debugging` → *Terminate background script*
+   mid-queue reproduces the same recover-on-wake behavior we get from Chrome's SW
+   kills.
+
+### W3 — Provider injection: `world: "MAIN"` content script
+
+Today `content.js:10–15` injects `nostr-provider.js` via a `<script src>` tag. On
+Firefox, a strict page CSP **can block that**, silently breaking `window.nostr` on
+exactly the security-conscious sites a signer serves. Firefox 128's `world: "MAIN"`
+injection is explicitly not subject to page CSP — and Chrome has supported the same
+key since 111. So fix it once, for both browsers, at the root:
+
+- Add a second `content_scripts` entry:
+  `{ "matches": ["<all_urls>"], "js": ["nostr-provider.js"], "run_at": "document_start", "world": "MAIN", "all_frames": false }`.
+- Delete the tag-injection block from `content.js` (and the now-unneeded
+  `web_accessible_resources` entry).
+- `nostr-provider.js` already talks to `content.js` over `window.postMessage`-style
+  eventing, which is identical in a MAIN-world script. Verify the
+  document_start ordering guarantee (provider must define `window.nostr` before any
+  page script runs) on both browsers.
+
+This is the one change that also *improves* the Chrome build (guaranteed-synchronous
+injection, no more races on fast-executing pages).
+
+### W4 — Host permissions UX (the real new work)
+
+On Firefox MV3, `host_permissions: ["https://*/*"]` is shown in the install prompt
+(127+) but the user can **uncheck it, or revoke it later** from `about:addons`.
+Without the grant: no content script → no `window.nostr`, no paste guard, no
+Pay-with-Sidecar card; background `fetch`es (link previews, LNURL, profile imports,
+uploads) lose their CORS exemption. Chrome has no equivalent state, so this is the
+one place parity requires *new* surface:
+
+1. **Detection** — on panel init, `browser.permissions.contains({ origins: ['https://*/*'] })`.
+2. **Recovery UI** — if missing, a persistent, non-dismissable banner in the side
+   panel: *"Sidecar can't see websites yet — grant access to sign in on Nostr
+   apps"*, with a button that calls `permissions.request(...)` (valid gesture:
+   button click in an extension page).
+3. **Onboarding** — the welcome/first-run flow checks the grant before declaring
+   setup complete.
+4. **`permissions.onRemoved` listener** — flip the banner back on live if the user
+   revokes mid-session.
+5. Guard all four `chrome.permissions` calls so they're no-ops on Chrome (where
+   `contains` simply always returns true — the code can be unconditional, which
+   keeps one code path).
+
+For development, the manifest flag `"granted_host_permissions": true` auto-grants
+hosts on temporary loads via `about:debugging` (it has no effect on installed
+builds) — worth adding so the dev workflow isn't gated on manual grants, and worth
+a line in the README dev-install section.
+
+### W5 — Sidebar wiring
+
+- `background.js:186–188` — guard: `if (chrome.sidePanel) chrome.sidePanel.setPanelBehavior(...)`.
+- `background.js:194–196` — in the `action.onClicked` listener:
+  `if (chrome.sidePanel) { chrome.sidePanel.open({ tabId }) } else { browser.sidebarAction.toggle() }`.
+  `sidebarAction.toggle()`/`.open()` must be called **synchronously** in the
+  user-input handler — no `await` before it. The current listener is synchronous;
+  keep it that way.
+- Accepted platform variance: Chrome's panel is per-tab-ish, Firefox's sidebar is
+  per-window and persists across tab switches. No code change; the panel already
+  resolves "current tab" via `tabs.query({ active: true })` per operation. The
+  prompt-popup placement logic (`background.js:384+`) is window-based and carries
+  over untouched.
+
+### W6 — Small shims and polish
+
+| Item | Change |
+|---|---|
+| Update check button (`sidepanel.js:6658–6680`) | `if (!chrome.runtime.requestUpdateCheck)` hide the Updates control; AMO auto-updates. About dialog text says "updates via Firefox Add-ons" on Firefox. |
+| `targetUrlPatterns: ['lightning:*']` (`background.js:1295`) | Verify Firefox accepts the non-standard scheme in menu URL patterns; if not, drop `targetUrlPatterns` on Firefox and filter by `info.linkUrl` prefix in the click handler (works everywhere). |
+| Scrollbars (`styles.css`, 4 `::-webkit-scrollbar*` rules) | Add `scrollbar-width: thin; scrollbar-color: <thumb> <track>` on the same containers. |
+| `::-webkit-details-marker` | Add `summary { list-style: none }` / `summary::marker { content: none }`. |
+| Clipboard copies (8 sites in `sidepanel.js`) | All are click-handler-gated, so they should just work; QA each. Add `clipboardWrite` permission **only** if a copy proves flaky — it changes the AMO permission prompt. |
+| Popup window chrome | Firefox `type: 'popup'` windows render slightly different chrome; verify the 400×628-ish prompt isn't clipped, adjust `POPUP_W/H` per-browser if needed. |
+| Private browsing | Firefox disables extensions in PB windows by default; add a help.html note. |
+
+### W7 — Docs & site
+
+- README: Firefox install section (AMO link once live; dev flow =
+  `about:debugging#/runtime/this-firefox` → *Load Temporary Add-on* → pick
+  `manifest.json`), plus the host-permission grant step.
+- `help.html` + `welcome.js` copy: anywhere that says "Chrome" or
+  `chrome://extensions` gets browser-neutral or dual-path wording.
+- PRIVACY.md: storage/permissions story is identical; add one line that Firefox
+  users can revoke site access (and what breaks).
+- sidecar.top: update via the existing `update-sidecar-site` flow once the AMO
+  listing is live (add the AMO badge next to the Chrome Web Store one).
+
+### W8 — AMO submission
+
+- Register `sidecar@sidecar.top`; create the AMO listing (reuse Chrome Web Store
+  copy/screenshots; retake the hero screenshot in Firefox chrome).
+- No build step ⇒ the uploaded zip **is** the source; still pre-write reviewer
+  notes: why `<all_urls>` (NIP-07 signers must be able to provide `window.nostr`
+  on any Nostr client, which can be any domain), why `notifications`/`alarms`/
+  `contextMenus`, and that all crypto is local (link PRIVACY.md).
+- Expect a manual review pass given broad host permissions + key handling; budget
+  calendar time (days-to-weeks), not work time.
+- Versioning: keep versions in lockstep with Chrome from one tag; the single
+  manifest makes this automatic.
+
+## 1:1 parity benchmark
+
+Parity is **measured, not asserted**: every feature below is executed on Chrome
+(stable, as control) and Firefox 128 ESR + current release, same account fixtures,
+same wallet, and must behave identically. The matrix lives as a checklist
+(`docs/parity-firefox.md` or a tracking issue) with per-cell pass/fail + notes.
+
+### Feature matrix (each row = scripted manual test)
+
+| # | Feature | Acceptance check |
+|---|---|---|
+| 1 | First-run: PIN setup, strength meter | identical flow, keystore created |
+| 2 | Generate key + guided profile setup (name/photo/bio, kind 0 publish) | profile visible on relays |
+| 3 | Import nsec/hex with live profile preview; ncryptsec (NIP-49) import/export | preview renders; round-trip decrypts |
+| 4 | Multi-account: add ≥3, drag-reorder, switch active, per-site binding + wrong-account guard, reload offer | binding survives switch; guard fires on multi-login clients |
+| 5 | Lock/auto-lock: timer fires, background restart re-locks/restores per design | kill background mid-session (about:debugging / SW kill) — identical recovery |
+| 6 | NIP-07 surface: `getPublicKey`, `signEvent`, `nip04.*`, `nip44.*`, `getRelays` | script-driven check on a test page, all six methods |
+| 7 | Approval prompt: correct window placement (multi-window!), kind labels, queue counter, clear-backlog | burst 10 requests; none lost across a background kill |
+| 8 | NIP-42 relay auth auto-sign | client stays connected, no prompt |
+| 9 | nsec paste guard | blocked everywhere except import field |
+| 10 | Per-site permissions & Connected Sites (approve, reject, move account, revoke); port-aware `localhost:3000` vs `:5173` | identical persistence |
+| 11 | Profile: edit/publish kind 0, following count, NIP-05 check, lightning-address sync offer | identical |
+| 12 | NIP-65 outbox editor (kind 10002 read/write markers) | publish + re-read |
+| 13 | Backups: NIP-78 encrypted to relays, signed JSON export, vault export/restore **cross-browser** (Chrome vault → Firefox restore and vice versa) | byte-compatible restore |
+| 14 | Follow-list recovery (kind 3 scan/republish) | identical candidate list |
+| 15 | Composer: draft autosave, send countdown/cancel, @-mention pills (follows + global), note/nevent/naddr embeds, link previews, media upload (Blossom + nostr.build fallback), client tag toggle | post from Firefox verifiable in a client |
+| 16 | Notifications page: replies/mentions/reposts/reactions/zaps, mute filtering, open-in-client | identical |
+| 17 | System notification toasts (`notifications.create`) | renders (Firefox styling differs — allowed) |
+| 18 | NWC wallet: connect, balance, send BOLT11 + lightning address (LNURL), receive invoice + QR, paginated history w/ details, connection backup/export | payment succeeds end-to-end |
+| 19 | WebLN provider: approval prompt, per-site daily budget set/edit/revoke | budget enforced across background restarts |
+| 20 | Pay-with-Sidecar card on invoice-showing pages | card appears on signed-in apps only |
+| 21 | Context-menu pays: `lightning:` link, selected BOLT11, QR image | all three decode & prompt |
+| 22 | Auto-approve zaps: under-limit silent, over-limit/daily-cap/non-zap/locked all prompt | identical thresholds |
+| 23 | Help & welcome pages, About dialog | correct browser-specific copy (allowed variance) |
+| 24 | Reset Sidecar (type-to-confirm wipe) | storage fully cleared |
+
+### Firefox-specific adversarial tests
+
+- **Strict-CSP page** — a local test page with `script-src 'self'`: `window.nostr`
+  must exist (this is what W3 buys us).
+- **Host permission revoked** mid-session — banner appears, re-grant restores
+  everything without a browser restart.
+- **Event-page kill** during: queued signing burst, in-flight NWC payment, composer
+  countdown. Queue reconcile must match Chrome behavior.
+- **Client grid** — sign in + sign + zap on: Jumble, Coracle, noStrudel, Primal,
+  YakiHonne, Snort (the README's client families).
+
+### Exit criteria
+
+- 24/24 matrix rows pass on Firefox 128 ESR and current Firefox release.
+- The only permitted deltas are the four **declared platform variances**:
+  (1) sidebar is per-window not per-tab; (2) update-check button hidden (AMO
+  auto-updates); (3) install-time host-permission prompt + recovery banner exists;
+  (4) native toast styling. Anything else failing blocks release.
+- Chrome regression pass on the same build (single manifest = single artifact),
+  since W3 changes injection for Chrome too.
+
+## Sequencing & effort
+
+| Phase | Work | Estimate |
+|---|---|---|
+| 1 | W1 + W2 (manifest, background loading, first boot in Firefox) | 1–2 days |
+| 2 | W3 + W5 (MAIN-world injection, sidebar wiring) — signer usable end-to-end | 1–2 days |
+| 3 | W4 + W6 (permission UX, shims, CSS) | 2–3 days |
+| 4 | Full parity benchmark on both browsers + fixes it shakes out | 3–5 days |
+| 5 | W7 + W8 (docs, site, AMO listing + review) | 1 day work + review wait |
+
+Roughly **8–13 working days** plus AMO review latency. Phases 1–2 produce a
+temporarily-loadable Firefox build worth putting in testers' hands early.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| User declines/revokes host permissions and thinks Sidecar is broken | W4 banner + onboarding gate; help.html section |
+| AMO review friction over `<all_urls>` + key custody | Reviewer notes prepared up front; plain-JS source is fully auditable |
+| Firefox event-page suspension differs subtly from Chrome SW timing | The queue/reconcile design is timing-agnostic; adversarial kill tests in the benchmark |
+| Chrome Web Store objects to Firefox-only manifest keys | Currently warning-only; packaging script fallback ready |
+| `world: "MAIN"` regression on Chrome (injection rewrite) | Benchmark runs the full matrix on Chrome too before release |

--- a/README.md
+++ b/README.md
@@ -104,9 +104,12 @@ current state on Firefox **128 or later**:
 
 Temporary add-ons are removed when Firefox quits — reload after each restart. If
 `window.nostr` doesn't appear on web pages, grant site access under
-`about:addons` → Sidecar → **Permissions** → *Access your data for all websites*.
-Signing on live clients is still being ported, so expect rough edges beyond the
-account flow.
+`about:addons` → Sidecar → **Permissions** → *Access your data for all websites*
+(the panel also shows a one-click **Grant access** banner whenever that permission
+is missing). The full feature set — signing, wallet, pay cards, context-menu pays —
+is wired up for Firefox at parity with the Chrome build; it's "experimental" only
+until the cross-browser test pass in [FIREFOX_PORT.md](FIREFOX_PORT.md) is complete
+and the add-on ships on AMO.
 
 **Updating:** Chrome Web Store installs update automatically — you can trigger a check any time from **Settings → Updates** or the About dialog. For a source build, pull the latest code (`git pull`), then return to the extensions page and click the **reload** (↻) icon on the Sidecar card. Reloading is required after changing `background.js` or any provider script.
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 **A Classy Nostr Signer.**
 
-A NIP-07 Nostr signing extension that lives in your browser's side panel. Sidecar
+A NIP-07 Nostr signing extension that lives in your browser's side panel (or Firefox sidebar). Sidecar
 holds your keys locally — encrypted behind a PIN — and provides `window.nostr` to the
 web apps you use, so you can sign in and sign events across Nostr clients without
 pasting your nsec anywhere. It also has a built-in Lightning wallet (Nostr Wallet
 Connect) and a composer for posting notes directly from the panel.
 
-**[Website](https://sidecar.top)** · **[Chrome Web Store](https://chromewebstore.google.com/detail/sidecar-a-classy-nostr-si/moimlikilhheabdafocpmneehpblhiln)** · **[Privacy Policy](https://sidecar.top/privacy.php)** · **[Changelog](CHANGELOG.md)**
+**[Website](https://sidecar.top)** · **[Chrome Web Store](https://chromewebstore.google.com/detail/sidecar-a-classy-nostr-si/moimlikilhheabdafocpmneehpblhiln)** · **[Firefox Add-ons](https://addons.mozilla.org/firefox/addon/sidecar/)** · **[Privacy Policy](https://sidecar.top/privacy)** · **[Changelog](CHANGELOG.md)**
 
 <img width="3456" height="1944" alt="Sidecar" src="https://i.nostr.build/u9KBCFMuJk23EOrD.jpg" />
 
@@ -97,25 +97,19 @@ Sidecar has **no build step** — it's plain JavaScript loaded directly. To run 
 
 7. **Use it on a Nostr site.** Open any NIP-07 client (e.g. [Jumble](https://jumble.social), [Coracle](https://coracle.social), [noStrudel](https://nostrudel.ninja)) and choose "log in with extension" — Sidecar will prompt you to approve.
 
-#### Firefox (experimental, temporary add-on)
+#### Firefox
 
-The Firefox port is in progress (see [FIREFOX_PORT.md](FIREFOX_PORT.md)). To try the
-current state on Firefox **128 or later**:
+Sidecar runs on Firefox **128 and later** — the same signer, wallet, and approval flow as Chrome, in the sidebar instead of the side panel.
 
-1. Visit `about:debugging#/runtime/this-firefox`.
-2. Click **Load Temporary Add-on…** and select `manifest.json` in the `sidecar` folder.
-3. Click the Sidecar toolbar icon to toggle the sidebar, set a PIN, and add an account.
+1. **Install from [Firefox Add-ons](https://addons.mozilla.org/firefox/addon/sidecar/).**
+2. **Open the sidebar** — View → Sidebar → Sidecar (or click the Sidecar toolbar button). On first run you'll set a PIN, then add an account.
+3. **Use it on a Nostr site** — same as above.
 
-Temporary add-ons are removed when Firefox quits — reload after each restart. If
-`window.nostr` doesn't appear on web pages, grant site access under
-`about:addons` → Sidecar → **Permissions** → *Access your data for all websites*
-(the panel also shows a one-click **Grant access** banner whenever that permission
-is missing). The full feature set — signing, wallet, pay cards, context-menu pays —
-is wired up for Firefox at parity with the Chrome build; it's "experimental" only
-until the cross-browser test pass in [FIREFOX_PORT.md](FIREFOX_PORT.md) is complete
-and the add-on ships on AMO.
+Two Firefox specifics: extensions stay off in private windows unless you allow them (Manage Extensions → Sidecar → Run in Private Windows), and Sidecar needs the site access it asks for at install — if you declined that, the panel shows a one-click **Grant access** banner until it's restored.
 
-**Updating:** Chrome Web Store installs update automatically — you can trigger a check any time from **Settings → Updates** or the About dialog. For a source build, pull the latest code (`git pull`), then return to the extensions page and click the **reload** (↻) icon on the Sidecar card. Reloading is required after changing `background.js` or any provider script.
+> **Developers:** to load Sidecar unpacked on Firefox, visit `about:debugging#/runtime/this-firefox` → **Load Temporary Add-on…** → select `manifest.json`. Temporary add-ons are removed when Firefox quits.
+
+**Updating:** Both the Chrome Web Store and Firefox Add-ons install paths update automatically. On Chrome you can also trigger a check from **Settings → Updates** or the About dialog (Firefox manages updates on its own). For a source build, pull the latest code (`git pull`), then return to the extensions page and click the **reload** (↻) icon on the Sidecar card. Reloading is required after changing `background.js` or any provider script.
 
 ### Build version stamp (optional)
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,21 @@ Sidecar has **no build step** — it's plain JavaScript loaded directly. To run 
 
 7. **Use it on a Nostr site.** Open any NIP-07 client (e.g. [Jumble](https://jumble.social), [Coracle](https://coracle.social), [noStrudel](https://nostrudel.ninja)) and choose "log in with extension" — Sidecar will prompt you to approve.
 
+#### Firefox (experimental, temporary add-on)
+
+The Firefox port is in progress (see [FIREFOX_PORT.md](FIREFOX_PORT.md)). To try the
+current state on Firefox **128 or later**:
+
+1. Visit `about:debugging#/runtime/this-firefox`.
+2. Click **Load Temporary Add-on…** and select `manifest.json` in the `sidecar` folder.
+3. Click the Sidecar toolbar icon to toggle the sidebar, set a PIN, and add an account.
+
+Temporary add-ons are removed when Firefox quits — reload after each restart. If
+`window.nostr` doesn't appear on web pages, grant site access under
+`about:addons` → Sidecar → **Permissions** → *Access your data for all websites*.
+Signing on live clients is still being ported, so expect rough edges beyond the
+account flow.
+
 **Updating:** Chrome Web Store installs update automatically — you can trigger a check any time from **Settings → Updates** or the About dialog. For a source build, pull the latest code (`git pull`), then return to the extensions page and click the **reload** (↻) icon on the Sidecar card. Reloading is required after changing `background.js` or any provider script.
 
 ### Build version stamp (optional)

--- a/background.js
+++ b/background.js
@@ -205,7 +205,13 @@ async function logActivity(entry) {
 // payments per account). This is internal diagnostics: message dispatch,
 // timings, and uncaught errors. In-memory only, so it resets on a service
 // worker restart (~30s idle) — same tradeoff as the keystore re-locking.
-const IS_DEV_BUILD = (() => {
+// Chrome: the Web Store injects `update_url` when it packages a release, so its
+// absence reliably means an unpacked dev load. Firefox/AMO never injects one, so
+// that heuristic would flag every production install as dev — there, start closed
+// and let management.getSelf() (async; getSelf is exempt from the "management"
+// permission) flip it on for temporary about:debugging loads only.
+let IS_DEV_BUILD = (() => {
+  if (typeof browser !== 'undefined') return false; // Firefox: resolved async below
   try { return !chrome.runtime.getManifest().update_url; } catch (_) { return false; }
 })();
 const DEBUG_LOG_MAX = 300;
@@ -262,15 +268,28 @@ const QUEUE_SESSION_KEY = 'sidecar_prompt_queue';
 const QUEUE_KEEPALIVE_ALARM = 'sidecar-queue-keepalive';
 
 // dlog() reads panelPort (declared above) to ping the panel on a new entry, so
-// this must run after that declaration — the log call below is synchronous.
-if (IS_DEV_BUILD) {
-  dlog('info', 'sw', 'Service worker started', { version: chrome.runtime.getManifest().version });
+// this must run after that declaration — the Chrome-path log call is synchronous.
+function startDebugLog() {
+  dlog('info', 'bg', 'Background started', { version: chrome.runtime.getManifest().version });
   self.addEventListener('error', (e) => {
-    dlog('error', 'sw', 'Uncaught error', { message: e.message, filename: e.filename, lineno: e.lineno });
+    dlog('error', 'bg', 'Uncaught error', { message: e.message, filename: e.filename, lineno: e.lineno });
   });
   self.addEventListener('unhandledrejection', (e) => {
-    dlog('error', 'sw', 'Unhandled rejection', { reason: String((e.reason && e.reason.message) || e.reason) });
+    dlog('error', 'bg', 'Unhandled rejection', { reason: String((e.reason && e.reason.message) || e.reason) });
   });
+}
+if (IS_DEV_BUILD) {
+  startDebugLog();
+} else if (typeof browser !== 'undefined') {
+  // Firefox: the answer arrives async, so the first moments of logs are dropped —
+  // failing closed beats showing dev UI to every AMO install.
+  try {
+    browser.management.getSelf().then((info) => {
+      if (info.installType !== 'development') return;
+      IS_DEV_BUILD = true;
+      startDebugLog();
+    }).catch(() => {});
+  } catch (_) {}
 }
 
 // ---- session mirror (metadata only — no callbacks, no signable material) ----
@@ -1354,12 +1373,28 @@ async function invoiceFromQrImage(srcUrl) {
 
 function createPayMenu() {
   if (!chrome.contextMenus) return;
+  // Failures surface synchronously (throw, Firefox) or via lastError in the
+  // callback (Chrome) — cover both so one bad item can't take out the menu.
+  const create = (props, onFail) => {
+    try {
+      chrome.contextMenus.create(props, () => {
+        if (chrome.runtime.lastError && onFail) onFail();
+      });
+    } catch (_) { if (onFail) onFail(); }
+  };
   chrome.contextMenus.removeAll(() => {
     // Only on lightning: links (not every link), on any text selection, and on
     // QR images. (Canvas/SVG QRs have no image context — a later pass.)
-    chrome.contextMenus.create({ id: 'sidecar-pay-link', title: 'Pay this invoice with Sidecar', contexts: ['link'], targetUrlPatterns: ['lightning:*'] });
-    chrome.contextMenus.create({ id: 'sidecar-pay-selection', title: 'Pay Lightning invoice with Sidecar', contexts: ['selection'] });
-    chrome.contextMenus.create({ id: 'sidecar-pay-qr', title: 'Pay QR code with Sidecar', contexts: ['image'] });
+    // Both browsers document targetUrlPatterns as accepting any URL scheme, but
+    // if a build ever rejects the lightning: pattern, fall back to a pattern-less
+    // link item — the click handler's extractInvoice already fails safe on
+    // non-lightning links with a "no invoice found" notice.
+    create(
+      { id: 'sidecar-pay-link', title: 'Pay this invoice with Sidecar', contexts: ['link'], targetUrlPatterns: ['lightning:*'] },
+      () => create({ id: 'sidecar-pay-link', title: 'Pay this invoice with Sidecar', contexts: ['link'] })
+    );
+    create({ id: 'sidecar-pay-selection', title: 'Pay Lightning invoice with Sidecar', contexts: ['selection'] });
+    create({ id: 'sidecar-pay-qr', title: 'Pay QR code with Sidecar', contexts: ['image'] });
   });
 }
 chrome.runtime.onStartup && chrome.runtime.onStartup.addListener(createPayMenu);

--- a/background.js
+++ b/background.js
@@ -1808,15 +1808,16 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   // in CONTENT_OK. But the keystore/wallet/owner-crypto/prompt handlers below are
   // the crown jewels, so we ALSO hard-require an extension-page origin for
   // everything a content script doesn't legitimately need — the identity check is
-  // the sender's ORIGIN (our pages are chrome-extension://<id>/…; a content
-  // script carries the web page's origin), NOT sender.tab (prompt.html and
-  // welcome.html are extension pages that DO have a tab). This way no future
-  // content-script bug can pivot a hostile page into signing, key reveal,
-  // decryption, unlock, or settling an approval.
-  const EXT_ORIGIN = 'chrome-extension://' + chrome.runtime.id;
+  // whether the sender's URL is under OUR extension origin, taken from
+  // runtime.getURL (chrome-extension://<id>/ on Chrome, moz-extension://<uuid>/ on
+  // Firefox — so this is correct on both). A content script carries the web page's
+  // URL instead. NOT sender.tab (prompt.html and welcome.html are extension pages
+  // that DO have a tab). This way no future content-script bug can pivot a hostile
+  // page into signing, key reveal, decryption, unlock, or settling an approval.
+  const EXT_URL_PREFIX = chrome.runtime.getURL('/');
   const fromExtPage = !!sender && (
-    sender.origin === EXT_ORIGIN ||
-    (typeof sender.url === 'string' && sender.url.startsWith(EXT_ORIGIN + '/'))
+    (typeof sender.url === 'string' && sender.url.startsWith(EXT_URL_PREFIX)) ||
+    (typeof sender.origin === 'string' && sender.origin + '/' === EXT_URL_PREFIX)
   );
   const CONTENT_OK = new Set([
     'SIDECAR_NOSTR_RPC', 'SIDECAR_WEBLN_RPC', 'SIDECAR_PAY_PAGE_INVOICE',

--- a/background.js
+++ b/background.js
@@ -7,8 +7,16 @@
 //
 // Decrypted private keys live only in the keystore's in-memory map here. If this worker
 // is killed (MV3 ~30s idle), that map is gone and the keystore re-locks — a feature.
+//
+// Chrome runs this file as a service worker and pulls its deps in via importScripts;
+// Firefox has no MV3 service workers and runs it as an event page (a window, where
+// importScripts doesn't exist) with the same files already loaded, in the same order,
+// via manifest background.scripts. Both suspend after ~30s idle, so the
+// survive-restart machinery below applies equally to both.
 
-importScripts('nostr-tools.js', 'crypto.js', 'keystore.js', 'permissions.js', 'signer.js', 'wallet-budgets.js', 'nwc-client.js');
+if (typeof importScripts === 'function') {
+  importScripts('nostr-tools.js', 'crypto.js', 'keystore.js', 'permissions.js', 'signer.js', 'wallet-budgets.js', 'nwc-client.js');
+}
 
 const KS = self.SidecarKeystore;
 const PERMS = self.SidecarPermissions;
@@ -210,7 +218,7 @@ function dlog(level, tag, msg, data) {
 }
 // ---- side panel open on toolbar click ----
 chrome.runtime.onInstalled.addListener((details) => {
-  chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true }).catch(() => {});
+  if (chrome.sidePanel) chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true }).catch(() => {});
   createPayMenu();
   if (details.reason === 'install') {
     chrome.storage.local.remove('firstPostTipDismissed');
@@ -218,7 +226,13 @@ chrome.runtime.onInstalled.addListener((details) => {
   }
 });
 chrome.action.onClicked.addListener((tab) => {
-  chrome.sidePanel.open({ tabId: tab.id }).catch(() => {});
+  if (chrome.sidePanel) {
+    chrome.sidePanel.open({ tabId: tab.id }).catch(() => {});
+  } else if (typeof browser !== 'undefined' && browser.sidebarAction) {
+    // Firefox sidebar. toggle() only works when called synchronously from the
+    // user-input handler — no awaits before this line.
+    browser.sidebarAction.toggle();
+  }
 });
 
 // ============================================================================
@@ -1315,7 +1329,12 @@ function extractInvoice(text) {
 // run jsQR. jsQR is heavy (~250KB) so it's imported lazily, only on first QR pay.
 let jsqrReady = false;
 function ensureJsQR() {
-  if (!jsqrReady) { importScripts('jsqr.js'); jsqrReady = true; }
+  // Firefox (event page) has no importScripts — jsqr.js is loaded up front via
+  // manifest background.scripts there, so it's already on self.
+  if (!jsqrReady) {
+    if (typeof importScripts === 'function') importScripts('jsqr.js');
+    jsqrReady = true;
+  }
   return self.jsQR;
 }
 async function invoiceFromQrImage(srcUrl) {

--- a/content.js
+++ b/content.js
@@ -1,18 +1,13 @@
 // Sidecar content script — bridges the page's window.nostr (nostr-provider.js) to the
-// extension service worker. Injects the provider at document_start, then relays each
-// request to the background, attaching the TRUSTED host (taken from location here, never
-// from the page), and posts the response back to the page.
+// extension service worker. The provider itself is injected by the browser as a
+// MAIN-world content script (see manifest.json) — guaranteed to run before any page
+// script, and immune to page CSP, which could block the old <script src> injection
+// on strict sites. This file relays each request to the background, attaching the
+// TRUSTED host (taken from location here, never from the page), and posts the
+// response back to the page.
 
 (function () {
   'use strict';
-
-  // Inject the page-context provider as early as possible.
-  const script = document.createElement('script');
-  script.src = chrome.runtime.getURL('nostr-provider.js');
-  script.onload = function () {
-    this.remove();
-  };
-  (document.head || document.documentElement).appendChild(script);
 
   const host = location.host; // trusted origin identity (includes port, e.g. localhost:3000)
 

--- a/help.html
+++ b/help.html
@@ -53,6 +53,12 @@
       extension.</p>
       <p>Everything is protected by the PIN you chose when you set up Sidecar, and the
       panel locks itself after a period of inactivity you can adjust in Settings.</p>
+      <p>On Firefox, Sidecar lives in the sidebar rather than the side panel — same
+      signer, same features, and updates install automatically through the browser.
+      Two Firefox specifics: extensions stay off in private windows unless you allow
+      them (Manage Extensions → Sidecar → Run in Private Windows), and Sidecar needs
+      the site access it asks for at install — if you declined that, the panel shows
+      a one-click <em>Grant access</em> banner until it's restored.</p>
 
       <!-- screenshot: the approval prompt, a site asking to sign an event -->
       <figure class="shot">

--- a/help.html
+++ b/help.html
@@ -236,21 +236,18 @@
          linked below. -->
     <section class="guide-section" id="whats-new">
       <h2>What's new</h2>
+      <p class="whatsnew-version">Version 1.5.0</p>
+      <ul class="whatsnew-list">
+        <li><strong>Sidecar is now on Firefox.</strong> The full signer — multi-account, NIP-07, the Lightning wallet, and the approval flow — runs on Firefox 128 and later, at parity with Chrome. On Firefox it lives in the sidebar; install it from Firefox Add-ons.</li>
+        <li><strong>Three themes to choose from.</strong> A new picker in Settings offers Speakeasy (the original velvet), Film Noir (matte black with silver accents), and Art Deco (a daylight eggshell-and-bronze look). Your pick sticks, and the on-page "Pay with Sidecar" card follows it too.</li>
+        <li><strong>Toasts moved to the bottom</strong> of the panel, so a confirmation no longer sits over the account switcher and toolbar.</li>
+      </ul>
       <p class="whatsnew-version">Version 1.4.1</p>
       <ul class="whatsnew-list">
         <li><strong>Auto-lock, smoothed out.</strong> When the idle timer fires, the panel drops straight to the unlock screen with a "Locked due to inactivity" notice, instead of only surfacing the lock on your next action. Composing counts as activity so it won't lock mid-draft — and unlocking straight from a key reveal or export now flows through in one step.</li>
         <li><strong>Stronger PIN protection.</strong> The unlock screen's brute-force guard — escalating delays between wrong tries and the final-strike wipe — now covers every PIN prompt, including key reveals and exports.</li>
         <li><strong>More apps to explore.</strong> Eight new apps in the directory — Flotilla, Tunestr, Wavlake, WaveFunc Radio, Boost Me Bitch, Cordn, Imwald, and ContextVM — now also browsable on the web at sidecar.top/apps.</li>
         <li><strong>A lighter quoted-note icon</strong> in notifications, easier to see on the dark panel.</li>
-      </ul>
-      <p class="whatsnew-version">Version 1.4.0</p>
-      <ul class="whatsnew-list">
-        <li><strong>A clearer signing prompt.</strong> Event content shows in a compact, expandable preview with Formatted, Raw, and JSON views, and roughly 40 more event kinds are recognized by name — so routine actions no longer show the "unrecognized kind" caution.</li>
-        <li><strong>Readable identities.</strong> Encrypt and decrypt prompts show the other party by name, with their npub kept beneath it as a verifiable key — click the npub to reveal the full key.</li>
-        <li><strong>Auto-lock is on by default.</strong> Sidecar now locks after 15 minutes of inactivity — adjustable in Settings, including back to Never, and changes apply immediately.</li>
-        <li><strong>Save-your-PIN reminder.</strong> Right after you create a PIN, a one-time reminder prompts you to write it down or store it in a password manager — there's no recovery if it's forgotten.</li>
-        <li><strong>Tighter settings privacy.</strong> Websites can no longer read Sidecar's settings; pages see only the on-page pay-card toggle.</li>
-        <li><strong>Security audit addressed.</strong> Refreshed core libraries, tamper-detection for every bundled file, and a licensing fix so the whole project stays cleanly open source.</li>
       </ul>
       <p>The full history, including earlier releases, is in the
       <a href="https://github.com/dmnyc/sidecar/blob/main/CHANGELOG.md" target="_blank" rel="noreferrer noopener" id="changelog-link">changelog on GitHub</a>.</p>

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Sidecar | A Classy Nostr Signer",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "minimum_chrome_version": "114",
   "description": "A multi-account NIP-07 Nostr signer with a built-in Lightning wallet, in your browser sidebar.",
   "permissions": [

--- a/manifest.json
+++ b/manifest.json
@@ -15,10 +15,30 @@
     "https://*/*"
   ],
   "background": {
-    "service_worker": "background.js"
+    "service_worker": "background.js",
+    "scripts": [
+      "nostr-tools.js",
+      "crypto.js",
+      "keystore.js",
+      "permissions.js",
+      "signer.js",
+      "wallet-budgets.js",
+      "nwc-client.js",
+      "jsqr.js",
+      "background.js"
+    ]
   },
   "side_panel": {
     "default_path": "sidepanel.html"
+  },
+  "sidebar_action": {
+    "default_panel": "sidepanel.html",
+    "default_title": "Sidecar",
+    "default_icon": {
+      "16": "icons/icon16.png",
+      "32": "icons/icon32.png"
+    },
+    "open_at_install": false
   },
   "action": {
     "default_title": "Open Sidecar"
@@ -37,6 +57,15 @@
       "matches": ["<all_urls>"]
     }
   ],
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "sidecar@sidecar.top",
+      "strict_min_version": "128.0",
+      "data_collection_permissions": {
+        "required": ["none"]
+      }
+    }
+  },
   "icons": {
     "16": "icons/icon16.png",
     "32": "icons/icon32.png",

--- a/manifest.json
+++ b/manifest.json
@@ -46,15 +46,16 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
+      "js": ["nostr-provider.js"],
+      "run_at": "document_start",
+      "world": "MAIN",
+      "all_frames": false
+    },
+    {
+      "matches": ["<all_urls>"],
       "js": ["content.js"],
       "run_at": "document_start",
       "all_frames": false
-    }
-  ],
-  "web_accessible_resources": [
-    {
-      "resources": ["nostr-provider.js"],
-      "matches": ["<all_urls>"]
     }
   ],
   "browser_specific_settings": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sidecar-nostr-signer",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "A multi-account NIP-07 nostr signer with a built-in Lightning wallet, in your browser sidebar",
   "scripts": {
     "dev": "echo 'Load this folder as an unpacked extension at chrome://extensions'",

--- a/prompt.js
+++ b/prompt.js
@@ -286,7 +286,15 @@
       els.ask.textContent = 'This request has expired.';
       els.allow.classList.add('hidden');
       els.trust.classList.add('hidden');
-      els.reject.textContent = 'Close';
+      // The request is already purged from the background queue, so routing Close
+      // through decide('reject') — the reject button's normal binding — is a no-op:
+      // the background has nothing to settle for this id and never closes the window.
+      // Swap in a fresh node (cloneNode drops the old listener) and close directly.
+      const close = els.reject.cloneNode(true);
+      close.textContent = 'Close';
+      els.reject.replaceWith(close);
+      els.reject = close;
+      els.reject.addEventListener('click', () => window.close());
       return;
     }
     data = resp.data;

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -1,18 +1,26 @@
 #!/usr/bin/env bash
-# Packages a Sidecar release zip from a git tag into dist/.
+# Packages Sidecar release zips (Chrome + Firefox) from a git tag into dist/.
 #
 # The GitHub Release is the canonical home for release zips; this script just
-# builds the local artifact to upload. dist/ is gitignored — nothing here is
-# committed. The output is a flat-root zip (manifest.json at the top, no wrapper
-# folder) ready for the Chrome Web Store and a GitHub Release asset.
+# builds the local artifacts to upload. dist/ is gitignored — nothing here is
+# committed. Each output is a flat-root zip (manifest.json at the top, no wrapper
+# folder): sidecar-X.Y.Z.zip for the Chrome Web Store, sidecar-X.Y.Z-firefox.zip
+# for AMO.
+#
+# Sidecar ships ONE unified codebase; the only per-store difference is the
+# manifest. The repo keeps the union of both browsers' keys (so dev-loading
+# unpacked works in either browser with no build step); at package time this
+# strips each store's zip down to the keys that store actually uses:
+#   Chrome  — drops sidebar_action, browser_specific_settings, background.scripts
+#   Firefox — drops side_panel, minimum_chrome_version, background.service_worker
+# so neither store's validator sees the other's keys (avoids a Chrome Web Store
+# rejection on the Firefox-only keys, and console warnings on both sides).
+# Requires node (dev-time only; not shipped) for the manifest edit.
 #
 # Usage: scripts/package.sh [vX.Y.Z]   (default: the manifest's current version)
-#
-# What it does: git archive the tag → strip docs/dev/tooling (README, CHANGELOG,
-# PRIVACY.md, scripts/, assets/, .github/, …) → regenerate version.js (gitignored,
-# stamped to the tag's short commit, clean) → zip → print sha256 + file count.
 set -euo pipefail
 cd "$(dirname "$0")/.."
+ROOT="$PWD"
 
 MANIFEST_VERSION=$(grep -m1 '"version"' manifest.json | sed -E 's/.*"version"[^"]*"([^"]+)".*/\1/')
 TAG="${1:-v${MANIFEST_VERSION}}"
@@ -28,7 +36,6 @@ fi
 
 SHORT=$(git rev-parse --short "${TAG}^{commit}")
 VERSION_NO_V="${TAG#v}"
-OUT="dist/sidecar-${VERSION_NO_V}.zip"
 
 STAGE="$(mktemp -d)/sidecar"
 mkdir -p "${STAGE}"
@@ -38,7 +45,7 @@ git archive "${TAG}" | tar -x -C "${STAGE}"
 rm -rf "${STAGE}/.claude" "${STAGE}/.github" "${STAGE}/scripts" "${STAGE}/assets"
 rm -f "${STAGE}/.gitignore" "${STAGE}/README.md" "${STAGE}/CHANGELOG.md" \
       "${STAGE}/FEATURES.md" "${STAGE}/PRIVACY.md" "${STAGE}/BROWSER_PARITY.md" \
-      "${STAGE}/VENDOR.md" "${STAGE}/package.json"
+      "${STAGE}/FIREFOX_PORT.md" "${STAGE}/VENDOR.md" "${STAGE}/package.json"
 
 # version.js is gitignored and not in the archive — regenerate it, stamped to the tag.
 cat > "${STAGE}/version.js" <<EOF
@@ -46,13 +53,39 @@ cat > "${STAGE}/version.js" <<EOF
 window.SIDECAR_BUILD = { version: '${VERSION_NO_V}', commit: '${SHORT}' };
 EOF
 
-mkdir -p dist
-rm -f "${OUT}"
-( cd "${STAGE}" && zip -rqX "${OLDPWD}/${OUT}" . -x ".*" )
+# The archived manifest carries both browsers' keys; each zip gets only its own.
+PRISTINE_MANIFEST="$(mktemp)"
+cp "${STAGE}/manifest.json" "${PRISTINE_MANIFEST}"
 
-FILES=$(unzip -Z1 "${OUT}" | grep -vc '/$')
-SHA=$(shasum -a 256 "${OUT}" | awk '{print $1}')
-echo "Built ${OUT}"
-echo "  tag:      ${TAG} (${SHORT})"
-echo "  files:    ${FILES}"
-echo "  sha256:   ${SHA}"
+build_zip() {
+  local target="$1" out="$2"
+  cp "${PRISTINE_MANIFEST}" "${STAGE}/manifest.json"
+  node -e '
+    const fs = require("fs");
+    const file = process.argv[1], target = process.argv[2];
+    const m = JSON.parse(fs.readFileSync(file, "utf8"));
+    if (target === "chrome") {
+      delete m.sidebar_action;
+      delete m.browser_specific_settings;
+      if (m.background) delete m.background.scripts;
+    } else {
+      delete m.side_panel;
+      delete m.minimum_chrome_version;
+      if (m.background) delete m.background.service_worker;
+    }
+    fs.writeFileSync(file, JSON.stringify(m, null, 2) + "\n");
+  ' "${STAGE}/manifest.json" "${target}"
+  rm -f "${ROOT}/${out}"
+  ( cd "${STAGE}" && zip -rqX "${ROOT}/${out}" . -x ".*" )
+  local files sha
+  files=$(unzip -Z1 "${ROOT}/${out}" | grep -vc '/$')
+  sha=$(shasum -a 256 "${ROOT}/${out}" | awk '{print $1}')
+  echo "Built ${out}  [${target}]"
+  echo "  files:   ${files}"
+  echo "  sha256:  ${sha}"
+}
+
+mkdir -p dist
+echo "Packaging ${TAG} (${SHORT})"
+build_zip chrome  "dist/sidecar-${VERSION_NO_V}.zip"
+build_zip firefox "dist/sidecar-${VERSION_NO_V}-firefox.zip"

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -71,6 +71,11 @@ build_zip() {
     } else {
       delete m.side_panel;
       delete m.minimum_chrome_version;
+      // sidePanel is a Chrome-only permission; drop it so AMO's validator
+      // doesn't flag an unrecognized permission in the Firefox zip.
+      if (Array.isArray(m.permissions)) {
+        m.permissions = m.permissions.filter((p) => p !== "sidePanel");
+      }
       if (m.background) delete m.background.service_worker;
     }
     fs.writeFileSync(file, JSON.stringify(m, null, 2) + "\n");

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -76,6 +76,13 @@
     </nav>
 
 
+    <!-- Firefox lets the user decline/revoke site access (host permissions); without
+         it there is no window.nostr anywhere and the signer looks dead. Chrome grants
+         at install, so this only shows there if the user restricted site access. -->
+    <div id="host-perm-banner" class="host-perm-banner hidden">
+      <div class="host-perm-msg"><strong>Sidecar can't see websites yet.</strong> Grant site access so Nostr apps can use your signer.</div>
+      <button id="host-perm-grant-btn" class="host-perm-grant-btn">Grant access</button>
+    </div>
     <div id="post-banner" class="post-banner hidden"></div>
     <!-- Offer to reload the open Nostr site so an account switch takes effect there. -->
     <div id="reload-banner" class="reload-banner hidden"></div>

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -72,9 +72,24 @@
   // from the Web Store (or with a configured update URL) — never for an unpacked
   // load. That makes it a reliable, permission-free way to tell a local dev build
   // apart from the shipped one, so dev-only UI never leaks into production.
-  function isDevBuild() {
+  // Firefox/AMO never injects update_url, so there the same absence proves
+  // nothing — ask management.getSelf() (async; getSelf is exempt from the
+  // "management" permission) and fail closed until it answers: only a temporary
+  // about:debugging load counts as dev. initDevBadge awaits devBuildReady so the
+  // one-shot panel-boot render can't race the answer.
+  let devBuild = (() => {
+    if (typeof browser !== 'undefined') return false; // Firefox: resolved async below
     try { return !chrome.runtime.getManifest().update_url; } catch (_) { return false; }
-  }
+  })();
+  const devBuildReady = (() => {
+    if (typeof browser === 'undefined') return Promise.resolve();
+    try {
+      return browser.management.getSelf()
+        .then((info) => { devBuild = info.installType === 'development'; })
+        .catch(() => {});
+    } catch (_) { return Promise.resolve(); }
+  })();
+  function isDevBuild() { return devBuild; }
 
   // Filled lightning bolt (from wordswithzaps' bolt-yellow.svg). Inherits color
   // via currentColor; sized inline with text by the .bolt-ico class.
@@ -7836,6 +7851,7 @@
   // clean screenshots. Never appears on the Chrome Web Store build, regardless of
   // a stored setting.
   async function initDevBadge() {
+    await devBuildReady; // Firefox: don't decide before management.getSelf answers
     if (!isDevBuild()) return;
     show($('dev-settings-section'));
     const settings = await call({ type: 'SIDECAR_GET_SETTINGS' });
@@ -7945,8 +7961,40 @@
   $('dev-badge').addEventListener('click', openDebugPanel);
   $('dev-badge').appendChild(icon('bug'));
 
+  // ---- host (site) permission guard ----
+  // Firefox MV3 shows https://*/* as a checkbox in the install prompt and lets
+  // the user revoke it later from about:addons. Without the grant there is no
+  // content script — no window.nostr, no paste guard, no pay card — and
+  // background fetches lose their CORS exemption, so the signer just looks dead.
+  // Detect it, explain it, and offer the one-click re-grant. Chrome grants
+  // host_permissions at install, so contains() is normally true there and the
+  // banner never renders (unless the user manually restricted site access — in
+  // which case this same recovery path is exactly what they need).
+  const HOST_ORIGINS = { origins: ['https://*/*'] };
+  // browser.* is promise-based on Firefox; chrome.* is promise-capable on Chrome MV3.
+  const PERMS_API = (typeof browser !== 'undefined' && browser.permissions) ? browser.permissions : chrome.permissions;
+  async function syncHostPermBanner() {
+    let granted = true;
+    try { granted = await PERMS_API.contains(HOST_ORIGINS); } catch (_) {}
+    $('host-perm-banner').classList.toggle('hidden', granted);
+  }
+  function initHostPermGuard() {
+    if (!PERMS_API || !PERMS_API.contains) return; // fail open: banner stays hidden
+    $('host-perm-grant-btn').addEventListener('click', () => {
+      // request() must run inside the click gesture — no awaits before it.
+      PERMS_API.request(HOST_ORIGINS).then(syncHostPermBanner).catch(() => {});
+    });
+    // Flip live if the user grants/revokes from about:addons mid-session.
+    try {
+      if (PERMS_API.onAdded) PERMS_API.onAdded.addListener(syncHostPermBanner);
+      if (PERMS_API.onRemoved) PERMS_API.onRemoved.addListener(syncHostPermBanner);
+    } catch (_) {}
+    syncHostPermBanner();
+  }
+
   // ---- boot ----
   document.addEventListener('DOMContentLoaded', refresh);
   if (document.readyState !== 'loading') refresh();
   initDevBadge();
+  initHostPermGuard();
 })();

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -6935,6 +6935,8 @@
       const zap = h('button', { className: 'about-link about-link-btn' }, [document.createTextNode('Donate '), boltIcon()]);
       zap.addEventListener('click', () => { closeModal(); creatorZapModal(); });
 
+      // Firefox has no requestUpdateCheck — the browser updates add-ons itself.
+      const canCheckUpdates = typeof chrome.runtime.requestUpdateCheck === 'function';
       const updateBtn = h('button', { className: 'about-update-btn', textContent: 'Check for updates' });
       const updateStatus = h('p', { className: 'hint about-update-status' });
       updateBtn.addEventListener('click', () => checkForUpdates(updateBtn, updateStatus));
@@ -6946,8 +6948,8 @@
           h('p', { className: 'about-description', textContent: 'A classy multi-account Nostr signer with a built-in Lightning wallet. Your keys stay encrypted on this device.' }),
           h('div', { className: 'about-creator' }, [document.createTextNode('Created by '), creator]),
           ver ? h('div', { className: 'about-version', textContent: verText }) : document.createTextNode(''),
-          updateBtn,
-          updateStatus,
+          canCheckUpdates ? updateBtn : document.createTextNode(''),
+          canCheckUpdates ? updateStatus : document.createTextNode(''),
           h('div', { className: 'about-links' }, [website, repo, support, privacy, zap]),
         ])
       );
@@ -7100,9 +7102,15 @@
     renderSettings();
   });
 
-  $('check-update-btn').addEventListener('click', () => {
-    checkForUpdates($('check-update-btn'), $('check-update-status'));
-  });
+  if (typeof chrome.runtime.requestUpdateCheck === 'function') {
+    $('check-update-btn').addEventListener('click', () => {
+      checkForUpdates($('check-update-btn'), $('check-update-status'));
+    });
+  } else {
+    // Firefox has no on-demand update check — the browser updates add-ons itself.
+    $('check-update-btn').hidden = true;
+    $('check-update-status').textContent = 'Updates install automatically through your browser.';
+  }
 
   $('export-vault-btn').addEventListener('click', () => exportVaultModal());
   $('import-vault-btn').addEventListener('click', () => $('import-vault-file').click());

--- a/styles.css
+++ b/styles.css
@@ -1498,6 +1498,25 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
 }
 .interrupted-dismiss:hover { color: var(--text); text-decoration: underline; }
 
+/* Host-permission recovery banner (Firefox can decline/revoke site access —
+   without it there's no window.nostr, no paste guard, no pay card). */
+.host-perm-banner {
+  display: flex; align-items: center; gap: 10px;
+  margin: 10px 16px 0; padding: 10px 12px; border-radius: 10px;
+  background: rgba(240, 86, 107, 0.12); border: 1px solid rgba(240, 86, 107, 0.35);
+}
+.host-perm-msg { font-size: 12.5px; line-height: 1.4; color: var(--text-2); }
+.host-perm-msg strong { color: var(--text); }
+.host-perm-grant-btn {
+  flex-shrink: 0; margin-left: auto; cursor: pointer; white-space: nowrap;
+  padding: 6px 12px; border-radius: 8px; border: none;
+  background: linear-gradient(180deg, #e2b968, var(--gold) 60%, #b7863a);
+  color: #1c1206; font-weight: 600; font-size: 12.5px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.3);
+  transition: filter 0.15s;
+}
+.host-perm-grant-btn:hover { filter: brightness(1.06); }
+
 /* "N more waiting" backlog strip + Reject all, inside the approval card. */
 .approval-backlog {
   display: flex; align-items: center; gap: 10px;
@@ -1654,6 +1673,13 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
 ::-webkit-scrollbar-track { background: transparent; }
 ::-webkit-scrollbar-thumb { background: linear-gradient(180deg, #3a2470, #251147); border-radius: 8px; border: 2px solid transparent; background-clip: padding-box; }
 ::-webkit-scrollbar-thumb:hover { background: #4a2f8a; background-clip: padding-box; }
+/* Firefox has no ::-webkit-scrollbar — the standard properties are its whole
+   scrollbar API (flat thumb color instead of the gradient; same intent). Scoped
+   to Firefox because Chrome 121+ also honors scrollbar-color and would then
+   IGNORE the ::-webkit-* styling above. */
+@supports (-moz-appearance: none) {
+  * { scrollbar-width: thin; scrollbar-color: #2f1b5c transparent; }
+}
 
 /* ===== inline signing approval ===== */
 /* Top-aligned + scrollable so a long event preview never pushes the buttons

--- a/welcome.css
+++ b/welcome.css
@@ -475,3 +475,22 @@ body {
   .helpnav-pages a,
   .helpnav-guide { padding: 11px 12px; font-size: 15px; border-radius: 10px; }
 }
+
+/* Host-permission gate — Firefox users can decline site access in the install
+   prompt; without it no app below can see the signer. Hidden whenever granted
+   (always, on Chrome). Toggled from welcome.js via the [hidden] attribute. */
+.perm-gate {
+  display: flex; align-items: center; gap: 14px; flex-wrap: wrap;
+  margin: 0 0 28px; padding: 14px 16px; border-radius: 12px;
+  background: rgba(240, 86, 107, 0.10); border: 1px solid rgba(240, 86, 107, 0.35);
+}
+.perm-gate[hidden] { display: none; }
+.perm-gate p { margin: 0; flex: 1 1 260px; color: var(--text-2); font-size: 14px; line-height: 1.5; }
+.perm-gate strong { color: var(--text); }
+.perm-grant-btn {
+  cursor: pointer; white-space: nowrap; border: none; border-radius: 10px;
+  padding: 10px 18px; font-weight: 600; font-size: 14px; color: #1c1206;
+  background: linear-gradient(180deg, #e2b968, var(--gold) 60%, #b7863a);
+  transition: filter 0.15s;
+}
+.perm-grant-btn:hover { filter: brightness(1.06); }

--- a/welcome.html
+++ b/welcome.html
@@ -27,6 +27,13 @@
 
   <div class="page">
 
+    <!-- Firefox can decline site access in the install prompt — without it none of
+         these apps can see the signer. Chrome grants at install; never shows there. -->
+    <div id="perm-gate" class="perm-gate" hidden>
+      <p><strong>One more step:</strong> Sidecar needs permission to work on websites — without it, these apps can't see your signer.</p>
+      <button id="perm-grant-btn" class="perm-grant-btn">Grant site access</button>
+    </div>
+
     <header class="header">
       <h1>Your Nostr signer is ready.</h1>
       <p>Sign in to any of these apps — no password, just your key. Click the Sidecar icon in your toolbar whenever a site asks.</p>

--- a/welcome.js
+++ b/welcome.js
@@ -436,3 +436,31 @@ document.getElementById('filters').addEventListener('click', e => {
     document.addEventListener('visibilitychange', () => { if (!document.hidden) check(); });
   });
 })();
+
+// ---- host-permission gate (Firefox can decline site access at install) ----
+// Firefox MV3 shows https://*/* as an install-prompt checkbox; a user who
+// unchecks it lands here with a signer no site can see. Surface that and offer
+// the one-click grant. On Chrome host_permissions are granted at install, so
+// contains() is true and the gate never appears.
+(function () {
+  'use strict';
+  const gate = document.getElementById('perm-gate');
+  const btn = document.getElementById('perm-grant-btn');
+  if (!gate || !btn) return;
+  // browser.* is promise-based on Firefox; chrome.* is promise-capable on Chrome MV3.
+  const API = (typeof browser !== 'undefined' && browser.permissions)
+    ? browser.permissions
+    : (typeof chrome !== 'undefined' ? chrome.permissions : null);
+  if (!API || !API.contains) return; // fail open: gate stays hidden
+  const ORIGINS = { origins: ['https://*/*'] };
+  const sync = () => {
+    API.contains(ORIGINS).then((ok) => { gate.hidden = !!ok; }).catch(() => {});
+  };
+  btn.addEventListener('click', () => {
+    // request() must run inside the click gesture — no awaits before it.
+    API.request(ORIGINS).then(sync).catch(() => {});
+  });
+  if (API.onAdded) API.onAdded.addListener(sync);
+  if (API.onRemoved) API.onRemoved.addListener(sync);
+  sync();
+})();


### PR DESCRIPTION
The 1.5.0 release — Sidecar's **first simultaneous Chrome + Firefox launch**. Themes (#116–#118) already shipped to `main`; this PR brings the rest of 1.5.0: the Firefox port, the release machinery for two stores, and a bug fix.

## What's in here
- **Firefox support.** The full signer — multi-account, NIP-07, the Lightning wallet, the approval flow — runs on Firefox 128+ at parity with Chrome, from **one shared codebase**: a unified `manifest.json` (both browsers' keys) with runtime `typeof browser` detection. No fork, no build step for dev. Going forward every change is inherently cross-browser; each release just emits two zips.
- **Dual-store packaging.** `scripts/package.sh vX.Y.Z` now builds both `sidecar-X.Y.Z.zip` (Chrome) and `sidecar-X.Y.Z-firefox.zip` (AMO) from one tagged commit, stripping each to its store's manifest keys (and the Chrome-only `sidePanel` permission from the Firefox zip) so neither validator sees foreign keys.
- **Expired-prompt Close fix** ([#119](https://github.com/dmnyc/sidecar/issues/119)) — the Close button on a timed-out standalone approval popup was a no-op; it now closes the window.
- **Release prep** — version → 1.5.0, dated changelog, in-app What's-new, README/help Firefox copy flipped from "experimental" to install-from-AMO.

## Verification
- ✅ End-to-end on Firefox via `about:debugging`: **posting** (NIP-07 signEvent) and **zapping** (NWC payment) confirmed working.
- ✅ Theme switching (Speakeasy / Film Noir / Art Deco) confirmed rendering correctly on Firefox.
- ✅ Statically clean: all JS parses, no Firefox-incompatible APIs (`chrome.sidePanel` is feature-gated), both store zips' manifests validated.
- The full 29-row `FIREFOX_PORT.md` parity benchmark wasn't run end-to-end, but the two headline flows + themes passing is a strong signal.

## Deferred
[#120](https://github.com/dmnyc/sidecar/issues/120) (NWC relay-timeout message — distinguish "wallet relay unreachable" from a generic timeout) is **deferred to 1.5.1**; it needs focused testing across wallet providers.

## Release plan (after merge)
1.4.1 is approved and live on Chrome, so the gate is clear. After merge: tag `v1.5.0` → `scripts/package.sh v1.5.0` builds both zips → GitHub Release (Chrome zip attached) → upload to Chrome Web Store + AMO. Firefox AMO is an independent review pipeline, so both submissions go in today; AMO's first-listing manual review is the long pole (days–~2 weeks).

🍸 Garnished with [Claude Code](https://claude.com/claude-code)