### PR TITLE
feat: optional pinned wallet balance bar

### DIFF
--- a/sidepanel.html
+++ b/sidepanel.html
@@ -80,6 +80,24 @@
     </nav>
 
 
+    <!-- Pinned wallet balance bar — under the nav on every tab when "Pin balance
+         bar" is on and a wallet is connected (the wallet screen hides its own big
+         balance card while pinned). Left: Send/Receive; center: balance; right:
+         hide balances + unpin. -->
+    <div id="pinned-balance" class="pinned-balance hidden">
+      <div class="pinned-balance-actions">
+        <button type="button" id="pinned-send" class="pinned-balance-btn" title="Send" aria-label="Send"></button>
+        <button type="button" id="pinned-receive" class="pinned-balance-btn" title="Receive" aria-label="Receive"></button>
+      </div>
+      <div class="pinned-balance-amt-wrap">
+        <span id="pinned-balance-amt" class="pinned-balance-amt">…</span>
+      </div>
+      <div class="pinned-balance-tools">
+        <button type="button" id="pinned-hide" class="pinned-balance-btn" title="Hide balances" aria-label="Hide balances"></button>
+        <button type="button" id="pinned-unpin" class="pinned-balance-btn" title="Unpin balance bar" aria-label="Unpin balance bar"></button>
+      </div>
+    </div>
+
     <!-- Firefox lets the user decline/revoke site access (host permissions); without
          it there is no window.nostr anywhere and the signer looks dead. Chrome grants
          at install, so this only shows there if the user restricted site access. -->
@@ -277,6 +295,12 @@
         <h3>Pay button on web pages</h3>
         <p class="hint">Show a floating “Pay with Sidecar” button when a page displays a Lightning invoice.</p>
         <label class="toggle-row"><input type="checkbox" id="paybutton-toggle" /> <span>Show pay button</span></label>
+      </div>
+
+      <div class="setting">
+        <h3>Pin balance bar</h3>
+        <p class="hint">Show your wallet balance under the navigation on every tab except Wallet, with quick Send and Receive buttons.</p>
+        <label class="toggle-row"><input type="checkbox" id="pinbalance-toggle" /> <span>Pin balance bar across tabs</span></label>
       </div>
 
       <div class="setting">

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -251,6 +251,7 @@
 
   let state = null;
   let hideBalances = false;
+  let pinBalanceBar = false;
   let _firstPostSeenPubkeys = null;
   let balanceCache = { pubkey: null, sats: null }; // last known balance for instant display
   const _notifCache = new Map(); // pubkey → { events: Event[], liveSub: Closeable|null }
@@ -319,6 +320,7 @@
     if (msg.event === 'walletChanged' && state && !state.locked) {
       const active = document.querySelector('.tab.active');
       if (active && active.dataset.tab === 'wallet') renderWallet();
+      renderPinnedBalanceBar(); // refresh the pinned bar on any tab
     }
     // Auto-lock (or a lock from elsewhere) fired in the background — drop to the
     // unlock screen now. refresh() closes any open modal and routes to view-lock.
@@ -413,6 +415,7 @@
     state = await call({ type: 'SIDECAR_GET_STATE' });
     const settings = await call({ type: 'SIDECAR_GET_SETTINGS' });
     hideBalances = !!(settings && settings.hideBalances);
+    pinBalanceBar = !!(settings && settings.pinBalanceBar);
     applyTheme(settings.theme || 'speakeasy'); // default to speakeasy
     applyHideBalances();
     closeAcctMenu();
@@ -824,6 +827,7 @@
       if (name === 'activity') { sitesShownN = 0; logShownN = 0; renderActivity(); }
       else if (name === 'profile') renderProfile();
       else if (name === 'wallet') renderWallet();
+      renderPinnedBalanceBar(); // show on non-wallet tabs, hide on Wallet
     });
   });
 
@@ -1780,6 +1784,7 @@
     $('chip-name').textContent = active ? displayName(active) : 'No account';
     refreshBell();
     syncRelax();
+    renderPinnedBalanceBar();
 
     // The active account already shows in the header chip and is marked (check +
     // highlight) in the list below, so the big "booth" card was a third copy.
@@ -2697,6 +2702,7 @@
     $('paybutton-toggle').checked = settings.showPayButton !== false; // default on
     $('clienttag-toggle').checked = settings.showClientTag !== false; // default on
     $('datasync-toggle').checked = settings.confirmDataSync === true; // default off (auto-allow)
+    $('pinbalance-toggle').checked = settings.pinBalanceBar === true; // default off
     $('autozap-toggle').checked = settings.autoZap === true;
     const azMax = Number(settings.autoZapMaxSats) || AUTOZAP_DEFAULT_MAX;
     $('autozap-max').value = String(azMax);
