### PR TITLE
fix: show pinned balance bar when a wallet is freshly connected

### DIFF
--- a/sidepanel.js
+++ b/sidepanel.js
@@ -6293,6 +6293,12 @@
     // When the balance bar is pinned, hide this screen's own big balance card —
     // the pinned bar already shows it (avoids a double display).
     $('tab-wallet').classList.toggle('wallet-pinned', pinBalanceBar);
+    // ...and since the card is now hidden, make sure the bar is actually showing
+    // the balance. This is the choke point for a freshly connected/restored
+    // wallet, and SIDECAR_SET_NWC doesn't broadcast walletChanged, so without
+    // this the bar stays hidden (nothing was connected when it last rendered) —
+    // leaving the balance invisible on the Wallet screen until a tab switch.
+    if (pinBalanceBar) renderPinnedBalanceBar();
     // Balance card — show the last-known balance instantly, refresh below.
     const cached = balanceCache.pubkey === state.activePubkey && balanceCache.sats != null;
     // Sentinel above the card; its visibility (not scrollTop) drives the collapse.


### PR DESCRIPTION
`pinBalanceBar` is a global setting, so when one account pins it the setting applies to all. Connecting or restoring a wallet on an account that previously had none hides the wallet screen's big balance card (`wallet-pinned`) but never showed the pinned bar — `SIDECAR_SET_NWC` doesn't broadcast `walletChanged`, and `renderWalletConnected` never re-renders it. The balance thus vanished on the Wallet screen until a tab switch happened to re-run `renderPinnedBalanceBar()`.

Fix: call `renderPinnedBalanceBar()` from `renderWalletConnected()` when pinned. It's the single choke point every freshly connected/restored wallet passes through, so it covers the connect button, "Restore from Nostr," and the add-account-with-NWC path.

Tests: existing 14 still pass.

🍻 Poured with [Claude Code](https://claude.com/claude-code)