### PR TITLE
fix: restore themed background on wallets and help pages

### DIFF
--- a/help.html
+++ b/help.html
@@ -6,6 +6,10 @@
   <title>Sidecar Help &amp; Guides</title>
   <link rel="stylesheet" href="fonts.css">
   <link rel="stylesheet" href="welcome.css">
+  <link rel="stylesheet" href="themes/speakeasy.css">
+  <link rel="stylesheet" href="themes/film-noir.css">
+  <link rel="stylesheet" href="themes/art-deco.css">
+  <link rel="stylesheet" href="themes/patterns.css">
   <link rel="stylesheet" href="help.css">
 </head>
 <body>

--- a/wallets.html
+++ b/wallets.html
@@ -6,6 +6,10 @@
   <title>Find a wallet for Sidecar</title>
   <link rel="stylesheet" href="fonts.css">
   <link rel="stylesheet" href="welcome.css">
+  <link rel="stylesheet" href="themes/speakeasy.css">
+  <link rel="stylesheet" href="themes/film-noir.css">
+  <link rel="stylesheet" href="themes/art-deco.css">
+  <link rel="stylesheet" href="themes/patterns.css">
   <link rel="stylesheet" href="wallets.css">
 </head>
 <body>


### PR DESCRIPTION
## Problem

Since 1.5.0, the **Wallets** and **Help** standalone pages render a flat, darker background — missing the velvet texture and gradient highlights that the Welcome page has.

## Root cause

The 1.5.0 theme work (commit `5506b27`) moved the decorative `body { background-image }` rule **out of `welcome.css` into the new `themes/patterns.css`**. `welcome.html` was updated at the same time to link the theme files, but `wallets.html` and `help.html` were never updated — and since `welcome.css` (which both pages *do* load) no longer carries the image, they silently fell back to flat `background-color: var(--bg)`.

The color itself (`--bg: #0a0118`) is the same with or without the theme files — what's missing is the SVG lattice texture, the purple/orange radial-glow highlights, and the lighter-purple gradient layer that `patterns.css` paints on top.

## Fix

Add the four theme `<link>` tags to both pages (after `welcome.css`, before the page-specific CSS), matching the order already used by `welcome.html` and `prompt.html`:

```html
<link rel="stylesheet" href="themes/speakeasy.css">
<link rel="stylesheet" href="themes/film-noir.css">
<link rel="stylesheet" href="themes/art-deco.css">
<link rel="stylesheet" href="themes/patterns.css">
```

Confirmed scope: only `wallets.html` and `help.html` were affected. `welcome.html`, `prompt.html`, and `theme-preview.html` already load the full theme set.

🧉 Steeped with [Claude Code](https://claude.com/claude-code)