@@ -6054,6 +6060,56 @@
   const fmtSats = (n) => Math.round(n).toLocaleString('en-US');
   const msatToSat = (m) => Math.floor((m || 0) / 1000);
 
+  // Optional pinned balance bar — compact balance + Send/Receive under the nav,
+  // on every tab except Wallet (which has the full display). Only renders when
+  // the setting is on, an account is active, and a wallet is connected. Paints
+  // the shared balanceCache instantly, then fetches fresh if it's empty or stale
+  // (>60s) for this account.
+  async function renderPinnedBalanceBar() {
+    const bar = $('pinned-balance');
+    if (!bar) return;
+    if (!pinBalanceBar || !state || !state.activePubkey) { hide(bar); return; }
+    let has = false;
+    try { has = !!(await call({ type: 'SIDECAR_HAS_NWC' })).has; } catch (_) {}
+    if (!has) { hide(bar); return; } // no wallet for this account — Wallet tab owns onboarding
+    show(bar);
+    const hideBtn = $('pinned-hide');
+    if (hideBtn) { hideBtn.innerHTML = ''; hideBtn.appendChild(icon(hideBalances ? 'eye-off' : 'eye')); hideBtn.title = hideBalances ? 'Show balances' : 'Hide balances'; }
+    const amt = $('pinned-balance-amt');
+    if (!amt) return;
+    const cached = balanceCache && balanceCache.pubkey === state.activePubkey && balanceCache.sats != null;
+    amt.textContent = cached ? fmtSats(balanceCache.sats) : '…';
+    const stale = !cached || !balanceCache.ts || Date.now() - balanceCache.ts > 60000;
+    if (stale) {
+      try {
+        const client = await ensureNwc();
+        if (client) {
+          const b = await client.getBalance();
+          balanceCache = { pubkey: state.activePubkey, sats: msatToSat(b && b.balance), ts: Date.now() };
+          amt.textContent = fmtSats(balanceCache.sats);
+        }
+      } catch (_) {}
+    }
+  }
+
+  // Keep the three pin affordances (settings checkbox, wallet-card pin icon, the
+  // bar itself) in sync after any of them toggles pinBalanceBar.
+  function syncPinControls() {
+    const cb = $('pinbalance-toggle');
+    if (cb) cb.checked = pinBalanceBar;
+    const wt = $('tab-wallet');
+    if (wt) wt.classList.toggle('wallet-pinned', pinBalanceBar); // hide/show the wallet's own balance card
+    renderPinnedBalanceBar();
+  }
+
+  // Keep the two hide-balances affordances (bar eye + wallet-card eye) in sync.
+  function syncHideControls() {
+    applyHideBalances();
+    const setEye = (btn) => { if (!btn) return; btn.innerHTML = ''; btn.appendChild(icon(hideBalances ? 'eye-off' : 'eye')); btn.title = hideBalances ? 'Show balances' : 'Hide balances'; };
+    setEye($('pinned-hide'));
+    document.querySelectorAll('.wallet-eye').forEach(setEye);
+  }
+
   // Lightning address for receiving. Some NWC connection strings embed a `lud16`
   // (the wallet's own address) — prefer that, then fall back to the account's
   // profile lud16. Returns null when neither is present.
