### PR TITLE
feat: lightning strike animation when a payment is sent

### DIFF
--- a/background.js
+++ b/background.js
@@ -1352,6 +1352,11 @@ async function payInvoiceLocked(invoiceRaw, host, pubkey, memo, originWindowId) 
   logActivity({ ts: Date.now(), host, method: 'webln.sendPayment', amountSats: sats, pubkey });
   // Tell an open side panel to refresh its balance/history.
   chrome.runtime.sendMessage({ type: 'SIDECAR_EVENT', event: 'walletChanged' }).catch(() => {});
+  // Let the paying page celebrate (the content script's lightning strike). This is the
+  // WebLN path — a zap from a client's own UI, where notifyTabPaid isn't otherwise
+  // called because there's no "Pay with Sidecar" card involved. Best-effort: the page
+  // may have navigated away, and a missing flourish is not an error.
+  notifyTabsPaidByHost(host);
   return { preimage: preimage || '', sats };
 }
 
@@ -1372,6 +1377,26 @@ function notify(message) {
 
 // Tell a tab a page invoice was paid, so its "Pay with Sidecar" pill clears
 // (the invoice link often lingers in the DOM after the modal shows "Paid").
+// Tell the tabs on `host` that a payment settled, so the content script can throw its
+// lightning strike. Scoped to the paying host — never broadcast to every open tab, or
+// an unrelated page would flash for a payment that had nothing to do with it. Carries
+// no invoice: this is a visual cue, and the pay-card dismissal keys off the invoice via
+// notifyTabPaid instead.
+function notifyTabsPaidByHost(host) {
+  if (!host || !chrome.tabs) return;
+  try {
+    chrome.tabs.query({}, (tabs) => {
+      void chrome.runtime.lastError;
+      for (const t of tabs || []) {
+        let h = '';
+        try { h = new URL(t.url || '').host; } catch (_) { continue; }
+        if (h !== host || t.id == null) continue;
+        chrome.tabs.sendMessage(t.id, { type: 'SIDECAR_EVENT', event: 'paidflash' }, () => void chrome.runtime.lastError);
+      }
+    });
+  } catch (_) {}
+}
+
 function notifyTabPaid(tabId, invoice) {
   if (tabId != null && chrome.tabs) {
     chrome.tabs.sendMessage(tabId, { type: 'SIDECAR_EVENT', event: 'paid', invoice }, () => void chrome.runtime.lastError);

--- a/background.js
+++ b/background.js
@@ -1356,7 +1356,7 @@ async function payInvoiceLocked(invoiceRaw, host, pubkey, memo, originWindowId) 
   // WebLN path — a zap from a client's own UI, where notifyTabPaid isn't otherwise
   // called because there's no "Pay with Sidecar" card involved. Best-effort: the page
   // may have navigated away, and a missing flourish is not an error.
-  notifyTabsPaidByHost(host);
+  notifyTabsPaidByHost(host).catch(() => {}); // deliberately not awaited — a flourish must not delay the reply
   return { preimage: preimage || '', sats };
 }
 
@@ -1382,8 +1382,14 @@ function notify(message) {
 // an unrelated page would flash for a payment that had nothing to do with it. Carries
 // no invoice: this is a visual cue, and the pay-card dismissal keys off the invoice via
 // notifyTabPaid instead.
-function notifyTabsPaidByHost(host) {
+async function notifyTabsPaidByHost(host) {
   if (!host || !chrome.tabs) return;
+  // Gate here rather than in the content script: the page-facing settings read is
+  // deliberately clamped to showPayButton (see SIDECAR_GET_SETTINGS above), and
+  // widening it would hand every visited site another config bit to fingerprint.
+  // Default on — only an explicit false disables it.
+  const settings = (await sget('sidecar_settings')).sidecar_settings || {};
+  if (settings.zapFlash === false) return;
   try {
     chrome.tabs.query({}, (tabs) => {
       void chrome.runtime.lastError;

--- a/content.js
+++ b/content.js
@@ -480,16 +480,26 @@
       // pointer-events is set INLINE, not just in the :host rule — `all:initial`
       // resets it, and relying on the overlay merely being transparent to stay
       // click-through is too fragile for something covering the whole page.
-      host.style.cssText = 'all:initial;position:fixed;inset:0;pointer-events:none;z-index:2147483646;';
+      //
+      // z-index alone can't win here: a payment modal (Bitcoin Connect, and Sidecar's
+      // own pay card) sits at the maximum 2147483647, so a bolt below that draws
+      // BEHIND the very modal the payment came from. Instead promote the overlay to
+      // the browser's TOP LAYER via the Popover API, which renders above every
+      // z-index stacking context regardless of value. Supported by both floors this
+      // extension targets (Chrome 114+, Firefox 128+); the max z-index below is the
+      // fallback if showPopover throws.
+      host.style.cssText = 'all:initial;position:fixed;inset:0;pointer-events:none;z-index:2147483647;border:0;background:transparent;';
       const root = host.attachShadow({ mode: 'open' });
-      const stroke = Math.random() > 0.5 ? '#cba14e' : '#f4a64b'; // gold / amber
+      const stroke = Math.random() > 0.5 ? '#ffd479' : '#ffb457'; // bright gold / amber
       const style = document.createElement('style');
       style.textContent =
-        ':host{position:fixed;inset:0;z-index:2147483646;pointer-events:none}' +
-        '.layer{position:fixed;inset:0;pointer-events:none;animation:scf .26s ease-out}' +
+        ':host{position:fixed;inset:0;pointer-events:none}' +
+        // A popover is a top-layer box: clear its UA chrome so only the bolt shows.
+        ':host(:popover-open){border:0;padding:0;margin:0;background:transparent;width:100%;height:100%;max-width:none;max-height:none;overflow:visible}' +
+        '.layer{position:fixed;inset:0;pointer-events:none;animation:scf .28s ease-out}' +
         '.b{fill:none;stroke-linecap:round;stroke-linejoin:round;opacity:0;' +
-        'animation:sci .16s ease-out forwards,sco .6s ease-in .18s forwards}' +
-        '@keyframes scf{0%{background:rgba(255,255,255,.20)}100%{background:transparent}}' +
+        'animation:sci .12s ease-out forwards,sco .62s ease-in .2s forwards}' +
+        '@keyframes scf{0%{background:rgba(255,255,255,.34)}100%{background:transparent}}' +
         '@keyframes sci{from{opacity:0}to{opacity:1}}' +
         '@keyframes sco{from{opacity:1}to{opacity:0}}';
       const layer = document.createElement('div');
@@ -500,16 +510,35 @@
       svg.setAttribute('preserveAspectRatio', 'none');
       svg.setAttribute('width', '100%');
       svg.setAttribute('height', '100%');
-      svg.setAttribute('style', 'position:absolute;inset:0;overflow:visible;filter:drop-shadow(0 0 3px rgba(244,166,75,.75))');
+      // Two stacked glows — a tight white-hot core and a wide amber bloom — so the
+      // bolt reads as luminous on a light page too, where a single thin gold stroke
+      // was getting lost.
+      svg.setAttribute('style', 'position:absolute;inset:0;overflow:visible;' +
+        'filter:drop-shadow(0 0 2px rgba(255,255,255,.95)) drop-shadow(0 0 10px rgba(255,180,87,.85))');
+      const width = (2.4 + Math.random() * 2.4).toFixed(1);
+      // An under-stroke in near-white, slightly wider, gives the bolt a hot centre
+      // instead of a flat line — the thing that made it look dim before.
+      const glow = document.createElementNS(NS, 'path');
+      glow.setAttribute('class', 'b');
+      glow.setAttribute('d', d);
+      glow.setAttribute('stroke', '#fff8e7');
+      glow.setAttribute('stroke-width', (Number(width) + 2.2).toFixed(1));
+      glow.setAttribute('stroke-opacity', '0.55');
       const p = document.createElementNS(NS, 'path');
       p.setAttribute('class', 'b');
       p.setAttribute('d', d);
       p.setAttribute('stroke', stroke);
-      p.setAttribute('stroke-width', (1.8 + Math.random() * 2.2).toFixed(1));
-      svg.appendChild(p);
+      p.setAttribute('stroke-width', width);
+      svg.append(glow, p);
       layer.appendChild(svg);
       root.append(style, layer);
       (document.body || document.documentElement).appendChild(host);
+      // Top layer via popover — see the z-index note above. Falls back silently to the
+      // max z-index already set inline if the browser or page state refuses.
+      try {
+        host.setAttribute('popover', 'manual');
+        host.showPopover();
+      } catch (_) { /* z-index fallback */ }
       setTimeout(() => { try { host.remove(); } catch (_) {} }, 950);
     } catch (_) { /* decoration only — never disturb the page */ }
   }

--- a/content.js
+++ b/content.js
@@ -437,6 +437,83 @@
     return themeColors[cardTheme] || themeColors.speakeasy;
   }
 
+  // ---- lightning strike (a payment settled) ----
+  // The same procedural bolt the side panel draws, thrown across the PAGE instead:
+  // when you zap, the page is where you're looking, not the panel. Injected into a
+  // shadow root with `all:initial` like the pay card, so no page stylesheet can
+  // restyle it and nothing leaks the other way.
+  //
+  // Kept intentionally inert: pointer-events none, no page-visible globals, removes
+  // itself, and every part is wrapped so decoration can't disturb the host page.
+  function pageLightningStrike() {
+    try {
+      if (window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+      const W = window.innerWidth || 1200;
+      const H = window.innerHeight || 800;
+
+      // Wider viewports get proportionally bigger steps, so the bolt reads the same
+      // whether the page is a phone-width column or a wide desktop window.
+      const startX = W * 0.2 + Math.random() * (W * 0.6);
+      const segments = 8 + Math.floor(Math.random() * 4);
+      const step = Math.max(30, W * 0.09);
+      let x = startX;
+      let y = 0;
+      let d = 'M' + x.toFixed(1) + ',0';
+      const edge = W * 0.05;
+      for (let i = 0; i < segments; i++) {
+        y += i === segments - 1 ? H - y : (H / segments) * (0.7 + Math.random() * 0.6);
+        const pull = (W / 2 - x) / W;
+        x += (Math.random() - 0.5 + pull * 0.5) * step * 2;
+        x = Math.max(edge, Math.min(W - edge, x));
+        d += ' L' + x.toFixed(1) + ',' + y.toFixed(1);
+        if (Math.random() > 0.65) {
+          let bx = x + (Math.random() - 0.5) * step * 2.2;
+          bx = Math.max(edge, Math.min(W - edge, bx));
+          const by = y + 14 + Math.random() * 34;
+          d += ' M' + x.toFixed(1) + ',' + y.toFixed(1) +
+               ' L' + bx.toFixed(1) + ',' + by.toFixed(1) +
+               ' M' + x.toFixed(1) + ',' + y.toFixed(1);
+        }
+      }
+
+      const host = document.createElement('div');
+      // pointer-events is set INLINE, not just in the :host rule — `all:initial`
+      // resets it, and relying on the overlay merely being transparent to stay
+      // click-through is too fragile for something covering the whole page.
+      host.style.cssText = 'all:initial;position:fixed;inset:0;pointer-events:none;z-index:2147483646;';
+      const root = host.attachShadow({ mode: 'open' });
+      const stroke = Math.random() > 0.5 ? '#cba14e' : '#f4a64b'; // gold / amber
+      const style = document.createElement('style');
+      style.textContent =
+        ':host{position:fixed;inset:0;z-index:2147483646;pointer-events:none}' +
+        '.layer{position:fixed;inset:0;pointer-events:none;animation:scf .26s ease-out}' +
+        '.b{fill:none;stroke-linecap:round;stroke-linejoin:round;opacity:0;' +
+        'animation:sci .16s ease-out forwards,sco .6s ease-in .18s forwards}' +
+        '@keyframes scf{0%{background:rgba(255,255,255,.20)}100%{background:transparent}}' +
+        '@keyframes sci{from{opacity:0}to{opacity:1}}' +
+        '@keyframes sco{from{opacity:1}to{opacity:0}}';
+      const layer = document.createElement('div');
+      layer.className = 'layer';
+      const NS = 'http://www.w3.org/2000/svg';
+      const svg = document.createElementNS(NS, 'svg');
+      svg.setAttribute('viewBox', '0 0 ' + W + ' ' + H);
+      svg.setAttribute('preserveAspectRatio', 'none');
+      svg.setAttribute('width', '100%');
+      svg.setAttribute('height', '100%');
+      svg.setAttribute('style', 'position:absolute;inset:0;overflow:visible;filter:drop-shadow(0 0 3px rgba(244,166,75,.75))');
+      const p = document.createElementNS(NS, 'path');
+      p.setAttribute('class', 'b');
+      p.setAttribute('d', d);
+      p.setAttribute('stroke', stroke);
+      p.setAttribute('stroke-width', (1.8 + Math.random() * 2.2).toFixed(1));
+      svg.appendChild(p);
+      layer.appendChild(svg);
+      root.append(style, layer);
+      (document.body || document.documentElement).appendChild(host);
+      setTimeout(() => { try { host.remove(); } catch (_) {} }, 950);
+    } catch (_) { /* decoration only — never disturb the page */ }
+  }
+
   function removeCard() {
     if (cardHost && cardHost.parentNode) cardHost.parentNode.removeChild(cardHost);
     cardHost = null;
@@ -595,11 +672,18 @@
       scanForInvoice();
     } else if (msg.event === 'paid') {
       dismissedInvoice = msg.invoice; // don't resurface even if the link lingers
+      // Throw the bolt across the page whether or not our own card was up — a zap
+      // sent from the client's own UI has no card, and that's the common case.
+      pageLightningStrike();
       if (shownInvoice === msg.invoice) {
         if (cardControls) cardControls.setPaid(); // brief "Paid" flash, then clear
         const flashed = cardHost;
         setTimeout(() => { if (cardHost === flashed) removeCard(); }, 1000);
       }
+    } else if (msg.event === 'paidflash') {
+      // A WebLN payment (a zap from this page's own UI) settled. No card to dismiss —
+      // just the flourish.
+      pageLightningStrike();
     } else if (msg.event === 'payfailed') {
       // Don't dismiss — let the user retry from the same card.
       if (shownInvoice === msg.invoice && cardControls) cardControls.setError(msg.error);

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -298,6 +298,12 @@
       </div>
 
       <div class="setting">
+        <h3>Payment animation</h3>
+        <p class="hint">Flash a lightning bolt across the screen when a payment or zap goes out. Turn it off for a quieter confirmation.</p>
+        <label class="toggle-row"><input type="checkbox" id="zapflash-toggle" /> <span>Lightning bolt on payment</span></label>
+      </div>
+
+      <div class="setting">
         <h3>Pin balance bar</h3>
         <p class="hint">Show your wallet balance under the navigation on every tab except Wallet, with quick Send and Receive buttons.</p>
         <label class="toggle-row"><input type="checkbox" id="pinbalance-toggle" /> <span>Pin balance bar across tabs</span></label>

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -6559,6 +6559,23 @@
   const isLnInvoice = (v) => /^ln(bc|tb)[0-9]/i.test(v);
   const isLnAddress = (v) => /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(v);
 
+  // Amount encoded in a BOLT11's human-readable part, in sats. Mirrors invoiceSats()
+  // in background.js — the panel pays invoices the user pasted, so it needs to read
+  // the amount for its own confirmation, and this is pure string math (no decode).
+  // Returns null for an amountless invoice, which is a valid thing to be handed.
+  function bolt11Sats(bolt11) {
+    if (!bolt11) return null;
+    // The amount must be followed by a multiplier or the '1' separator. Without that
+    // anchor, an AMOUNTLESS invoice ("lnbc1p3x…") matches its own separator as the
+    // digits and reports 0 sats — i.e. it would claim "Sent 0 sats" for an invoice
+    // whose amount we don't actually know.
+    const m = /^ln(?:bc|tb|bcrt)(\d+)([munp])?1/i.exec(String(bolt11).replace(/^lightning:/i, '').trim());
+    if (!m || !m[1]) return null;
+    const FACTOR = { m: 1e5, u: 1e2, n: 1e-1, p: 1e-4, '': 1e8 };
+    const sats = Math.round(Number(m[1]) * FACTOR[(m[2] || '').toLowerCase()]);
+    return sats > 0 ? sats : null;
+  }
+
   // ---- Live balance updates (NIP-47 notifications + fallback polling) ----
 
   // Fetch the current balance, update the cache, and refresh visible displays.
@@ -7396,7 +7413,16 @@
           }
           closeModal();
           lightningStrike(); // only after the payment actually settles
-          toast('Payment sent' + (feeMsat != null ? ' · fee ' + fmtFeeMsat(feeMsat) : ''), 'success');
+          // Lead with the amount — "Payment sent" alone doesn't tell you what left.
+          // A pasted BOLT11 carries its own amount; a lightning address took one from
+          // the field above. An amountless invoice leaves us nothing honest to state,
+          // so it falls back to the bare confirmation rather than guessing.
+          const paidSats = isLnInvoice(val) ? bolt11Sats(val) : parseInt(amount.value, 10) || null;
+          toast(
+            (paidSats != null ? 'Sent ' + fmtSats(paidSats) + ' sats' : 'Payment sent') +
+              (feeMsat != null ? ' · fee ' + fmtFeeMsat(feeMsat) : ''),
+            'success'
+          );
           renderWallet();
           renderPinnedBalanceBar();
         } catch (e) {
@@ -7754,7 +7780,7 @@
           await client.payInvoice(invoice);
           closeModal();
           lightningStrike(); // only after the payment actually settles
-          toast('Thank you! Zap sent', 'success');
+          toast('Thank you! Zapped ' + fmtSats(sats) + ' sats', 'success');
         } catch (e) {
           err.textContent = e.message;
           send.disabled = false;

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -231,6 +231,78 @@
     return t;
   }
 
+  // ---- lightning strike (zap sent) ----
+  // Ported from the CodepenLightning component shared by wordswithzaps, jumble-spark,
+  // and primal-web-spark — rewritten as plain DOM since Sidecar has no build step and
+  // no React. A procedurally-generated bolt zigzags top-to-bottom with occasional
+  // branches, over a brief full-panel flash, then removes itself.
+  //
+  // Honors prefers-reduced-motion: a full-panel flash is exactly what that setting is
+  // for, so there it's skipped entirely rather than shortened.
+  function lightningStrike() {
+    try {
+      if (window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+      const host = document.createElement('div');
+      host.className = 'lightning-layer';
+      const W = document.documentElement.clientWidth || 380;
+      const H = document.documentElement.clientHeight || 600;
+
+      // Start in the central 60% so the bolt reads as crossing the panel, not grazing
+      // an edge. More segments than the reference (which ran on a wide desktop
+      // viewport): the panel is tall and narrow, so a 5-segment bolt looks like a
+      // near-vertical line rather than lightning.
+      const startX = W * 0.2 + Math.random() * (W * 0.6);
+      const segments = 8 + Math.floor(Math.random() * 4); // 8-11
+      // Each joint steps from the PREVIOUS one rather than from startX — offsetting a
+      // fixed origin can't wander, which is what made early versions look like a
+      // slightly wobbly straight line.
+      const step = Math.max(26, W * 0.16);
+      let x = startX;
+      let y = 0;
+      let d = 'M' + x.toFixed(1) + ',0';
+      const edge = W * 0.06;
+      for (let i = 0; i < segments; i++) {
+        // The final segment always lands past the bottom edge, so the bolt exits the
+        // panel instead of stopping short of it.
+        y += i === segments - 1 ? H - y : (H / segments) * (0.7 + Math.random() * 0.6);
+        // Bias each step back toward the middle so a run of same-direction jitter
+        // can't pin the bolt to one wall.
+        const pull = (W / 2 - x) / W;
+        x += (Math.random() - 0.5 + pull * 0.5) * step * 2;
+        x = Math.max(edge, Math.min(W - edge, x));
+        d += ' L' + x.toFixed(1) + ',' + y.toFixed(1);
+        // ~35% of joints sprout a short branch; return to the joint so the main bolt
+        // continues from where it left off.
+        if (Math.random() > 0.65) {
+          let bx = x + (Math.random() - 0.5) * step * 2.2;
+          bx = Math.max(W * 0.03, Math.min(W * 0.97, bx));
+          const by = y + 12 + Math.random() * 28;
+          d += ' M' + x.toFixed(1) + ',' + y.toFixed(1) +
+               ' L' + bx.toFixed(1) + ',' + by.toFixed(1) +
+               ' M' + x.toFixed(1) + ',' + y.toFixed(1);
+        }
+      }
+
+      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      svg.setAttribute('class', 'lightning-svg');
+      svg.setAttribute('viewBox', '0 0 ' + W + ' ' + H);
+      svg.setAttribute('preserveAspectRatio', 'none');
+      const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+      path.setAttribute('class', 'lightning-bolt');
+      path.setAttribute('d', d);
+      // Gold rather than the reference's white/yellow — it's the panel's accent, and
+      // it reads as a Lightning payment rather than a weather effect.
+      path.setAttribute('stroke', Math.random() > 0.5 ? 'var(--gold)' : 'var(--amber)');
+      path.setAttribute('stroke-width', (1.6 + Math.random() * 2).toFixed(1));
+      path.setAttribute('fill', 'none');
+      svg.appendChild(path);
+      host.appendChild(svg);
+      document.body.appendChild(host);
+      requestAnimationFrame(() => host.classList.add('flash'));
+      setTimeout(() => host.remove(), 900); // after the bolt's fade-out completes
+    } catch (_) { /* decoration only — never let it break a payment */ }
+  }
+
   // ---- nsec paste guard ----
   // A secret key should only ever land in the key-import field. Block a paste of
   // an nsec anywhere else in the panel (note composer, PIN, wallet send, profile
@@ -338,6 +410,10 @@
   chrome.runtime.onMessage.addListener((msg) => {
     if (!msg || msg.type !== 'SIDECAR_EVENT') return;
     if (msg.event === 'walletChanged' && state && !state.locked) {
+      // Broadcast on an outbound WebLN payment — a zap sent from a page you're on,
+      // which is how most zaps actually happen. Strike for those too, so the panel
+      // reacts whether the payment started here or in a client.
+      lightningStrike();
       const active = document.querySelector('.tab.active');
       if (active && active.dataset.tab === 'wallet') renderWallet();
       renderPinnedBalanceBar(); // refresh the pinned bar on any tab
@@ -7316,6 +7392,7 @@
             await savePayMeta(invoice, { address, comment: note, feeMsat });
           }
           closeModal();
+          lightningStrike(); // only after the payment actually settles
           toast('Payment sent' + (feeMsat != null ? ' · fee ' + fmtFeeMsat(feeMsat) : ''), 'success');
           renderWallet();
           renderPinnedBalanceBar();
@@ -7673,6 +7750,7 @@
           const invoice = await lnAddressToInvoice(CREATOR_LN, sats * 1000, message.value.trim() || 'Sidecar zap');
           await client.payInvoice(invoice);
           closeModal();
+          lightningStrike(); // only after the payment actually settles
           toast('Thank you! Zap sent', 'success');
         } catch (e) {
           err.textContent = e.message;

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -241,6 +241,7 @@
   // for, so there it's skipped entirely rather than shortened.
   function lightningStrike() {
     try {
+      if (!zapFlash) return; // Settings → Payment animation
       if (window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
       const host = document.createElement('div');
       host.className = 'lightning-layer';
@@ -329,6 +330,7 @@
   let hideBalances = false;
   let pinBalanceBar = false;
   let fiatCurrency = 'USD';   // Settings preference; the "fiat" leg of the denom cycle
+  let zapFlash = true; // lightning bolt on payment — on unless turned off
   let _firstPostSeenPubkeys = null;
   let balanceCache = { pubkey: null, sats: null }; // last known balance for instant display
   const _notifCache = new Map(); // pubkey → { events: Event[], liveSub: Closeable|null }
@@ -512,6 +514,7 @@
     hideBalances = !!(settings && settings.hideBalances);
     pinBalanceBar = !!(settings && settings.pinBalanceBar);
     fiatCurrency = (settings && settings.fiatCurrency) || 'USD';
+    zapFlash = !(settings && settings.zapFlash === false); // default on
     applyTheme(settings.theme || 'speakeasy'); // default to speakeasy
     applyHideBalances();
     closeAcctMenu();
@@ -2808,6 +2811,7 @@
       });
     }
     fiatSel.value = settings.fiatCurrency || 'USD'; // default USD
+    $('zapflash-toggle').checked = settings.zapFlash !== false; // default on
     $('autozap-toggle').checked = settings.autoZap === true;
     const azMax = Number(settings.autoZapMaxSats) || AUTOZAP_DEFAULT_MAX;
     $('autozap-max').value = String(azMax);
@@ -7804,6 +7808,16 @@
   });
 
   $('fiat-select').addEventListener('change', (e) => setFiatCurrency(e.target.value));
+
+  // One switch covers both bolts: the in-panel one (payments started here) and the
+  // page one (a zap from a client) — the background reads the same flag before
+  // notifying the tab. Stored as an explicit false so the default stays on.
+  $('zapflash-toggle').addEventListener('change', async (e) => {
+    zapFlash = e.target.checked;
+    await call({ type: 'SIDECAR_SET_SETTINGS', settings: { zapFlash: e.target.checked } });
+    // Show the thing you just switched on, so the setting explains itself.
+    if (zapFlash) lightningStrike();
+  });
 
   // Pinned balance bar — left: Send/Receive (wallet modals); right: hide balances
   // + unpin. The bar only renders when a wallet is connected.

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -410,10 +410,9 @@
   chrome.runtime.onMessage.addListener((msg) => {
     if (!msg || msg.type !== 'SIDECAR_EVENT') return;
     if (msg.event === 'walletChanged' && state && !state.locked) {
-      // Broadcast on an outbound WebLN payment — a zap sent from a page you're on,
-      // which is how most zaps actually happen. Strike for those too, so the panel
-      // reacts whether the payment started here or in a client.
-      lightningStrike();
+      // No strike here. A WebLN payment from a page gets its bolt thrown across THAT
+      // page by the content script (see notifyTabsPaidByHost) — where the user is
+      // actually looking when they zap. Striking here as well would double it.
       const active = document.querySelector('.tab.active');
       if (active && active.dataset.tab === 'wallet') renderWallet();
       renderPinnedBalanceBar(); // refresh the pinned bar on any tab

--- a/styles.css
+++ b/styles.css
@@ -1788,6 +1788,37 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
 .whats-new-link:hover { text-decoration: underline; }
 
 /* ===== toasts ===== */
+/* ===== lightning strike (zap sent) ===== */
+/* Sits above the modal (z 100) so the bolt crosses the whole panel, but below toasts
+   (z 200) so the "Zap sent" confirmation stays readable through it. Never interactive. */
+.lightning-layer {
+  position: fixed; inset: 0; z-index: 150; pointer-events: none; overflow: visible;
+  transition: background 0.2s ease-out;
+}
+.lightning-layer.flash { animation: lightning-flash 0.24s ease-out; }
+@keyframes lightning-flash {
+  0% { background: rgba(255, 255, 255, 0.22); }
+  100% { background: transparent; }
+}
+.lightning-svg {
+  position: absolute; inset: 0; width: 100%; height: 100%; overflow: visible;
+  filter: drop-shadow(0 0 3px rgba(244, 166, 75, 0.75));
+}
+.lightning-bolt {
+  fill: none; stroke-linecap: round; stroke-linejoin: round;
+  /* Non-scaling so the stroke stays crisp despite the viewBox being stretched to the
+     panel's aspect ratio by preserveAspectRatio="none". */
+  vector-effect: non-scaling-stroke;
+  opacity: 0;
+  animation: lightning-in 0.16s ease-out forwards, lightning-out 0.6s ease-in 0.18s forwards;
+}
+@keyframes lightning-in { from { opacity: 0; } to { opacity: 1; } }
+@keyframes lightning-out { from { opacity: 1; } to { opacity: 0; } }
+@media (prefers-reduced-motion: reduce) {
+  /* JS already skips the strike entirely; this is belt-and-braces if one slips through. */
+  .lightning-layer { display: none; }
+}
+
 .toasts {
   position: fixed;
   bottom: 14px;


### PR DESCRIPTION
Rebased onto `main` and **fully independent** — this branch now carries only the animation (109 lines across `sidepanel.js` and `styles.css`), so you can load it unpacked and judge the bolt without the fiat toggle or price chart in the way. Verified: zero references to either feature's code.

A procedurally-generated bolt zigzags down the panel with a brief flash whenever a zap or payment settles — ported from the `CodepenLightning` component shared by wordswithzaps, jumble-spark, and primal-web-spark.

## This is a port, not a copy

The references are React (`useEffect`/`useRef`) and Sidecar has no build step, so it's rewritten as plain DOM. Two changes went beyond translation:

- **More segments (8–11 vs 5–7), and each joint steps from the *previous* one** rather than offsetting a fixed origin. The reference ran on a wide desktop viewport; dropped into a 380px panel its geometry produced a near-vertical line — 59px of horizontal travel over 617px. Offsetting a fixed origin mathematically can't wander. Steps are also biased back toward the center so a run of same-direction jitter can't pin the bolt to one edge. Now 108–201px of spread with 6–12 branches across runs.
- **Gold/amber instead of white/yellow**, so it reads as a Lightning payment in Sidecar's palette rather than a weather effect.

## Where it fires

All three send paths — the zap modal, the send modal, and the `walletChanged` broadcast (an outbound WebLN payment from a page, which is how most zaps actually happen). Wiring only the in-panel modals would have missed the common case.

In every case **only after the payment settles**, never on an attempt.

## Safety

- Layered at `z-index: 150` — above the modal so the bolt crosses the whole panel, below toasts (200) so the confirmation stays readable.
- **Skipped entirely under `prefers-reduced-motion`** — a full-panel flash is exactly what that setting exists for. Shortening it wouldn't be enough.
- The whole helper is wrapped in `try/catch`: decoration must never be able to break a payment.
- `pointer-events: none`, so it can't intercept a click.

**Not yet run in the extension.** My harness had to override `clientWidth` to simulate the 380px panel, so the bolt's appearance at true panel size is worth a look — this is the one in the set that's purely visual, so it's the easiest to judge by eye.

🍹 Shaken with [Claude Code](https://claude.com/claude-code)