### PR TITLE
Release 1.5.1: version bump, changelog, help.html what's-new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ Release practice: the latest release's highlights are also summarized in-app, in
 guide's **What's new** section (`help.html#whats-new`, linked from Settings → Updates).
 Update that section alongside this file as part of every release.
 
+## [1.5.1] — 2026-07-24
+
+### Fixed
+- **Relax mode reliability.** Three issues with timed auto-sign are resolved: the relax balloon and status bar no longer overlap; an activation race that could prevent relax mode from engaging is corrected; and the "granted 15 minutes, bar never showed" symptom is fixed at its root — relax mode was silently self-revoking when a host rebind occurred.
+- **Pinned balance bar on first wallet connect.** The balance bar now appears immediately when a wallet is freshly connected or restored on an account that previously had none, instead of requiring a panel reload.
+- **Themed backgrounds on Wallets and Help pages.** Both standalone pages lost their velvet texture and gradient highlights after the 1.5.0 theme refactor; the themed background is now restored on all three themes.
+
+### Changed
+- Tightened the switch-account tip and wallet onboarding copy for clarity.
+- Shortened the shared-identity heads-up blurb shown during signing approvals.
+
 ## [1.5.0] — 2026-07-21
 
 ### Added

--- a/help.html
+++ b/help.html
@@ -240,6 +240,12 @@
          linked below. -->
     <section class="guide-section" id="whats-new">
       <h2>What's new</h2>
+      <p class="whatsnew-version">Version 1.5.1</p>
+      <ul class="whatsnew-list">
+        <li><strong>Relax mode fixes.</strong> Timed auto-sign is more reliable — the status bar and balloon no longer overlap, and relax mode no longer silently revokes itself when a site rebinds (the cause of "granted 15 min, bar never showed").</li>
+        <li><strong>Balance bar shows on first connect.</strong> The pinned balance bar now appears immediately when you connect or restore a wallet, without needing to reload the panel.</li>
+        <li><strong>Themed backgrounds restored</strong> on the Wallets and Help pages — the velvet texture and theme gradients are back.</li>
+      </ul>
       <p class="whatsnew-version">Version 1.5.0</p>
       <ul class="whatsnew-list">
         <li><strong>Sidecar is now on Firefox.</strong> The full signer — multi-account, NIP-07, the Lightning wallet, and the approval flow — runs on Firefox 128 and later, at parity with Chrome. On Firefox it lives in the sidebar; install it from Firefox Add-ons.</li>

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Sidecar | A Classy Nostr Signer",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "minimum_chrome_version": "114",
   "description": "A multi-account NIP-07 Nostr signer with a built-in Lightning wallet, in your browser sidebar.",
   "permissions": [


### PR DESCRIPTION
## Summary

- **`manifest.json`**: version `1.5.0` → `1.5.1`
- **`CHANGELOG.md`**: new `[1.5.1]` entry covering #125, #126, #128, #129
- **`help.html#whats-new`**: matching user-facing summary slotted above the 1.5.0 block

Issue #127 (coinos NWC description array) is intentionally excluded for now — will be folded in via force-push once #127 merges.

Covers: #125 #126 #128 #129

🧋 Sipped with [Claude Code](https://claude.com/claude-code)