@@ -6234,6 +6290,9 @@
   }
 
   async function renderWalletConnected(view) {
+    // When the balance bar is pinned, hide this screen's own big balance card —
+    // the pinned bar already shows it (avoids a double display).
+    $('tab-wallet').classList.toggle('wallet-pinned', pinBalanceBar);
     // Balance card — show the last-known balance instantly, refresh below.
     const cached = balanceCache.pubkey === state.activePubkey && balanceCache.sats != null;
     // Sentinel above the card; its visibility (not scrollTop) drives the collapse.
@@ -6260,12 +6319,18 @@
     eye.addEventListener('click', async () => {
       hideBalances = !hideBalances;
       await call({ type: 'SIDECAR_SET_SETTINGS', settings: { hideBalances } });
-      applyHideBalances();
-      eye.innerHTML = '';
-      eye.appendChild(icon(hideBalances ? 'eye-off' : 'eye'));
-      eye.title = hideBalances ? 'Show balances' : 'Hide balances';
+      syncHideControls();
     });
-    card.append(eye, refresh, h('div', { className: 'wallet-bal-label', textContent: 'Balance' }), bal, unit);
+    // Pin the balance bar from the card's corner. Only reachable while the bar is
+    // unpinned (the card hides once pinned), so this is a one-way "pin" affordance.
+    const pin = h('button', { className: 'wallet-pin', title: 'Pin balance bar' });
+    pin.appendChild(icon('pin'));
+    pin.addEventListener('click', async () => {
+      pinBalanceBar = true;
+      await call({ type: 'SIDECAR_SET_SETTINGS', settings: { pinBalanceBar: true } });
+      syncPinControls();
+    });
+    card.append(eye, refresh, h('div', { className: 'wallet-bal-label', textContent: 'Balance' }), bal, unit, pin);
     view.append(card);
 
     // Actions
@@ -6356,7 +6421,7 @@
     if (!client) { view.innerHTML = ''; renderWalletConnect(view); return; }
     try {
       const b = await client.getBalance();
-      balanceCache = { pubkey: state.activePubkey, sats: msatToSat(b && b.balance) };
+      balanceCache = { pubkey: state.activePubkey, sats: msatToSat(b && b.balance), ts: Date.now() };
       bal.textContent = fmtSats(balanceCache.sats);
     } catch (_) {
       if (!cached) { bal.textContent = '—'; unit.textContent = 'balance unavailable'; }
@@ -6800,6 +6865,7 @@
           closeModal();
           toast('Payment sent' + (feeMsat != null ? ' · fee ' + fmtFeeMsat(feeMsat) : ''), 'success');
           renderWallet();
+          renderPinnedBalanceBar();
         } catch (e) {
           err.textContent = e.message;
           pay.disabled = false;
@@ -6884,6 +6950,7 @@
                   stopPoll();
                   showReceiveSuccess(body, sats);
                   renderWallet();
+                  renderPinnedBalanceBar();
                   return;
                 }
               } catch (_) {}
