### PR TITLE
Prevent account-signing mismatch: fail-closed owner-signing + cross-window sync

### DIFF
--- a/background.js
+++ b/background.js
@@ -1711,8 +1711,9 @@ async function handleControl(message, sendResponse) {
       case 'SIDECAR_OWNER_SIGN': {
         if (message.pin != null) await stepUpPin(message.pin); // unlocks if auto-lock raced the modal
         else if (KS.isLocked()) throw new Error('Keystore is locked');
-        const pk = await KS.getActivePubkey();
-        result = self.NostrTools.finalizeEvent(message.event, await KS.getPrivkey(pk));
+        // expectedPubkey (when the caller supplies it) makes this fail closed if
+        // the active account changed out from under the caller — see KS.ownerSign.
+        result = await KS.ownerSign(message.event, message.expectedPubkey);
         break;
       }
       case 'SIDECAR_OWNER_ENCRYPT': {

--- a/keystore.js
+++ b/keystore.js
@@ -385,6 +385,25 @@
     return bytes;
   }
 
+  // Sign an event as the OWNER — first-party panel actions (note publish, image /
+  // Blossom upload auth). Fails closed: when the caller names the account it
+  // believes is active (`expectedPubkey`) and the keystore has since switched
+  // (e.g. Sidecar switched accounts in another window and this panel went stale),
+  // refuse rather than silently sign as the wrong account. Omitting
+  // `expectedPubkey` preserves the old "sign as whatever is active" behavior.
+  async function ownerSign(event, expectedPubkey) {
+    requireUnlocked();
+    const pk = await getActivePubkey();
+    if (!pk) throw new Error('No active account');
+    if (expectedPubkey && expectedPubkey !== pk) {
+      throw new Error(
+        'Active account changed — not signing (expected ' +
+          expectedPubkey.slice(0, 8) + '…, active ' + pk.slice(0, 8) + '…)'
+      );
+    }
+    return root.NostrTools.finalizeEvent(event, await getPrivkey(pk));
+  }
+
   // Re-wrap every account (and the verifier) under a new PIN.
   async function changePin(oldPin, newPin) {
     const store = await loadStore();
@@ -430,6 +449,7 @@
     getActivePubkey,
     hasAccount,
     getPrivkey,
+    ownerSign,
     setNwc,
     getNwc,
     hasNwc,

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A multi-account NIP-07 nostr signer with a built-in Lightning wallet, in your browser sidebar",
   "scripts": {
     "dev": "echo 'Load this folder as an unpacked extension at chrome://extensions'",
+    "test": "node --test test/*.test.js",
     "update-vendor": "scripts/update-vendor.sh",
     "verify-vendor": "sha256sum -c scripts/vendor-hashes.sha256"
   },

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -42,7 +42,7 @@ mkdir -p "${STAGE}"
 git archive "${TAG}" | tar -x -C "${STAGE}"
 
 # Strip everything that isn't part of the running extension.
-rm -rf "${STAGE}/.claude" "${STAGE}/.github" "${STAGE}/scripts" "${STAGE}/assets"
+rm -rf "${STAGE}/.claude" "${STAGE}/.github" "${STAGE}/scripts" "${STAGE}/assets" "${STAGE}/test"
 rm -f "${STAGE}/.gitignore" "${STAGE}/README.md" "${STAGE}/CHANGELOG.md" \
       "${STAGE}/FEATURES.md" "${STAGE}/PRIVACY.md" "${STAGE}/BROWSER_PARITY.md" \
       "${STAGE}/FIREFOX_PORT.md" "${STAGE}/VENDOR.md" "${STAGE}/package.json"

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -3001,6 +3001,15 @@
   let activityRefreshTimer = null;
   chrome.storage.onChanged.addListener((changes, area) => {
     if (area !== 'local') return;
+    // The keystore's active account can change from another Sidecar view (e.g. a
+    // second window switching accounts). Storage change events reach every view, so
+    // treat an active-pubkey change as authoritative and re-sync — otherwise this
+    // panel keeps showing (and composing/signing as) a stale account.
+    if ('sidecar_active_pubkey' in changes && state && !state.locked
+        && changes.sidecar_active_pubkey.newValue !== state.activePubkey) {
+      refresh();
+      return;
+    }
     if (!('sidecar_activity' in changes) && !('sidecar_site_accounts' in changes) && !('sidecar_permissions' in changes)) return;
     if (!state || state.locked) return;
     const activeTab = document.querySelector('.tab.active');
@@ -3594,7 +3603,7 @@
     return servers;
   }
 
-  async function uploadToBlossom(file, servers) {
+  async function uploadToBlossom(file, servers, forPubkey) {
     const buffer = await file.arrayBuffer();
     const hash = await sha256Hex(buffer);
     const now = Math.floor(Date.now() / 1000);
@@ -3604,7 +3613,7 @@
       tags: [['t', 'upload'], ['x', hash], ['expiration', String(now + 300)]],
       content: 'Upload file',
     };
-    const signed = await call({ type: 'SIDECAR_OWNER_SIGN', event: authEvent });
+    const signed = await call({ type: 'SIDECAR_OWNER_SIGN', event: authEvent, expectedPubkey: forPubkey });
     const authorization = 'Nostr ' + btoa(JSON.stringify(signed));
     let lastError;
     for (const server of servers) {
@@ -3634,12 +3643,13 @@
   // Returns a hosted URL via Blossom, or null when Blossom isn't usable (no
   // active account, no server list, or every server failed) — caller then falls
   // back to nostr.build.
-  async function tryBlossomFirst(file) {
-    if (!state.activePubkey) return null;
+  async function tryBlossomFirst(file, forPubkey) {
+    const pk = forPubkey || state.activePubkey;
+    if (!pk) return null;
     try {
-      const servers = await fetchBlossomServers(state.activePubkey);
+      const servers = await fetchBlossomServers(pk);
       if (!servers.length) return null;
-      return await uploadToBlossom(file, servers);
+      return await uploadToBlossom(file, servers, pk);
     } catch (e) {
       console.warn('[Upload] Blossom failed, falling back to nostr.build:', e);
       return null;
@@ -3647,10 +3657,11 @@
   }
 
   // ---- image upload (Blossom → nostr.build via NIP-98) ----
-  async function uploadImage(file, kind) {
+  async function uploadImage(file, kind, forPubkey) {
     if (!file.type.startsWith('image/')) throw new Error('Choose an image file');
     if (file.size > 10 * 1024 * 1024) throw new Error('Image too large (max 10MB)');
-    const blossomUrl = await tryBlossomFirst(file);
+    const forPk = forPubkey || state.activePubkey;
+    const blossomUrl = await tryBlossomFirst(file, forPk);
     if (blossomUrl) return blossomUrl;
     const url = 'https://nostr.build/api/v2/upload/' + (kind === 'profile' ? 'profile' : 'files');
     const authEvent = {
@@ -3659,7 +3670,7 @@
       tags: [['u', url], ['method', 'POST']],
       content: '',
     };
-    const signed = await call({ type: 'SIDECAR_OWNER_SIGN', event: authEvent });
+    const signed = await call({ type: 'SIDECAR_OWNER_SIGN', event: authEvent, expectedPubkey: forPk });
     const token = 'Nostr ' + btoa(JSON.stringify(signed));
     const form = new FormData();
     form.append('file', file);
@@ -3672,12 +3683,13 @@
   }
 
   // ---- note media upload (Blossom → nostr.build via NIP-98, images + video) ----
-  async function uploadMedia(file) {
+  async function uploadMedia(file, forPubkey) {
     const isImg = file.type.startsWith('image/');
     const isVid = file.type.startsWith('video/');
     if (!isImg && !isVid) throw new Error('Choose an image or video');
     if (file.size > 100 * 1024 * 1024) throw new Error('File too large (max 100MB)');
-    const blossomUrl = await tryBlossomFirst(file);
+    const forPk = forPubkey || state.activePubkey;
+    const blossomUrl = await tryBlossomFirst(file, forPk);
     if (blossomUrl) return blossomUrl;
     const url = 'https://nostr.build/api/v2/upload/files';
     const authEvent = {
@@ -3686,7 +3698,7 @@
       tags: [['u', url], ['method', 'POST']],
       content: '',
     };
-    const signed = await call({ type: 'SIDECAR_OWNER_SIGN', event: authEvent });
+    const signed = await call({ type: 'SIDECAR_OWNER_SIGN', event: authEvent, expectedPubkey: forPk });
     const token = 'Nostr ' + btoa(JSON.stringify(signed));
     const form = new FormData();
     form.append('file', file);
@@ -4162,7 +4174,7 @@
         tags,
         content,
       };
-      const signed = await call({ type: 'SIDECAR_OWNER_SIGN', event });
+      const signed = await call({ type: 'SIDECAR_OWNER_SIGN', event, expectedPubkey: pubkey });
       await publishSigned(signed);
       return signed;
     }
@@ -4464,7 +4476,7 @@
         const prev = lbl.textContent;
         lbl.textContent = 'Uploading…';
         try {
-          const url = await uploadMedia(file);
+          const url = await uploadMedia(file, pubkey);
           draft.media.push({ url, isVideo: file.type.startsWith('video/') });
           appendMediaUrl(url);
           draft.text = serializeEditor(editor);
@@ -4499,7 +4511,7 @@
         lbl.textContent = 'Uploading…';
         try {
           for (const file of imageFiles) {
-            const url = await uploadMedia(file);
+            const url = await uploadMedia(file, pubkey);
             draft.media.push({ url, isVideo: false });
             appendMediaUrl(url);
           }

--- a/test/MANUAL-account-mismatch.md
+++ b/test/MANUAL-account-mismatch.md
@@ -1,0 +1,47 @@
+# Manual reproduction — cross-window account signing mismatch
+
+`owner-sign.test.js` unit-covers the signing guard (the actual defect). The full
+symptom is a **two-window** staleness that spans two panel contexts and can't be
+reduced to a single unit test — reproduce it by hand.
+
+## Setup
+- Two accounts in Sidecar, **A** and **B**. Ideally give them *different* Blossom
+  server lists (kind:10063) so the upload target is visually distinguishable.
+- Open Sidecar in **two separate browser windows**. Each window has its own side
+  panel / sidebar instance with its own in-memory `state.activePubkey`; the
+  keystore's active account (`sidecar_active_pubkey`) is shared between them.
+
+## Reproduce (before the fix)
+1. In **Window 1**, make **B** active. Both windows show B.
+2. In **Window 2**, switch the active account to **A**. Window 2 shows A.
+3. Return to **Window 1** — it still shows **B** (it was never notified).
+4. In Window 1, open the composer (it reads "Posting as B"), attach an image, and post.
+
+**Buggy result:** the image uploads authed as **A** and the note publishes under
+**A**, even though Window 1 showed B throughout — often with a broken thumbnail
+from the auth/owner/server mismatch.
+
+## Expected (after the fix)
+- **Panel sync:** Window 1's `storage.onChanged` sees the `sidecar_active_pubkey`
+  change and refreshes, so after step 2 it updates to show **A** — the display no
+  longer lies about the active account.
+- **Fail-closed signing:** if a signature is attempted while the composer's
+  expected account (B) no longer matches the keystore's active account (A),
+  `KS.ownerSign` throws ("Active account changed — not signing …") instead of
+  silently signing as A. The note/upload fails with a clear error rather than
+  going out under the wrong account.
+
+## Root cause (for reference)
+- The panel's displayed `state.activePubkey` refreshed only on that panel's own
+  account switch; nothing re-synced it when another view changed the shared
+  keystore active account. `storage.onChanged` explicitly ignored
+  `sidecar_active_pubkey`, and `KS.setActive` sent no panel notification.
+- Owner-signing (`SIDECAR_OWNER_SIGN`) always signed with the keystore's live
+  active account and took no account from the caller — so a composer showing B
+  could sign as A with no signal.
+
+## Fix scope
+Composer note publish + image/Blossom uploads now pass `expectedPubkey`, and the
+panel re-syncs on active-pubkey storage changes. The remaining owner-sign call
+sites (profile / relay-list / backup publishes) share the class but weren't the
+reported bug — apply the same `expectedPubkey` pattern to them as a follow-up.

--- a/test/owner-sign.test.js
+++ b/test/owner-sign.test.js
@@ -1,0 +1,87 @@
+'use strict';
+
+// Reproduces the account-signing mismatch and locks in the fix.
+//
+// The panel's displayed account and the keystore's active account share one
+// stored value, but an open panel can go stale (e.g. Sidecar open in a second
+// window switches accounts — the first window is never told). All owner-signing
+// (note publish + Blossom/upload auth) goes through the background OWNER_SIGN
+// path, which today signs with KS.getActivePubkey() and takes NO account from
+// the caller — so a composer showing account B can sign as account A.
+//
+// The fix: KS.ownerSign(event, expectedPubkey) fails closed — it refuses to sign
+// when the caller's expected account no longer matches the active one.
+//
+// This unit-covers the SIGNING half (the actual defect). The two-window staleness
+// is an integration scenario across two panel contexts — see
+// test/MANUAL-account-mismatch.md for the manual reproduction.
+
+const { test, before } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const ROOT = path.join(__dirname, '..');
+
+// Minimal in-memory chrome.storage area (local + session), callback-style like MV3.
+function makeStorageArea() {
+  const data = {};
+  return {
+    get(keys, cb) {
+      let out = {};
+      if (keys == null) out = { ...data };
+      else if (typeof keys === 'string') { if (keys in data) out[keys] = data[keys]; }
+      else if (Array.isArray(keys)) { for (const k of keys) if (k in data) out[k] = data[k]; }
+      else { for (const k of Object.keys(keys)) out[k] = (k in data) ? data[k] : keys[k]; }
+      cb(out);
+    },
+    set(obj, cb) { Object.assign(data, obj); cb && cb(); },
+    remove(keys, cb) { for (const k of (Array.isArray(keys) ? keys : [keys])) delete data[k]; cb && cb(); },
+    clear(cb) { for (const k of Object.keys(data)) delete data[k]; cb && cb(); },
+  };
+}
+
+let KS, NostrTools, pkA, pkB;
+
+before(async () => {
+  // The IIFEs resolve their root as `self`; give them one, plus a chrome mock.
+  // Node 22 already provides globalThis.crypto (WebCrypto), which crypto.js uses.
+  globalThis.self = globalThis;
+  globalThis.chrome = { storage: { local: makeStorageArea(), session: makeStorageArea() } };
+  for (const f of ['nostr-tools.js', 'crypto.js', 'keystore.js']) {
+    vm.runInThisContext(fs.readFileSync(path.join(ROOT, f), 'utf8'), { filename: f });
+  }
+  NostrTools = globalThis.NostrTools;
+  KS = globalThis.SidecarKeystore;
+  assert.ok(KS, 'SidecarKeystore loaded');
+  assert.ok(NostrTools && NostrTools.finalizeEvent, 'NostrTools loaded');
+
+  await KS.initialize('sidecar-test-pin');
+  pkA = (await KS.addAccountFromBytes(NostrTools.generateSecretKey(), 'A')).pubkey; // first add → active
+  pkB = (await KS.addAccountFromBytes(NostrTools.generateSecretKey(), 'B')).pubkey;
+  assert.notEqual(pkA, pkB);
+});
+
+const note = () => ({ kind: 1, created_at: 1, tags: [], content: 'hello' });
+
+test('the bug: owner-signing follows the keystore active account, ignoring caller intent', async () => {
+  await KS.setActive(pkA);
+  // Exactly what background.js SIDECAR_OWNER_SIGN does today.
+  const signed = NostrTools.finalizeEvent(note(), await KS.getPrivkey(await KS.getActivePubkey()));
+  assert.equal(signed.pubkey, pkA);
+  // A composer that showed B would still have produced an A-signed note. No signal to the caller.
+});
+
+test('the fix: KS.ownerSign rejects when expectedPubkey != active account', async () => {
+  await KS.setActive(pkA);
+  assert.equal(typeof KS.ownerSign, 'function', 'KS.ownerSign must exist');
+  await assert.rejects(() => KS.ownerSign(note(), pkB), /account/i,
+    'signing as B while A is active must fail closed');
+});
+
+test('the fix: KS.ownerSign signs as the active account when expected matches (or is omitted)', async () => {
+  await KS.setActive(pkA);
+  assert.equal((await KS.ownerSign(note(), pkA)).pubkey, pkA);
+  assert.equal((await KS.ownerSign(note())).pubkey, pkA); // omitted = backward compatible
+});


### PR DESCRIPTION
Fixes a bug where an open Sidecar panel could display one account while signing/uploading as another — reproduced with Sidecar open in **two windows** (switching accounts in one left the other's panel stale; owner-signing always used the keystore's live active account with no caller pinning, so composing in the stale window posted + uploaded under the wrong account — the broken-thumbnail / wrong-author report).

## Changes
- `keystore.js`: `ownerSign(event, expectedPubkey)` — fails closed (throws) when the active account no longer matches the caller's expected account.
- `background.js`: `SIDECAR_OWNER_SIGN` delegates to `KS.ownerSign` with the caller's `expectedPubkey`.
- `sidepanel.js`: composer note publish + Blossom/image/media uploads pin to the composer's account; `storage.onChanged` re-syncs on `sidecar_active_pubkey` changes so a second window can't leave a panel stale.
- Tests: `test/owner-sign.test.js` (`npm test`, Node built-in runner) + `test/MANUAL-account-mismatch.md` (two-window manual repro). `test/` is stripped from shipped zips.

## Notes
- Does **not** affect the in-review 1.5.0 — merges untagged; ships in a later release per the one-in-pipeline cadence.
- Behavior change: signing now **fails closed** on an account mismatch (a clear error) rather than silently signing as the wrong account.

## Easy revert
The fix is one commit (`23151d1`) — if the fail-closed guard causes false positives in real use, `git revert 23151d1`.

## Follow-up
Apply the same `expectedPubkey` pinning to the remaining owner-sign call sites (profile / relay-list / backup publishes).

🍸 Shaken with [Claude Code](https://claude.com/claude-code)