@@ -7197,6 +7264,30 @@
 
   $('datasync-toggle').addEventListener('change', async (e) => {
     await call({ type: 'SIDECAR_SET_SETTINGS', settings: { confirmDataSync: e.target.checked } });
+  });
+
+  $('pinbalance-toggle').addEventListener('change', async (e) => {
+    pinBalanceBar = e.target.checked;
+    await call({ type: 'SIDECAR_SET_SETTINGS', settings: { pinBalanceBar: e.target.checked } });
+    syncPinControls();
+  });
+
+  // Pinned balance bar — left: Send/Receive (wallet modals); right: hide balances
+  // + unpin. The bar only renders when a wallet is connected.
+  $('pinned-send').append(icon('arrow-up-right'));
+  $('pinned-receive').append(icon('arrow-down-left'));
+  $('pinned-unpin').append(icon('x'));
+  $('pinned-send').addEventListener('click', () => sendModal());
+  $('pinned-receive').addEventListener('click', () => receiveModal());
+  $('pinned-hide').addEventListener('click', async () => {
+    hideBalances = !hideBalances;
+    await call({ type: 'SIDECAR_SET_SETTINGS', settings: { hideBalances } });
+    syncHideControls();
+  });
+  $('pinned-unpin').addEventListener('click', async () => {
+    pinBalanceBar = false;
+    await call({ type: 'SIDECAR_SET_SETTINGS', settings: { pinBalanceBar: false } });
+    syncPinControls();
   });
 
   $('countdown-toggle').addEventListener('change', async (e) => {

--- a/styles.css
+++ b/styles.css
@@ -1274,10 +1274,54 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
 /* privacy masking — masks each glyph at its real width, so toggling never reflows */
 .balances-hidden .wallet-balance,
 .balances-hidden .tx-amt,
-.balances-hidden .amt-hide {
+.balances-hidden .amt-hide,
+.balances-hidden .pinned-balance-amt {
   -webkit-text-security: disc;
   text-security: disc;
 }
+
+/* Pinned wallet balance bar — above the nav on every tab when enabled. Left:
+   Send/Receive (open the wallet's own modals); center: balance; right: hide
+   balances + unpin. flex-shrink:0 keeps it pinned above the scrolling content. */
+.pinned-balance {
+  flex-shrink: 0; display: flex; align-items: center; gap: 8px;
+  padding: 7px 12px; border-bottom: 1px solid var(--border);
+  background: linear-gradient(180deg, var(--velvet-2), var(--velvet-1));
+  position: relative; z-index: 6; /* above scrolling content so the shadow lands on it */
+  box-shadow: 0 4px 8px -5px rgba(0, 0, 0, 0.22);
+}
+/* film-noir's velvet-1 is its darker shade (inverse of the other themes), so its
+   underhang keeps the default gradient direction — which already reads recessed. */
+[data-theme="film-noir"] .pinned-balance {
+  background: linear-gradient(180deg, var(--velvet-1), var(--velvet-2));
+}
+.pinned-balance-actions, .pinned-balance-tools { display: flex; align-items: center; gap: 6px; }
+.pinned-balance-amt-wrap { flex: 1; min-width: 0; display: flex; align-items: baseline; justify-content: center; gap: 5px; }
+.pinned-balance-amt { font-family: var(--font-display); font-weight: 700; font-size: 24px; color: var(--gold); font-variant-numeric: tabular-nums; line-height: 1; }
+.pinned-balance-btn {
+  width: 30px; height: 30px; flex-shrink: 0; padding: 0; border-radius: 50%; cursor: pointer;
+  background: var(--hover-soft); border: 1px solid var(--border-strong); color: var(--muted);
+  display: inline-flex; align-items: center; justify-content: center; transition: color 0.15s, background 0.15s;
+}
+.pinned-balance-btn svg { width: 15px; height: 15px; }
+.pinned-balance-btn:hover { color: var(--lav); background: var(--hover-medium); }
+
+/* When the balance bar is pinned, the wallet screen hides its own big balance
+   card (and the scroll-collapsed mini — same element): the pinned bar already
+   shows the balance, so this avoids a double display. */
+#tab-wallet.wallet-pinned .wallet-card,
+#tab-wallet.wallet-pinned .wallet-sentinel,
+#tab-wallet.wallet-pinned .wallet-spacer { display: none; }
+
+/* Pin toggle on the balance card (bottom-right). Only visible while the bar is
+   unpinned — the card hides once pinned — so it's a one-way "pin" affordance. */
+.wallet-pin {
+  position: absolute; bottom: 8px; right: 10px; width: 30px; height: 30px; padding: 0;
+  border-radius: 50%; cursor: pointer; background: transparent; border: 1px solid var(--border);
+  color: var(--muted); display: inline-flex; align-items: center; justify-content: center;
+}
+.wallet-pin svg { width: 15px; height: 15px; }
+.wallet-pin:hover { border-color: var(--gold-soft); color: var(--gold); }
 
 .wallet-card {
   position: sticky; top: 0; z-index: 5;
@@ -1306,7 +1350,8 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
 .wallet-card.compact .wallet-bal-label,
 .wallet-card.compact .wallet-unit,
 .wallet-card.compact .wallet-eye,
-.wallet-card.compact .wallet-refresh { display: none; }
+.wallet-card.compact .wallet-refresh,
+.wallet-card.compact .wallet-pin { display: none; }
 .wallet-card.compact .wallet-balance { font-size: 24px; margin: 0; line-height: 1; }
 .wallet-refresh {
   position: absolute; top: 10px; right: 10px;


### PR DESCRIPTION
## What

Adds an optional **pinned wallet balance bar** under the nav — `Send · balance · Receive` on the left, `hide · unpin` on the right — visible across tabs when "Pin balance bar" is on and a wallet is connected. On the wallet screen the big balance card (and its scroll-collapsed mini) hides while pinned, since the bar already shows the balance; unpinning restores the normal view.

## Why

Today the balance (and Send/Receive) only live on the Wallet tab, so checking it or sending/receiving from any other tab means a round-trip to Wallet. This keeps the balance + quick actions one tap away everywhere, while the Wallet tab still owns the full display when the bar is off.

## How
- **`renderPinnedBalanceBar()`** reuses the existing balance plumbing — `fmtSats`, the shared `balanceCache` (now timestamped), and `ensureNwc().getBalance()` for a fresh fetch only when the cache is empty or >60s stale. Send/Reuse the wallet's own zero-arg `sendModal()` / `receiveModal()`.
- **Shown only when** the setting is on, an account is active, and a wallet is connected (`SIDECAR_HAS_NWC`).
- **Refreshed** on tab switch, `refresh`, the `walletChanged` broadcast (widened to fire on any tab), the toggle, and after a send/receive.
- **Pin/hide sync** across three affordances (the Settings toggle, the card's corner pin icon, and the bar's unpin) and two hide affordances (bar eye + card eye).
- **Wallet card** hides (card + sentinel + spacer via a `wallet-pinned` class) while pinned; the card's pin icon is a one-way "pin" since the card is hidden once pinned.
- **Privacy**: the balance is masked by the existing eye-toggle.
- **Styling**: themed gradient (with a film-noir override, since noir's velvet vars are ordered opposite), muted icon buttons with a themed stroke, and a subtle drop shadow over scrolling content. No `background.js` change — `SIDECAR_SET_SETTINGS` already merges the new key.

## Status
Opening for review — manual QA wanted across themes (the bar, the wallet-card hide/show on pin, send/receive from the bar, and the hide/unpin affordances). Not requesting a merge yet.

🍸 Stirred with [Claude Code](https://claude.com/claude-code)
