### PR TITLE
feat: warn before signing an event that erases profile data

### DIFF
--- a/background.js
+++ b/background.js
@@ -15,7 +15,7 @@
 // survive-restart machinery below applies equally to both.
 
 if (typeof importScripts === 'function') {
-  importScripts('nostr-tools.js', 'crypto.js', 'keystore.js', 'permissions.js', 'signer.js', 'wallet-budgets.js', 'nwc-client.js', 'relax-grants.js');
+  importScripts('nostr-tools.js', 'crypto.js', 'keystore.js', 'permissions.js', 'signer.js', 'wallet-budgets.js', 'nwc-client.js', 'relax-grants.js', 'replaceable-baseline.js');
 }
 
 const KS = self.SidecarKeystore;
@@ -24,6 +24,7 @@ const SIGNER = self.SidecarSigner;
 const BUDGETS = self.SidecarBudgets;
 const NWC = self.SidecarNWC;
 const RELAX = self.SidecarRelax;
+const BASELINE = self.SidecarBaseline;
 
 const DEFAULT_RELAYS = {
   'wss://nos.lol': { read: true, write: true },
@@ -929,12 +930,26 @@ async function handleNostrRpc(method, params, host, sendResponse, originWindowId
     const relaxEligible = isContentSign && !RELAX.isControlKind(signKind);
     const relaxActive = relaxEligible && (await RELAX.has(host, activePubkey));
     if (relaxActive) sharedIdentity = false;
+
+    // Destructive-overwrite check. Kinds 0/3/10000 REPLACE their previous version, so
+    // a client publishing a short or empty list wipes the real one everywhere. Compare
+    // against what Sidecar last signed and, if this looks like a wipe, always confirm —
+    // even on a trusted site and even mid relax window, on the same reasoning that
+    // exempts the account/wallet-control kinds: losing your whole follow list is not
+    // something to auto-approve. Purely local state, so it costs no network time.
+    // Fails open (null) — it can raise a confirm, never suppress one.
+    const destructive = method === 'signEvent' && !isRelayAuth
+      ? await BASELINE.check(activePubkey, signEvent)
+      : null;
+
     // A shared-identity content sign always confirms, regardless of trust tier —
     // unless it's a coalesced app-data sign, under an active relax window, etc.
-    const needApproval =
-      coalesced || appDataAutoAllow || decryptCoalesced || relaxActive
-        ? false
-        : ((status === 'ask' && !isRelayAuth) || sharedIdentity);
+    // A destructive overwrite overrides every skip.
+    const needApproval = destructive
+      ? true
+      : (coalesced || appDataAutoAllow || decryptCoalesced || relaxActive
+          ? false
+          : ((status === 'ask' && !isRelayAuth) || sharedIdentity));
 
     // Every getPublicKey is a login, and a login is the safe moment to pick an
     // identity: whatever pubkey we return is the identity the site adopts from
@@ -987,6 +1002,7 @@ async function handleNostrRpc(method, params, host, sendResponse, originWindowId
         needApproval,
         sharedIdentity,
         relaxEligible,
+        destructive, // null, or { kind, type, from, to, lost, fields, message }
         level: await PERMS.getLevel(activePubkey, host),
         otherAccounts: otherAccounts && otherAccounts.length ? otherAccounts : null,
       }, originWindowId);
@@ -1030,6 +1046,15 @@ async function handleNostrRpc(method, params, host, sendResponse, originWindowId
     } else {
       const privBytes = needsKey ? await KS.getPrivkey(activePubkey) : null;
       result = await SIGNER.perform(method, params, privBytes, activePubkey);
+    }
+
+    // The user approved this replaceable overwrite, so it becomes the new baseline —
+    // otherwise a deliberate list cut would keep re-warning against the old size on
+    // every subsequent edit. Recorded from the SIGNED event so created_at is the one
+    // that actually went out. Best-effort: a bookkeeping failure must not fail a sign
+    // that already succeeded.
+    if (method === 'signEvent' && !isRelayAuth && result && BASELINE.isTracked(result.kind)) {
+      try { await BASELINE.record(activePubkey, result, result.created_at || 0); } catch (_) {}
     }
 
     // Pin this host to the account it just successfully used. Only an explicit
@@ -1759,6 +1784,7 @@ async function handleControl(message, sendResponse) {
         await PERMS.clearAccount(message.pubkey);
         await BUDGETS.clearAccount(message.pubkey);
         await clearSiteAccountsForPubkey(message.pubkey);
+        await BASELINE.forget(message.pubkey); // don't leave overwrite baselines behind
         const acts = (await sget(ACTIVITY_KEY))[ACTIVITY_KEY] || [];
         await sset({ [ACTIVITY_KEY]: acts.filter((e) => e.pubkey !== message.pubkey) });
         break;
@@ -2121,6 +2147,16 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   // "End now" button revokes one. Extension-page only (not in CONTENT_OK).
   if (message.type === 'SIDECAR_GET_RELAX') {
     RELAX.active().then((result) => sendResponse({ ok: true, result }));
+    return true; // async response
+  }
+  // The panel seeds an overwrite baseline from a version it fetched off relays, so a
+  // fresh install isn't blind until its first sign of that kind. recordIfNewer means a
+  // late-arriving older relay copy can't clobber what Sidecar itself just signed.
+  // Extension-page only (not in CONTENT_OK) — a page must never write these.
+  if (message.type === 'SIDECAR_SEED_BASELINE') {
+    BASELINE.recordIfNewer(message.pubkey, message.event, (message.event && message.event.created_at) || 0)
+      .then((updated) => sendResponse({ ok: true, result: updated }))
+      .catch(() => sendResponse({ ok: true, result: false }));
     return true; // async response
   }
   if (message.type === 'SIDECAR_REVOKE_RELAX') {

--- a/manifest.json
+++ b/manifest.json
@@ -25,6 +25,7 @@
       "wallet-budgets.js",
       "nwc-client.js",
       "relax-grants.js",
+      "replaceable-baseline.js",
       "jsqr.js",
       "background.js"
     ]

--- a/prompt.html
+++ b/prompt.html
@@ -170,15 +170,17 @@
     }
     /* Reject inside the warning, styled as the affirmative action — the red here means
        "keep my data". The acknowledgement is deliberately quieter. */
-    .destructive-warn-actions { display: flex; flex-direction: column; gap: 7px; margin-top: 11px; }
+    .destructive-warn-actions { display: flex; gap: 8px; margin-top: 11px; }
     .destructive-warn-reject {
-      width: 100%; padding: 9px 12px; border-radius: 8px; cursor: pointer;
+      flex: 1.3; padding: 9px 12px; border-radius: 8px; cursor: pointer;
       background: #f0566b; border: 1px solid #f0566b; color: #fff;
       font-family: inherit; font-size: 13px; font-weight: 700;
+      display: inline-flex; align-items: center; justify-content: center; gap: 6px;
     }
+    .destructive-warn-reject svg { width: 14px; height: 14px; flex-shrink: 0; }
     .destructive-warn-reject:hover { filter: brightness(1.08); }
     .destructive-warn-ack {
-      width: 100%; padding: 7px 12px; border-radius: 8px; cursor: pointer;
+      flex: 1; padding: 7px 12px; border-radius: 8px; cursor: pointer;
       background: transparent; border: 1px solid var(--border-strong); color: var(--muted);
       font-family: inherit; font-size: 12px;
     }

--- a/prompt.html
+++ b/prompt.html
@@ -148,19 +148,23 @@
       color: #ffb38a; font-size: 12px; text-align: left;
     }
     /* Destructive replaceable overwrite — louder than .kind-warn above, which only
-       says "unusual kind". This one means data you already have is about to be erased,
-       so it borrows the error red. Mirrors .destructive-warn in styles.css; this window
-       carries its own styles rather than loading that file. */
+       says "unusual kind". This means data you already have is about to be erased.
+       Set as an editorial aside (rule + Playfair headline) rather than a nested red
+       box, which read as a stray browser error inside the preview card. Mirrors
+       .destructive-warn in styles.css; this window carries its own styles. */
     .destructive-warn {
-      margin-top: 10px; padding: 10px 12px; border-radius: 9px; text-align: left;
-      background: rgba(240, 86, 107, 0.1); border: 1px solid rgba(240, 86, 107, 0.4);
+      margin-top: 12px; padding: 1px 0 1px 12px; text-align: left;
+      border-left: 2px solid #f0566b;
     }
-    .destructive-warn-title { color: #f0566b; font-weight: 700; font-size: 12.5px; }
-    .destructive-warn-body {
-      margin: 6px 0 0; color: var(--text); font-size: 12.5px; line-height: 1.45; font-weight: 600;
+    .destructive-warn-title {
+      display: flex; align-items: center; gap: 6px;
+      font-family: var(--font-display); font-weight: 700; font-size: 15px;
+      color: #f0566b; letter-spacing: 0.01em; margin-bottom: 3px;
     }
+    .destructive-warn-title svg { width: 14px; height: 14px; flex-shrink: 0; }
+    .destructive-warn-body { margin: 0; color: var(--text); font-size: 13px; line-height: 1.5; }
     .destructive-warn-hint {
-      margin: 5px 0 0; color: var(--muted); font-size: 11.5px; line-height: 1.4;
+      margin: 5px 0 0; color: var(--faint); font-size: 11.5px; line-height: 1.45;
     }
     .info-note {
       margin-bottom: 16px; padding: 9px 11px; border-radius: 8px;

--- a/prompt.html
+++ b/prompt.html
@@ -163,8 +163,10 @@
     }
     .destructive-warn-title svg { width: 14px; height: 14px; flex-shrink: 0; }
     .destructive-warn-body { margin: 0; color: var(--text); font-size: 13px; line-height: 1.5; }
+    /* --muted, not --faint: --faint fails WCAG AA contrast in every theme at this
+       size. See the matching note in styles.css. */
     .destructive-warn-hint {
-      margin: 5px 0 0; color: var(--faint); font-size: 11.5px; line-height: 1.45;
+      margin: 6px 0 0; color: var(--muted); font-size: 12.5px; line-height: 1.5;
     }
     .info-note {
       margin-bottom: 16px; padding: 9px 11px; border-radius: 8px;

--- a/prompt.html
+++ b/prompt.html
@@ -168,6 +168,25 @@
     .destructive-warn-hint {
       margin: 6px 0 0; color: var(--muted); font-size: 12.5px; line-height: 1.5;
     }
+    /* Reject inside the warning, styled as the affirmative action — the red here means
+       "keep my data". The acknowledgement is deliberately quieter. */
+    .destructive-warn-actions { display: flex; flex-direction: column; gap: 7px; margin-top: 11px; }
+    .destructive-warn-reject {
+      width: 100%; padding: 9px 12px; border-radius: 8px; cursor: pointer;
+      background: #f0566b; border: 1px solid #f0566b; color: #fff;
+      font-family: inherit; font-size: 13px; font-weight: 700;
+    }
+    .destructive-warn-reject:hover { filter: brightness(1.08); }
+    .destructive-warn-ack {
+      width: 100%; padding: 7px 12px; border-radius: 8px; cursor: pointer;
+      background: transparent; border: 1px solid var(--border-strong); color: var(--muted);
+      font-family: inherit; font-size: 12px;
+    }
+    .destructive-warn-ack:hover { color: var(--text); border-color: var(--muted); }
+    .destructive-warn-unlocked { margin: 9px 0 0; color: var(--muted); font-size: 12px; font-style: italic; }
+    .approval-locked #allow, .approval-locked #trust {
+      opacity: 0.4; cursor: not-allowed; filter: grayscale(0.5);
+    }
     .info-note {
       margin-bottom: 16px; padding: 9px 11px; border-radius: 8px;
       background: rgba(167, 139, 250, 0.08); border: 1px solid rgba(167, 139, 250, 0.22);

--- a/prompt.html
+++ b/prompt.html
@@ -170,17 +170,17 @@
     }
     /* Reject inside the warning, styled as the affirmative action — the red here means
        "keep my data". The acknowledgement is deliberately quieter. */
-    .destructive-warn-actions { display: flex; gap: 8px; margin-top: 11px; }
+    .destructive-warn-actions { display: flex; flex-direction: column; gap: 7px; margin-top: 11px; }
+    /* Uppercased in CSS so screen readers still announce "Don't allow". */
     .destructive-warn-reject {
-      flex: 1.3; padding: 9px 12px; border-radius: 8px; cursor: pointer;
+      width: 100%; padding: 9px 12px; border-radius: 8px; cursor: pointer;
       background: #f0566b; border: 1px solid #f0566b; color: #fff;
       font-family: inherit; font-size: 13px; font-weight: 700;
-      display: inline-flex; align-items: center; justify-content: center; gap: 6px;
+      text-transform: uppercase; letter-spacing: 0.06em;
     }
-    .destructive-warn-reject svg { width: 14px; height: 14px; flex-shrink: 0; }
     .destructive-warn-reject:hover { filter: brightness(1.08); }
     .destructive-warn-ack {
-      flex: 1; padding: 7px 12px; border-radius: 8px; cursor: pointer;
+      width: 100%; padding: 7px 12px; border-radius: 8px; cursor: pointer;
       background: transparent; border: 1px solid var(--border-strong); color: var(--muted);
       font-family: inherit; font-size: 12px;
     }

--- a/prompt.html
+++ b/prompt.html
@@ -147,6 +147,21 @@
       background: rgba(255, 179, 138, 0.1); border: 1px solid rgba(255, 179, 138, 0.3);
       color: #ffb38a; font-size: 12px; text-align: left;
     }
+    /* Destructive replaceable overwrite — louder than .kind-warn above, which only
+       says "unusual kind". This one means data you already have is about to be erased,
+       so it borrows the error red. Mirrors .destructive-warn in styles.css; this window
+       carries its own styles rather than loading that file. */
+    .destructive-warn {
+      margin-top: 10px; padding: 10px 12px; border-radius: 9px; text-align: left;
+      background: rgba(240, 86, 107, 0.1); border: 1px solid rgba(240, 86, 107, 0.4);
+    }
+    .destructive-warn-title { color: #f0566b; font-weight: 700; font-size: 12.5px; }
+    .destructive-warn-body {
+      margin: 6px 0 0; color: var(--text); font-size: 12.5px; line-height: 1.45; font-weight: 600;
+    }
+    .destructive-warn-hint {
+      margin: 5px 0 0; color: var(--muted); font-size: 11.5px; line-height: 1.4;
+    }
     .info-note {
       margin-bottom: 16px; padding: 9px 11px; border-radius: 8px;
       background: rgba(167, 139, 250, 0.08); border: 1px solid rgba(167, 139, 250, 0.22);

--- a/prompt.js
+++ b/prompt.js
@@ -284,8 +284,31 @@
         const hint = document.createElement('p');
         hint.className = 'destructive-warn-hint';
         hint.textContent = "If you didn't mean to do this, reject — the version on your relays stays as it is.";
-        box.append(title, body, hint);
+
+        // Reject inside the warning; Allow/Trust disabled until acknowledged. See the
+        // matching note in sidepanel.js — approving normally is muscle memory, and this
+        // is the one prompt where that shouldn't be enough.
+        const actions = document.createElement('div');
+        actions.className = 'destructive-warn-actions';
+        const rejectBtn = document.createElement('button');
+        rejectBtn.className = 'destructive-warn-reject';
+        rejectBtn.textContent = 'Reject — keep my data';
+        rejectBtn.addEventListener('click', () => decide('reject'));
+        const ackBtn = document.createElement('button');
+        ackBtn.className = 'destructive-warn-ack';
+        ackBtn.textContent = 'I understand, let me approve it';
+        ackBtn.addEventListener('click', () => {
+          setLocked(false);
+          ackBtn.remove();
+          const note = document.createElement('p');
+          note.className = 'destructive-warn-unlocked';
+          note.textContent = 'Approval unlocked below.';
+          box.appendChild(note);
+        });
+        actions.append(rejectBtn, ackBtn);
+        box.append(title, body, hint, actions);
         els.preview.appendChild(box);
+        setLocked(true);
       }
       if (ev.content) appendEventContent(els.preview, ev);
       els.preview.classList.remove('hidden');
@@ -545,6 +568,15 @@
     });
   }
 
+  // Disable Allow once + Trust this site while a destructive overwrite is
+  // unacknowledged. Reject is never gated — the safe way out must stay reachable.
+  function setLocked(locked) {
+    if (els.allow) els.allow.disabled = locked;
+    if (els.trust) els.trust.disabled = locked;
+    const footer = els.allow && els.allow.parentNode;
+    if (footer) footer.classList.toggle('approval-locked', locked);
+  }
+
   async function decide(action, opts) {
     els.error.textContent = '';
     // Unlock first if needed (Allow once / Trust / Relax / Pay only).
@@ -602,7 +634,9 @@
   els.reject.addEventListener('click', () => decide('reject'));
   els.pin &&
     els.pin.addEventListener('keydown', (e) => {
-      if (e.key === 'Enter') decide('once');
+      // Respect the destructive lock — Enter bypasses the disabled Allow button
+      // otherwise. Same guard as the panel's PIN field.
+      if (e.key === 'Enter' && !els.allow.disabled) decide('once');
     });
 
   init();

--- a/prompt.js
+++ b/prompt.js
@@ -296,7 +296,7 @@
         rejectBtn.addEventListener('click', () => decide('reject'));
         const ackBtn = document.createElement('button');
         ackBtn.className = 'destructive-warn-ack';
-        ackBtn.textContent = 'Approve anyway';
+        ackBtn.textContent = 'I understand';
         ackBtn.addEventListener('click', () => {
           setLocked(false);
           ackBtn.remove();

--- a/prompt.js
+++ b/prompt.js
@@ -292,22 +292,7 @@
         actions.className = 'destructive-warn-actions';
         const rejectBtn = document.createElement('button');
         rejectBtn.className = 'destructive-warn-reject';
-        const stopIcon = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-        stopIcon.setAttribute('viewBox', '0 0 24 24');
-        stopIcon.setAttribute('fill', 'none');
-        stopIcon.setAttribute('stroke', 'currentColor');
-        stopIcon.setAttribute('stroke-width', '2');
-        stopIcon.setAttribute('stroke-linecap', 'round');
-        stopIcon.setAttribute('stroke-linejoin', 'round');
-        stopIcon.setAttribute('aria-hidden', 'true');
-        stopIcon.innerHTML =
-          '<path d="M9 11V5.5a1.5 1.5 0 0 1 3 0V11"></path>' +
-          '<path d="M12 11V4.5a1.5 1.5 0 0 1 3 0V11"></path>' +
-          '<path d="M15 11V6.5a1.5 1.5 0 0 1 3 0V13a7 7 0 0 1-7 7h-1a6 6 0 0 1-5.2-3l-2.2-3.8a1.5 1.5 0 0 1 2.6-1.5L6 14"></path>' +
-          '<path d="M9 11V9.5a1.5 1.5 0 0 0-3 0V14"></path>';
-        const rejectLabel = document.createElement('span');
-        rejectLabel.textContent = "Don't allow";
-        rejectBtn.append(stopIcon, rejectLabel);
+        rejectBtn.textContent = "Don't allow";
         rejectBtn.addEventListener('click', () => decide('reject'));
         const ackBtn = document.createElement('button');
         ackBtn.className = 'destructive-warn-ack';

--- a/prompt.js
+++ b/prompt.js
@@ -264,7 +264,20 @@
         box.className = 'destructive-warn';
         const title = document.createElement('div');
         title.className = 'destructive-warn-title';
-        title.textContent = 'This erases data';
+        // Glyph as well as colour — the panel's copy has one, and red text alone is
+        // not a signal for a red-green colourblind user.
+        const warnIcon = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+        warnIcon.setAttribute('viewBox', '0 0 24 24');
+        warnIcon.setAttribute('fill', 'none');
+        warnIcon.setAttribute('stroke', 'currentColor');
+        warnIcon.setAttribute('stroke-width', '2');
+        warnIcon.setAttribute('stroke-linecap', 'round');
+        warnIcon.setAttribute('aria-hidden', 'true');
+        warnIcon.innerHTML =
+          '<circle cx="12" cy="12" r="10"></circle>' +
+          '<line x1="12" y1="8" x2="12" y2="12"></line>' +
+          '<line x1="12" y1="16" x2="12.01" y2="16"></line>';
+        title.append(warnIcon, document.createTextNode('This action erases data'));
         const body = document.createElement('p');
         body.className = 'destructive-warn-body';
         body.textContent = data.destructive.message;

--- a/prompt.js
+++ b/prompt.js
@@ -255,6 +255,25 @@
         warn.textContent = warning;
         els.preview.appendChild(warn);
       }
+      // Destructive replaceable overwrite (see replaceable-baseline.js). The background
+      // resolves this from local state, so this window gets it without needing relay
+      // access of its own — the reason the check isn't a relay fetch at prompt time.
+      // Built with DOM calls, not innerHTML: the text is ours, but this is a signer.
+      if (data.destructive && data.destructive.message) {
+        const box = document.createElement('div');
+        box.className = 'destructive-warn';
+        const title = document.createElement('div');
+        title.className = 'destructive-warn-title';
+        title.textContent = 'This erases data';
+        const body = document.createElement('p');
+        body.className = 'destructive-warn-body';
+        body.textContent = data.destructive.message;
+        const hint = document.createElement('p');
+        hint.className = 'destructive-warn-hint';
+        hint.textContent = "If you didn't mean to do this, reject — the version on your relays stays as it is.";
+        box.append(title, body, hint);
+        els.preview.appendChild(box);
+      }
       if (ev.content) appendEventContent(els.preview, ev);
       els.preview.classList.remove('hidden');
     } else if (data.method === 'nip04.decrypt' || data.method === 'nip44.decrypt') {

--- a/prompt.js
+++ b/prompt.js
@@ -283,7 +283,7 @@
         body.textContent = data.destructive.message;
         const hint = document.createElement('p');
         hint.className = 'destructive-warn-hint';
-        hint.textContent = "If you didn't mean to do this, reject — the version on your relays stays as it is.";
+        hint.textContent = "If you didn't mean to do this, don't allow it — the version on your relays stays as it is.";
 
         // Reject inside the warning; Allow/Trust disabled until acknowledged. See the
         // matching note in sidepanel.js — approving normally is muscle memory, and this
@@ -292,11 +292,26 @@
         actions.className = 'destructive-warn-actions';
         const rejectBtn = document.createElement('button');
         rejectBtn.className = 'destructive-warn-reject';
-        rejectBtn.textContent = 'Reject — keep my data';
+        const stopIcon = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+        stopIcon.setAttribute('viewBox', '0 0 24 24');
+        stopIcon.setAttribute('fill', 'none');
+        stopIcon.setAttribute('stroke', 'currentColor');
+        stopIcon.setAttribute('stroke-width', '2');
+        stopIcon.setAttribute('stroke-linecap', 'round');
+        stopIcon.setAttribute('stroke-linejoin', 'round');
+        stopIcon.setAttribute('aria-hidden', 'true');
+        stopIcon.innerHTML =
+          '<path d="M9 11V5.5a1.5 1.5 0 0 1 3 0V11"></path>' +
+          '<path d="M12 11V4.5a1.5 1.5 0 0 1 3 0V11"></path>' +
+          '<path d="M15 11V6.5a1.5 1.5 0 0 1 3 0V13a7 7 0 0 1-7 7h-1a6 6 0 0 1-5.2-3l-2.2-3.8a1.5 1.5 0 0 1 2.6-1.5L6 14"></path>' +
+          '<path d="M9 11V9.5a1.5 1.5 0 0 0-3 0V14"></path>';
+        const rejectLabel = document.createElement('span');
+        rejectLabel.textContent = "Don't allow";
+        rejectBtn.append(stopIcon, rejectLabel);
         rejectBtn.addEventListener('click', () => decide('reject'));
         const ackBtn = document.createElement('button');
         ackBtn.className = 'destructive-warn-ack';
-        ackBtn.textContent = 'I understand, let me approve it';
+        ackBtn.textContent = 'Approve anyway';
         ackBtn.addEventListener('click', () => {
           setLocked(false);
           ackBtn.remove();

--- a/prompt.js
+++ b/prompt.js
@@ -350,9 +350,12 @@
     // hatch for the shared-host per-sign confirm, and a middle rung between Allow
     // once and Trust on any ask-tier site. Not for payments, decrypts, relay-auth,
     // or a pure unlock (those have no approval to skip).
+    // Also not on a destructive overwrite — see the matching note in sidepanel.js:
+    // approving the wipe makes the wiped list the new baseline, so a window granted
+    // here would let the next overwrite through unwarned.
     const isContentSign =
       data.method === 'signEvent' || data.method === 'nip04.encrypt' || data.method === 'nip44.encrypt';
-    if (data.needApproval && isContentSign && !isPayment) {
+    if (data.needApproval && isContentSign && !isPayment && !data.destructive) {
       els.relaxRow.classList.remove('hidden');
       els.relaxRow.querySelectorAll('.relax-chip').forEach((chip) => {
         chip.addEventListener('click', () =>

--- a/replaceable-baseline.js
+++ b/replaceable-baseline.js
@@ -1,0 +1,219 @@
+// Sidecar — destructive-overwrite detection for replaceable events (isolated module).
+//
+// Kinds 0 (profile), 3 (follows) and 10000 (mute list) are REPLACEABLE: the event
+// being signed wholly overwrites the previous one on every relay. A buggy or naive
+// client that publishes a short/empty list silently destroys the real one — the most
+// common data-loss complaint on Nostr, and the reason Sidecar already ships follow-list
+// RECOVERY. This module is the prevention half: it warns before the signature.
+//
+// HOW THE BASELINE IS OBTAINED — this is the crux of the design.
+// The obvious approach (fetch the current version from relays when the prompt opens)
+// doesn't work here: the approval prompt must never block on the network (clients time
+// out with "Signer did not respond in time"), and the standalone prompt window has no
+// relay access at all — it only talks to the background. So instead we keep a LOCAL
+// baseline: whatever Sidecar itself last signed for this (account, kind). The check is
+// then pure local state — synchronous, offline, and identical on both prompt surfaces.
+//
+// The panel, which does have relay access, can seed baselines from work it already
+// does (see recordFromEvent) so a fresh install isn't blind until its first sign.
+//
+// LIMITS, stated plainly:
+//  - No baseline ⇒ no warning. A first-ever sign of one of these kinds can't be judged.
+//  - A baseline can be stale (something else published a newer version elsewhere).
+//  - Therefore the ABSENCE of a warning NEVER means "this event is safe". This is a
+//    safety net, not a gate. It must never be the only thing standing between a user
+//    and data loss, and it must never block a signature on its own.
+//
+// Isolated (like keystore.js / permissions.js / relax-grants.js) so it can be unit
+// tested against a chrome mock — see test/replaceable-baseline.test.js.
+
+(function () {
+  'use strict';
+
+  const STORAGE_KEY = 'sidecar_replaceable_baseline';
+
+  // Kinds we track. Anything else is none of this module's business.
+  const KIND_FOLLOWS = 3;
+  const KIND_MUTE = 10000;
+  const KIND_PROFILE = 0;
+  const TRACKED = new Set([KIND_PROFILE, KIND_FOLLOWS, KIND_MUTE]);
+
+  // A shrink has to be BOTH proportionally large and numerically meaningful to warn.
+  // Unfollowing a handful of people is routine; losing most of a list is not. Without
+  // the floor, going 3 → 1 follows would cry wolf at the exact moment a new user is
+  // still assembling their list.
+  const SHRINK_RATIO = 0.5;   // warn when over half the entries disappear
+  const SHRINK_FLOOR = 10;    // ...and at least this many are lost
+
+  // Profile fields worth protecting. Deliberately NOT "every field that was there
+  // before": plenty of clients round-trip only the fields they understand, so warning
+  // on any omission would fire on ordinary edits from ordinary clients and train
+  // people to click through — which would defeat the entire point.
+  const PROFILE_FIELDS = ['about', 'picture', 'nip05', 'lud16', 'lud06', 'display_name'];
+
+  function sget(keys) {
+    return new Promise((r) => chrome.storage.local.get(keys, r));
+  }
+  function sset(obj) {
+    return new Promise((r) => chrome.storage.local.set(obj, r));
+  }
+
+  async function all() {
+    return (await sget(STORAGE_KEY))[STORAGE_KEY] || {};
+  }
+  function key(pubkey, kind) { return pubkey + '|' + kind; }
+
+  // Unique lowercase p-tag values — the entry count for kinds 3 and 10000. Deduped
+  // because a list carrying the same pubkey twice isn't two follows. Returns null when
+  // `tags` isn't an array: a malformed event is "unknown", not "an empty list", or a
+  // client sending junk would trigger a full-wipe warning on nothing.
+  function countPTags(ev) {
+    const tags = ev && ev.tags;
+    if (!Array.isArray(tags)) return null;
+    const out = new Set();
+    for (const t of tags) {
+      if (Array.isArray(t) && t[0] === 'p' && typeof t[1] === 'string' && t[1].length === 64) {
+        out.add(t[1].toLowerCase());
+      }
+    }
+    return out.size;
+  }
+
+  // Which PROFILE_FIELDS carry a non-empty value in a kind:0's JSON content.
+  // Unparseable content yields null — "unknown", never "empty", so a client using a
+  // content format we don't understand can't look like field loss.
+  function profileFields(ev) {
+    let obj;
+    try { obj = JSON.parse((ev && ev.content) || ''); } catch (_) { return null; }
+    if (!obj || typeof obj !== 'object') return null;
+    const present = [];
+    for (const f of PROFILE_FIELDS) {
+      const v = obj[f];
+      if (typeof v === 'string' ? v.trim() !== '' : v != null) present.push(f);
+    }
+    return present;
+  }
+
+  // Summarize an event into the shape we persist and compare. Returns null for kinds
+  // we don't track, or when a kind:0's content can't be read.
+  function summarize(ev) {
+    const kind = ev && ev.kind;
+    if (!TRACKED.has(kind)) return null;
+    if (kind === KIND_PROFILE) {
+      const fields = profileFields(ev);
+      if (!fields) return null;
+      return { kind, fields };
+    }
+    const count = countPTags(ev);
+    if (count == null) return null; // malformed — can't judge it
+    return { kind, count };
+  }
+
+  // Record what we just signed (or what the panel observed on relays) as the new
+  // baseline for this account+kind. `ts` is passed in rather than read from the clock
+  // so the caller controls it and tests stay deterministic.
+  async function record(pubkey, ev, ts) {
+    const s = summarize(ev);
+    if (!s || !pubkey) return false;
+    const m = await all();
+    m[key(pubkey, s.kind)] = Object.assign({ ts: ts || 0 }, s);
+    await sset({ [STORAGE_KEY]: m });
+    return true;
+  }
+
+  // Only overwrite an existing baseline if `ts` is newer — so the panel seeding from a
+  // relay copy can't clobber a fresher record of what Sidecar itself just signed.
+  async function recordIfNewer(pubkey, ev, ts) {
+    const s = summarize(ev);
+    if (!s || !pubkey) return false;
+    const m = await all();
+    const prev = m[key(pubkey, s.kind)];
+    if (prev && (prev.ts || 0) >= (ts || 0)) return false;
+    m[key(pubkey, s.kind)] = Object.assign({ ts: ts || 0 }, s);
+    await sset({ [STORAGE_KEY]: m });
+    return true;
+  }
+
+  // The check. Returns null when there's nothing to say (untracked kind, no baseline,
+  // or the change looks unremarkable), else a plain-language finding the prompt can
+  // render. Never throws: a broken check must not be able to block a signature.
+  //
+  // { kind, type, from, to, lost, fields, message }
+  async function check(pubkey, ev) {
+    try {
+      const s = summarize(ev);
+      if (!s || !pubkey) return null;
+      const prev = (await all())[key(pubkey, s.kind)];
+      if (!prev || prev.kind !== s.kind) return null; // nothing to compare against
+
+      if (s.kind === KIND_PROFILE) {
+        const before = new Set(prev.fields || []);
+        const after = new Set(s.fields || []);
+        const lost = [...before].filter((f) => !after.has(f));
+        if (!lost.length) return null;
+        return {
+          kind: s.kind, type: 'profile-fields', lost,
+          message: 'This will clear your ' + humanFields(lost) + '.',
+        };
+      }
+
+      const from = prev.count || 0;
+      const to = s.count || 0;
+      if (to >= from) return null; // growing or unchanged
+      const lost = from - to;
+
+      // Emptying a list that had anything in it is always worth flagging, however
+      // small — that's the total-wipe case people actually get burned by.
+      if (to === 0 && from > 0) {
+        return {
+          kind: s.kind, type: 'emptied', from, to, lost,
+          message: s.kind === KIND_FOLLOWS
+            ? 'This will remove all ' + from + ' accounts you follow.'
+            : 'This will clear your mute list of ' + from + ' ' + plural(from, 'account') + '.',
+        };
+      }
+      if (lost >= SHRINK_FLOOR && to <= from * SHRINK_RATIO) {
+        return {
+          kind: s.kind, type: 'shrink', from, to, lost,
+          message: s.kind === KIND_FOLLOWS
+            ? 'This will drop your follows from ' + from + ' to ' + to + '.'
+            : 'This will drop your mute list from ' + from + ' to ' + to + '.',
+        };
+      }
+      return null;
+    } catch (_) {
+      return null; // fail open — never let this stop a signature
+    }
+  }
+
+  function plural(n, word) { return n === 1 ? word : word + 's'; }
+
+  const FIELD_LABELS = {
+    about: 'bio', picture: 'profile picture', nip05: 'verified name',
+    lud16: 'Lightning address', lud06: 'Lightning address', display_name: 'display name',
+  };
+  function humanFields(fields) {
+    const names = [...new Set(fields.map((f) => FIELD_LABELS[f] || f))];
+    if (names.length === 1) return names[0];
+    if (names.length === 2) return names[0] + ' and ' + names[1];
+    return names.slice(0, -1).join(', ') + ', and ' + names[names.length - 1];
+  }
+
+  async function forget(pubkey) {
+    const m = await all();
+    let changed = false;
+    for (const k of Object.keys(m)) {
+      if (k.startsWith(pubkey + '|')) { delete m[k]; changed = true; }
+    }
+    if (changed) await sset({ [STORAGE_KEY]: m });
+  }
+
+  const api = {
+    STORAGE_KEY, TRACKED, PROFILE_FIELDS, SHRINK_RATIO, SHRINK_FLOOR,
+    KIND_PROFILE, KIND_FOLLOWS, KIND_MUTE,
+    summarize, record, recordIfNewer, check, forget,
+    isTracked: (k) => TRACKED.has(k),
+  };
+  if (typeof self !== 'undefined') self.SidecarBaseline = api;
+  if (typeof globalThis !== 'undefined') globalThis.SidecarBaseline = api;
+})();

--- a/replaceable-baseline.js
+++ b/replaceable-baseline.js
@@ -153,7 +153,7 @@
         if (!lost.length) return null;
         return {
           kind: s.kind, type: 'profile-fields', lost,
-          message: 'This will clear your ' + humanFields(lost) + '.',
+          message: 'Clears your ' + humanFields(lost) + '.',
         };
       }
 
@@ -168,16 +168,16 @@
         return {
           kind: s.kind, type: 'emptied', from, to, lost,
           message: s.kind === KIND_FOLLOWS
-            ? 'This will remove all ' + from + ' accounts you follow.'
-            : 'This will clear your mute list of ' + from + ' ' + plural(from, 'account') + '.',
+            ? 'Removes all ' + from + ' accounts you follow.'
+            : 'Clears your mute list of ' + from + ' ' + plural(from, 'account') + '.',
         };
       }
       if (lost >= SHRINK_FLOOR && to <= from * SHRINK_RATIO) {
         return {
           kind: s.kind, type: 'shrink', from, to, lost,
           message: s.kind === KIND_FOLLOWS
-            ? 'This will drop your follows from ' + from + ' to ' + to + '.'
-            : 'This will drop your mute list from ' + from + ' to ' + to + '.',
+            ? 'Drops your follows from ' + from + ' to ' + to + '.'
+            : 'Drops your mute list from ' + from + ' to ' + to + '.',
         };
       }
       return null;

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -7831,7 +7831,7 @@
           h('div', { className: 'destructive-warn' }, [
             h('div', { className: 'destructive-warn-title' }, [
               icon('alert'),
-              h('span', { textContent: 'This erases data' }),
+              h('span', { textContent: 'This action erases data' }),
             ]),
             h('p', { className: 'destructive-warn-body', textContent: data.destructive.message }),
             h('p', {

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -7839,7 +7839,7 @@
         reject.addEventListener('click', () => decideApproval('reject'));
         const ack = h('button', {
           className: 'destructive-warn-ack',
-          textContent: 'Approve anyway',
+          textContent: 'I understand',
         });
         ack.addEventListener('click', () => {
           setApprovalLocked(false);

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -931,6 +931,10 @@
   const PROFILE_TTL = 5 * 60 * 1000;
   const _profileCache = new Map();    // pubkey -> { content, name, picture, expiresAt }
   const _profileInflight = new Map(); // pubkey -> Promise
+  // Follow count per pubkey (see getFollowCount below). Session-lived with no TTL, so
+  // the profile screen's refresh button clears it alongside _profileCache — declared
+  // here rather than beside its function so both caches sit together.
+  const followCountCache = new Map(); // pubkey -> number|null
   function cacheProfile(pubkey, content) {
     const c = content || {};
     const rec = {
@@ -3214,17 +3218,45 @@
     // Following count (fetched from the account's kind:3). Followers are out of
     // scope for now — they require an aggregating index, not a single event.
     const followNum = h('strong', { textContent: '…' });
-    const backupJump = h('button', { className: 'profile-backup-jump', title: 'Backup & restore' });
-    backupJump.innerHTML =
-      '<svg viewBox="0 0 22 22" fill="currentColor" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">' +
-      '<path d="M10.9851 0C7.6057 0 4.58375 1.52106 2.56398 3.91405L0.855461 2.20784V7.70159H6.35666L4.78529 6.13235C6.22953 4.30005 8.46896 3.12232 10.9851 3.12232C15.3417 3.12232 18.8734 6.64928 18.8734 11C18.8734 15.3507 15.3417 18.8776 10.9851 18.8776C6.88814 18.8776 3.52149 15.7583 3.13471 11.7682H0C0.395343 17.4845 5.16066 22 10.9851 22C17.0685 22 22 17.0751 22 11C22 4.92486 17.0685 0 10.9851 0Z"/></svg>';
-    backupJump.addEventListener('click', () => {
-      const el = view.querySelector('.backup-setting');
-      if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    // This circular-arrow used to only scroll down to the backup section — it reads as
+    // a refresh, so it is one now. Follow List Recovery already sits at the bottom of
+    // this screen under its own clear label, so the jump wasn't earning the icon.
+    //
+    // Profile data is cached for PROFILE_TTL (5 min) and the follow count is cached for
+    // the whole session, so an edit made elsewhere can look stuck. This drops both for
+    // the active account and refetches.
+    const refreshBtn = h('button', { className: 'profile-backup-jump', title: 'Refresh profile and follow count' });
+    // Clockwise, near-closed circle with a short arrow at the top right — the
+    // conventional "reload" glyph. The old mark was counter-clockwise and filled,
+    // which reads more like "undo" than "refresh". Stroked so it inherits the same
+    // weight as the panel's other icons.
+    refreshBtn.innerHTML =
+      '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" ' +
+      'stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+      '<path d="M20 12a8 8 0 1 1-2.34-5.66"></path>' +
+      '<polyline points="20 4.5 20 9 15.5 9"></polyline></svg>';
+    refreshBtn.addEventListener('click', async () => {
+      if (refreshBtn.disabled) return;
+      refreshBtn.disabled = true;
+      refreshBtn.classList.add('spinning');
+      try {
+        _profileCache.delete(active.pubkey);
+        followCountCache.delete(active.pubkey);
+        profileFetchAttempted.delete(active.pubkey); // let fetchAndStoreProfile run again
+        await fetchAndStoreProfile(active.pubkey);
+        renderProfile();
+        toast('Profile refreshed', 'success');
+      } catch (_) {
+        toast("Couldn't reach your relays", 'error');
+      } finally {
+        // renderProfile() may have replaced this button; guard against a detached node.
+        refreshBtn.disabled = false;
+        refreshBtn.classList.remove('spinning');
+      }
     });
     const followStat = h('div', { className: 'profile-stats' }, [
       h('span', { className: 'profile-stat' }, [followNum, document.createTextNode(' following')]),
-      backupJump,
+      refreshBtn,
     ]);
     body.append(followStat);
     getFollowCount(active.pubkey).then((n) => {
@@ -3334,10 +3366,10 @@
 
   // Lightweight follow COUNT (unique p-tags on the account's kind:3) — avoids the
   // heavy kind:0 profile batch that getFollowList() does, since the profile just
-  // needs a number. Cached per pubkey. A completed query with no follow list means
-  // they aren't following anyone yet → 0 (common for a fresh account); only a
-  // thrown error returns null, which the UI renders as "—".
-  const followCountCache = new Map(); // pubkey -> number|null
+  // needs a number. Cached per pubkey (the cache itself is declared up with
+  // _profileCache, since the profile screen's refresh button clears both). A completed
+  // query with no follow list means they aren't following anyone yet → 0 (common for a
+  // fresh account); only a thrown error returns null, which the UI renders as "—".
   async function getFollowCount(pubkey) {
     if (!pubkey) return null;
     if (followCountCache.has(pubkey)) return followCountCache.get(pubkey);

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -55,6 +55,9 @@
     'eye-off': '<path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"></path><line x1="1" y1="1" x2="23" y2="23"></line>',
     pin: '<path d="M12 17v5"></path><path d="M9 10.76V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v6.76a2 2 0 0 0 .59 1.42l1.12 1.12A2 2 0 0 1 18 14.59V16a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1v-1.41a2 2 0 0 1 .29-1.29l1.12-1.12A2 2 0 0 0 9 10.76Z"></path>',
     bell: '<path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"></path><path d="M13.73 21a2 2 0 0 1-3.46 0"></path>',
+    // Raised palm — the "Don't allow" button on a destructive-overwrite warning. Reads
+    // as stop, where an X or a slashed circle would read as error or blocked.
+    'stop-hand': '<path d="M9 11V5.5a1.5 1.5 0 0 1 3 0V11"></path><path d="M12 11V4.5a1.5 1.5 0 0 1 3 0V11"></path><path d="M15 11V6.5a1.5 1.5 0 0 1 3 0V13a7 7 0 0 1-7 7h-1a6 6 0 0 1-5.2-3l-2.2-3.8a1.5 1.5 0 0 1 2.6-1.5L6 14"></path><path d="M9 11V9.5a1.5 1.5 0 0 0-3 0V14"></path>',
     qr: '<rect x="3" y="3" width="7" height="7" rx="1"></rect><rect x="14" y="3" width="7" height="7" rx="1"></rect><rect x="3" y="14" width="7" height="7" rx="1"></rect><path d="M14 14h3v3M21 14v7h-7v-3"></path>',
     share: '<path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8"></path><polyline points="16 6 12 2 8 6"></polyline><line x1="12" y1="2" x2="12" y2="15"></line>',
     bug: '<path d="m8 2 1.88 1.88"></path><path d="M14.12 3.88 16 2"></path><path d="M9 7.13v-1a3.003 3.003 0 1 1 6 0v1"></path><path d="M12 20c-3.3 0-6-2.7-6-6v-3a4 4 0 0 1 4-4h4a4 4 0 0 1 4 4v3c0 3.3-2.7 6-6 6"></path><path d="M12 20v-9"></path><path d="M6.53 9C4.6 8.8 3 7.1 3 5"></path><path d="M6 13H2"></path><path d="M3 21c0-2.1 1.7-3.9 3.8-4"></path><path d="M20.97 5c0 2.1-1.6 3.8-3.5 4"></path><path d="M22 13h-4"></path><path d="M17.2 17c2.1.1 3.8 1.9 3.8 4"></path>',
@@ -7832,14 +7835,12 @@
         // always is — muscle memory that's fine for a note and wrong for a wipe. The
         // safe choice should be the reachable one; the destructive choice should cost
         // a deliberate second action.
-        const reject = h('button', {
-          className: 'destructive-warn-reject',
-          textContent: 'Reject — keep my data',
-        });
+        const reject = h('button', { className: 'destructive-warn-reject' });
+        reject.append(icon('stop-hand'), h('span', { textContent: "Don't allow" }));
         reject.addEventListener('click', () => decideApproval('reject'));
         const ack = h('button', {
           className: 'destructive-warn-ack',
-          textContent: 'I understand, let me approve it',
+          textContent: 'Approve anyway',
         });
         ack.addEventListener('click', () => {
           setApprovalLocked(false);
@@ -7859,7 +7860,7 @@
             h('p', { className: 'destructive-warn-body', textContent: data.destructive.message }),
             h('p', {
               className: 'destructive-warn-hint',
-              textContent: 'If you didn\'t mean to do this, reject — the version on your relays stays as it is.',
+              textContent: 'If you didn\'t mean to do this, don\'t allow it — the version on your relays stays as it is.',
             }),
             h('div', { className: 'destructive-warn-actions' }, [reject, ack]),
           ])

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -7827,6 +7827,29 @@
       // Destructive replaceable overwrite (see replaceable-baseline.js) — louder than
       // the kind warning above, because this one is about losing data you already have.
       if (data.destructive && data.destructive.message) {
+        // Reject sits INSIDE the warning and Allow/Trust start disabled, unlocked only
+        // by an explicit "I understand". Approving normally means tapping where Allow
+        // always is — muscle memory that's fine for a note and wrong for a wipe. The
+        // safe choice should be the reachable one; the destructive choice should cost
+        // a deliberate second action.
+        const reject = h('button', {
+          className: 'destructive-warn-reject',
+          textContent: 'Reject — keep my data',
+        });
+        reject.addEventListener('click', () => decideApproval('reject'));
+        const ack = h('button', {
+          className: 'destructive-warn-ack',
+          textContent: 'I understand, let me approve it',
+        });
+        ack.addEventListener('click', () => {
+          setApprovalLocked(false);
+          ack.remove();
+          // Say what changed rather than just removing the button — otherwise the
+          // buttons below silently become live and it isn't obvious why.
+          box.querySelector('.destructive-warn').append(
+            h('p', { className: 'destructive-warn-unlocked', textContent: 'Approval unlocked below.' })
+          );
+        });
         box.append(
           h('div', { className: 'destructive-warn' }, [
             h('div', { className: 'destructive-warn-title' }, [
@@ -7838,6 +7861,7 @@
               className: 'destructive-warn-hint',
               textContent: 'If you didn\'t mean to do this, reject — the version on your relays stays as it is.',
             }),
+            h('div', { className: 'destructive-warn-actions' }, [reject, ack]),
           ])
         );
       }
@@ -7903,6 +7927,19 @@
       note.append(got);
     }
     acct.parentNode.insertBefore(note, acct);
+  }
+
+  // Disable/enable the approval prompt's Allow once + Trust this site while a
+  // destructive overwrite is unacknowledged. Reject is deliberately left alone — the
+  // safe way out must never be gated. The class on the footer dims the pair so they
+  // read as unavailable rather than merely unresponsive.
+  function setApprovalLocked(locked) {
+    const allow = $('approval-allow');
+    const trust = $('approval-trust');
+    if (allow) allow.disabled = locked;
+    if (trust) trust.disabled = locked;
+    const footer = allow && allow.parentNode;
+    if (footer) footer.classList.toggle('approval-locked', locked);
   }
 
   function renderApprovalAccountCapsule(data) {
@@ -7999,6 +8036,11 @@
     renderApprovalPreview(data);
 
     $('approval-error').textContent = '';
+    // Lock Allow/Trust behind the warning's "I understand" when this event destroys
+    // data. Applied here, after renderApprovalPreview built the warning, so a re-render
+    // (queue advance, unlock) re-locks rather than leaving a previous acknowledgement
+    // standing for a different event.
+    setApprovalLocked(!!(data.destructive && data.destructive.message));
     const allow = $('approval-allow');
     const trust = $('approval-trust');
     const pin = $('approval-pin');
@@ -8158,7 +8200,10 @@
     if (e.target === $('view-approval')) decideApproval('reject');
   });
   $('approval-pin').addEventListener('keydown', (e) => {
-    if (e.key === 'Enter') decideApproval('once');
+    // Respect the destructive lock: Enter here calls decideApproval directly, so
+    // without this check it would approve a wipe that the disabled Allow button is
+    // supposed to be holding back.
+    if (e.key === 'Enter' && !$('approval-allow').disabled) decideApproval('once');
   });
   // Numeric-only, capped budget input (static element, so not built via satsInput).
   $('approval-budget-amount').addEventListener('input', (e) => {

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -1068,6 +1068,7 @@
         new Promise((res) => setTimeout(() => res(null), 6000)),
       ]);
       if (!ev) return;
+      seedBaseline(pubkey, ev); // free ride — see seedBaseline
       let meta = {};
       try { meta = JSON.parse(ev.content) || {}; } catch (_) { return; }
       const name = meta.display_name || meta.displayName || meta.name || '';
@@ -1305,6 +1306,7 @@
         const evs = await getPool().querySync(relays, { kinds: [10000], authors: [pubkey] });
         const ev = (evs || []).sort((x, y) => y.created_at - x.created_at)[0];
         if (ev) {
+          seedBaseline(pubkey, ev); // free ride — see seedBaseline
           ev.tags.filter((t) => t[0] === 'p' && t[1]).forEach((t) => muted.add(t[1]));
           if (ev.content) {
             // NIP-04 ciphertext is "<base64>?iv=<base64>"; NIP-44 is a single
@@ -3320,6 +3322,16 @@
   let followListPubkey = null;
   let followListInflight = null; // dedupe concurrent loads (rapid @-keystrokes)
 
+  // Seed the destructive-overwrite baseline (replaceable-baseline.js) from a kind
+  // 0/3/10000 the panel already fetched off relays, so the warning works on a fresh
+  // install rather than only after Sidecar has signed that kind once. The background
+  // keeps the record because the standalone prompt window can't reach relays itself.
+  // Fire-and-forget: this is opportunistic seeding, never on a critical path.
+  function seedBaseline(pubkey, ev) {
+    if (!pubkey || !ev) return;
+    call({ type: 'SIDECAR_SEED_BASELINE', pubkey, event: ev }).catch(() => {});
+  }
+
   // Lightweight follow COUNT (unique p-tags on the account's kind:3) — avoids the
   // heavy kind:0 profile batch that getFollowList() does, since the profile just
   // needs a number. Cached per pubkey. A completed query with no follow list means
@@ -3335,6 +3347,10 @@
       if (ev) {
         const set = new Set(ev.tags.filter((t) => t[0] === 'p' && t[1] && t[1].length === 64).map((t) => t[1]));
         count = set.size;
+        // Free ride: we already have this account's real follow list, so seed the
+        // overwrite baseline from it. Without this a fresh install can't warn about a
+        // wipe until after it has signed a kind:3 itself. Fire-and-forget.
+        seedBaseline(pubkey, ev);
       } else {
         count = 0;
       }
@@ -7756,6 +7772,23 @@
       if (Array.isArray(ev.tags)) box.append(row('Tags', String(ev.tags.length)));
       const warning = approvalKindWarning(ev.kind);
       if (warning) box.append(h('div', { className: 'kind-warn', textContent: warning }));
+      // Destructive replaceable overwrite (see replaceable-baseline.js) — louder than
+      // the kind warning above, because this one is about losing data you already have.
+      if (data.destructive && data.destructive.message) {
+        box.append(
+          h('div', { className: 'destructive-warn' }, [
+            h('div', { className: 'destructive-warn-title' }, [
+              icon('alert'),
+              h('span', { textContent: 'This erases data' }),
+            ]),
+            h('p', { className: 'destructive-warn-body', textContent: data.destructive.message }),
+            h('p', {
+              className: 'destructive-warn-hint',
+              textContent: 'If you didn\'t mean to do this, reject — the version on your relays stays as it is.',
+            }),
+          ])
+        );
+      }
       if (ev.content) appendEventContent(box, ev);
     } else if (data.method === 'nip04.decrypt' || data.method === 'nip44.decrypt') {
       box.append(peerRow('From', data.params && data.params.pubkey));

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -8007,9 +8007,15 @@
     // shared-host escape hatch, and a middle rung between Allow once and Trust.
     // Hidden for payments, decrypts, relay-auth, pure unlocks, and batched bursts
     // (those already collapse into "Allow all").
+    //
+    // Also hidden on a destructive overwrite. Offering "auto-sign for 30 min" directly
+    // beneath "this erases data" invites the one tap that does real harm: approving the
+    // wipe ALSO makes the wiped list the new baseline, so within that window a second
+    // overwrite has nothing left to lose and won't warn. A client that just tried to
+    // clear your follow list is precisely the one that shouldn't get a free window.
     const relaxRow = $('approval-relax-row');
     const offerRelax =
-      !payment && groupN === 1 && data.needApproval &&
+      !payment && groupN === 1 && data.needApproval && !data.destructive &&
       (data.method === 'signEvent' || data.method === 'nip04.encrypt' || data.method === 'nip44.encrypt');
     if (offerRelax) {
       show(relaxRow);

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -55,9 +55,6 @@
     'eye-off': '<path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"></path><line x1="1" y1="1" x2="23" y2="23"></line>',
     pin: '<path d="M12 17v5"></path><path d="M9 10.76V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v6.76a2 2 0 0 0 .59 1.42l1.12 1.12A2 2 0 0 1 18 14.59V16a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1v-1.41a2 2 0 0 1 .29-1.29l1.12-1.12A2 2 0 0 0 9 10.76Z"></path>',
     bell: '<path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"></path><path d="M13.73 21a2 2 0 0 1-3.46 0"></path>',
-    // Raised palm — the "Don't allow" button on a destructive-overwrite warning. Reads
-    // as stop, where an X or a slashed circle would read as error or blocked.
-    'stop-hand': '<path d="M9 11V5.5a1.5 1.5 0 0 1 3 0V11"></path><path d="M12 11V4.5a1.5 1.5 0 0 1 3 0V11"></path><path d="M15 11V6.5a1.5 1.5 0 0 1 3 0V13a7 7 0 0 1-7 7h-1a6 6 0 0 1-5.2-3l-2.2-3.8a1.5 1.5 0 0 1 2.6-1.5L6 14"></path><path d="M9 11V9.5a1.5 1.5 0 0 0-3 0V14"></path>',
     qr: '<rect x="3" y="3" width="7" height="7" rx="1"></rect><rect x="14" y="3" width="7" height="7" rx="1"></rect><rect x="3" y="14" width="7" height="7" rx="1"></rect><path d="M14 14h3v3M21 14v7h-7v-3"></path>',
     share: '<path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8"></path><polyline points="16 6 12 2 8 6"></polyline><line x1="12" y1="2" x2="12" y2="15"></line>',
     bug: '<path d="m8 2 1.88 1.88"></path><path d="M14.12 3.88 16 2"></path><path d="M9 7.13v-1a3.003 3.003 0 1 1 6 0v1"></path><path d="M12 20c-3.3 0-6-2.7-6-6v-3a4 4 0 0 1 4-4h4a4 4 0 0 1 4 4v3c0 3.3-2.7 6-6 6"></path><path d="M12 20v-9"></path><path d="M6.53 9C4.6 8.8 3 7.1 3 5"></path><path d="M6 13H2"></path><path d="M3 21c0-2.1 1.7-3.9 3.8-4"></path><path d="M20.97 5c0 2.1-1.6 3.8-3.5 4"></path><path d="M22 13h-4"></path><path d="M17.2 17c2.1.1 3.8 1.9 3.8 4"></path>',
@@ -7835,8 +7832,10 @@
         // always is — muscle memory that's fine for a note and wrong for a wipe. The
         // safe choice should be the reachable one; the destructive choice should cost
         // a deliberate second action.
-        const reject = h('button', { className: 'destructive-warn-reject' });
-        reject.append(icon('stop-hand'), h('span', { textContent: "Don't allow" }));
+        const reject = h('button', {
+          className: 'destructive-warn-reject',
+          textContent: "Don't allow",
+        });
         reject.addEventListener('click', () => decideApproval('reject'));
         const ack = h('button', {
           className: 'destructive-warn-ack',

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -210,20 +210,40 @@
   }
 
   // ---- toast notifications ----
+  // An identical message already on screen is REPLACED rather than stacked: tapping a
+  // button twice should restart one confirmation, not pile up two saying the same
+  // thing. Different messages still stack, so a payment result and a lock notice can
+  // coexist. Each toast owns its dismissal timer so replacing one can cancel it —
+  // otherwise the outgoing toast's timer would later remove its replacement.
+  const _toastTimers = new WeakMap();
   function toast(message, type) {
+    const host = document.getElementById('toasts');
+    const cls = 'toast toast-' + (type === 'error' ? 'error' : 'success');
+    // Same text AND same kind — an error and a success reading alike are still two
+    // different outcomes and shouldn't silently collapse into one.
+    for (const prev of host.querySelectorAll('.toast')) {
+      if (prev.dataset.msg === message && prev.className.indexOf(cls) === 0) {
+        const timers = _toastTimers.get(prev);
+        if (timers) { clearTimeout(timers.hide); clearTimeout(timers.remove); }
+        prev.remove();
+      }
+    }
     const t = document.createElement('div');
-    t.className = 'toast toast-' + (type === 'error' ? 'error' : 'success');
+    t.className = cls;
+    t.dataset.msg = message;
     t.appendChild(icon(type === 'error' ? 'alert' : 'check'));
     const span = document.createElement('span');
     span.textContent = message;
     t.appendChild(span);
-    const host = document.getElementById('toasts');
     host.appendChild(t);
     requestAnimationFrame(() => t.classList.add('show'));
-    setTimeout(() => {
+    const hide = setTimeout(() => {
       t.classList.remove('show');
-      setTimeout(() => t.remove(), 250);
+      const rm = setTimeout(() => t.remove(), 250);
+      const cur = _toastTimers.get(t);
+      if (cur) cur.remove = rm;
     }, 3200);
+    _toastTimers.set(t, { hide, remove: null });
     return t;
   }
 

--- a/styles.css
+++ b/styles.css
@@ -245,7 +245,16 @@ input:focus, select:focus, textarea:focus {
   background: none; border: none; padding: 3px; border-radius: 8px; cursor: pointer; color: var(--muted);
 }
 .profile-backup-jump:hover { color: var(--lav); background: var(--hover-medium); }
-.profile-backup-jump svg { width: 15px; height: 15px; display: block; }
+/* 18px, not 15 — the stroked reload glyph carries less visual weight than the old
+   filled mark, so it needs the extra size to read as a control rather than a speck. */
+.profile-backup-jump svg { width: 18px; height: 18px; display: block; }
+/* Spins while the refresh is in flight, so a slow relay looks busy rather than dead. */
+.profile-backup-jump.spinning svg { animation: profile-refresh-spin 0.9s linear infinite; }
+.profile-backup-jump:disabled { cursor: default; }
+@keyframes profile-refresh-spin { to { transform: rotate(360deg); } }
+@media (prefers-reduced-motion: reduce) {
+  .profile-backup-jump.spinning svg { animation: none; opacity: 0.5; }
+}
 .profile-about {
   font-size: 14px; line-height: 1.55; color: var(--text); margin: 12px 0;
   white-space: pre-wrap; overflow-wrap: anywhere; text-align: left;

--- a/styles.css
+++ b/styles.css
@@ -1851,23 +1851,28 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
   color: var(--warn); font-size: 12px; text-align: left;
 }
 /* Destructive replaceable overwrite (follow list / mute list / profile fields about to
-   be erased). Deliberately louder than .kind-warn — that one says "unusual kind", this
-   one says "you are about to lose data you already have" — so it uses the red used for
-   errors rather than the amber caution tone. */
+   be erased). Louder than .kind-warn — that one says "unusual kind", this says "you are
+   about to lose data you already have" — but set as an editorial aside rather than a
+   system alert: a red box nested inside the event-preview box read as a stray browser
+   error, not as part of this panel. A rule and a Playfair headline carry the weight
+   instead, which is how the rest of Sidecar emphasises things.
+   The glyph stays so the warning isn't carried by colour alone. */
 .destructive-warn {
-  margin-top: 10px; padding: 10px 12px; border-radius: 9px; text-align: left;
-  background: rgba(240, 86, 107, 0.1); border: 1px solid rgba(240, 86, 107, 0.4);
+  margin-top: 12px; padding: 1px 0 1px 12px; text-align: left;
+  border-left: 2px solid var(--red);
 }
 .destructive-warn-title {
   display: flex; align-items: center; gap: 6px;
-  color: var(--red); font-weight: 700; font-size: 12.5px;
+  font-family: var(--font-display); font-weight: 700; font-size: 15px;
+  color: var(--red); letter-spacing: 0.01em; margin-bottom: 3px;
 }
 .destructive-warn-title svg { width: 14px; height: 14px; flex-shrink: 0; }
 .destructive-warn-body {
-  margin: 6px 0 0; color: var(--text); font-size: 12.5px; line-height: 1.45; font-weight: 600;
+  margin: 0; color: var(--text); font-size: 13px; line-height: 1.5;
 }
+.destructive-warn-body b { font-weight: 700; }
 .destructive-warn-hint {
-  margin: 5px 0 0; color: var(--muted); font-size: 11.5px; line-height: 1.4;
+  margin: 5px 0 0; color: var(--faint); font-size: 11.5px; line-height: 1.45;
 }
 /* PIN-save reminder: a gently swaying antique key stands in for a boxed warning. */
 .pin-reminder-icon { display: flex; justify-content: center; margin-bottom: 4px; }

--- a/styles.css
+++ b/styles.css
@@ -1881,24 +1881,23 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
 }
 /* Reject lives in the warning so the safe choice is the nearest one, and is styled as
    the affirmative action — the red button here MEANS "keep my data", not "danger". */
-/* Side by side now the labels are short enough — stacked full-width buttons made two
-   small choices look like two more steps. Keep-my-data takes the larger share. */
 .destructive-warn-actions {
-  display: flex; gap: 8px; margin-top: 11px;
+  display: flex; flex-direction: column; gap: 7px; margin-top: 11px;
 }
+/* Uppercased in CSS, not in the string, so screen readers still announce it as
+   "Don't allow" rather than spelling it out. */
 .destructive-warn-reject {
-  flex: 1.3; padding: 9px 12px; border-radius: 8px; cursor: pointer;
+  width: 100%; padding: 9px 12px; border-radius: 8px; cursor: pointer;
   background: var(--red); border: 1px solid var(--red); color: #fff;
   font-family: inherit; font-size: 13px; font-weight: 700;
-  display: inline-flex; align-items: center; justify-content: center; gap: 6px;
+  text-transform: uppercase; letter-spacing: 0.06em;
   transition: filter 0.12s;
 }
-.destructive-warn-reject svg { width: 14px; height: 14px; flex-shrink: 0; }
 .destructive-warn-reject:hover { filter: brightness(1.08); }
 /* The escape hatch is deliberately quiet: a bordered, low-contrast control rather than
    a second button competing with Reject. */
 .destructive-warn-ack {
-  flex: 1; padding: 7px 12px; border-radius: 8px; cursor: pointer;
+  width: 100%; padding: 7px 12px; border-radius: 8px; cursor: pointer;
   background: transparent; border: 1px solid var(--border-strong); color: var(--muted);
   font-family: inherit; font-size: 12px;
   transition: color 0.12s, border-color 0.12s;

--- a/styles.css
+++ b/styles.css
@@ -1881,20 +1881,24 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
 }
 /* Reject lives in the warning so the safe choice is the nearest one, and is styled as
    the affirmative action — the red button here MEANS "keep my data", not "danger". */
+/* Side by side now the labels are short enough — stacked full-width buttons made two
+   small choices look like two more steps. Keep-my-data takes the larger share. */
 .destructive-warn-actions {
-  display: flex; flex-direction: column; gap: 7px; margin-top: 11px;
+  display: flex; gap: 8px; margin-top: 11px;
 }
 .destructive-warn-reject {
-  width: 100%; padding: 9px 12px; border-radius: 8px; cursor: pointer;
+  flex: 1.3; padding: 9px 12px; border-radius: 8px; cursor: pointer;
   background: var(--red); border: 1px solid var(--red); color: #fff;
   font-family: inherit; font-size: 13px; font-weight: 700;
+  display: inline-flex; align-items: center; justify-content: center; gap: 6px;
   transition: filter 0.12s;
 }
+.destructive-warn-reject svg { width: 14px; height: 14px; flex-shrink: 0; }
 .destructive-warn-reject:hover { filter: brightness(1.08); }
 /* The escape hatch is deliberately quiet: a bordered, low-contrast control rather than
    a second button competing with Reject. */
 .destructive-warn-ack {
-  width: 100%; padding: 7px 12px; border-radius: 8px; cursor: pointer;
+  flex: 1; padding: 7px 12px; border-radius: 8px; cursor: pointer;
   background: transparent; border: 1px solid var(--border-strong); color: var(--muted);
   font-family: inherit; font-size: 12px;
   transition: color 0.12s, border-color 0.12s;

--- a/styles.css
+++ b/styles.css
@@ -1871,8 +1871,13 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
   margin: 0; color: var(--text); font-size: 13px; line-height: 1.5;
 }
 .destructive-warn-body b { font-weight: 700; }
+/* --muted, not --faint. Measured against each theme's card background, --faint gives
+   2.6-3.4:1 — under the 4.5:1 WCAG AA needs for small text, and worst on Art Deco's
+   light card. --muted clears it in all three (4.5-5.9:1). Size nudged up too: this
+   sentence tells you how to undo a mistake, so it shouldn't be the smallest thing on
+   the prompt. */
 .destructive-warn-hint {
-  margin: 5px 0 0; color: var(--faint); font-size: 11.5px; line-height: 1.45;
+  margin: 6px 0 0; color: var(--muted); font-size: 12.5px; line-height: 1.5;
 }
 /* PIN-save reminder: a gently swaying antique key stands in for a boxed warning. */
 .pin-reminder-icon { display: flex; justify-content: center; margin-bottom: 4px; }

--- a/styles.css
+++ b/styles.css
@@ -1841,6 +1841,25 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
   background: rgba(var(--warn-rgb), 0.1); border: 1px solid rgba(var(--warn-rgb), 0.3);
   color: var(--warn); font-size: 12px; text-align: left;
 }
+/* Destructive replaceable overwrite (follow list / mute list / profile fields about to
+   be erased). Deliberately louder than .kind-warn — that one says "unusual kind", this
+   one says "you are about to lose data you already have" — so it uses the red used for
+   errors rather than the amber caution tone. */
+.destructive-warn {
+  margin-top: 10px; padding: 10px 12px; border-radius: 9px; text-align: left;
+  background: rgba(240, 86, 107, 0.1); border: 1px solid rgba(240, 86, 107, 0.4);
+}
+.destructive-warn-title {
+  display: flex; align-items: center; gap: 6px;
+  color: var(--red); font-weight: 700; font-size: 12.5px;
+}
+.destructive-warn-title svg { width: 14px; height: 14px; flex-shrink: 0; }
+.destructive-warn-body {
+  margin: 6px 0 0; color: var(--text); font-size: 12.5px; line-height: 1.45; font-weight: 600;
+}
+.destructive-warn-hint {
+  margin: 5px 0 0; color: var(--muted); font-size: 11.5px; line-height: 1.4;
+}
 /* PIN-save reminder: a gently swaying antique key stands in for a boxed warning. */
 .pin-reminder-icon { display: flex; justify-content: center; margin-bottom: 4px; }
 .pin-reminder-key { width: 48px; height: 32px; color: var(--gold); animation: pin-key-sway 2.6s ease-in-out infinite; }

--- a/styles.css
+++ b/styles.css
@@ -1879,6 +1879,37 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
 .destructive-warn-hint {
   margin: 6px 0 0; color: var(--muted); font-size: 12.5px; line-height: 1.5;
 }
+/* Reject lives in the warning so the safe choice is the nearest one, and is styled as
+   the affirmative action — the red button here MEANS "keep my data", not "danger". */
+.destructive-warn-actions {
+  display: flex; flex-direction: column; gap: 7px; margin-top: 11px;
+}
+.destructive-warn-reject {
+  width: 100%; padding: 9px 12px; border-radius: 8px; cursor: pointer;
+  background: var(--red); border: 1px solid var(--red); color: #fff;
+  font-family: inherit; font-size: 13px; font-weight: 700;
+  transition: filter 0.12s;
+}
+.destructive-warn-reject:hover { filter: brightness(1.08); }
+/* The escape hatch is deliberately quiet: a bordered, low-contrast control rather than
+   a second button competing with Reject. */
+.destructive-warn-ack {
+  width: 100%; padding: 7px 12px; border-radius: 8px; cursor: pointer;
+  background: transparent; border: 1px solid var(--border-strong); color: var(--muted);
+  font-family: inherit; font-size: 12px;
+  transition: color 0.12s, border-color 0.12s;
+}
+.destructive-warn-ack:hover { color: var(--text); border-color: var(--muted); }
+.destructive-warn-unlocked {
+  margin: 9px 0 0; color: var(--muted); font-size: 12px; font-style: italic;
+}
+/* Dim the footer pair while locked so they read as unavailable, not just unresponsive. */
+.approval-locked #approval-allow,
+.approval-locked #approval-trust,
+.approval-locked #allow,
+.approval-locked #trust {
+  opacity: 0.4; cursor: not-allowed; filter: grayscale(0.5);
+}
 /* PIN-save reminder: a gently swaying antique key stands in for a boxed warning. */
 .pin-reminder-icon { display: flex; justify-content: center; margin-bottom: 4px; }
 .pin-reminder-key { width: 48px; height: 32px; color: var(--gold); animation: pin-key-sway 2.6s ease-in-out infinite; }

--- a/test/destructive-guard.html
+++ b/test/destructive-guard.html
@@ -141,6 +141,13 @@
     Just as important: a guard that fires on ordinary edits gets trained away. These must
     <em>not</em> warn.
   </p>
+  <div class="warnbox" style="border-color:var(--gold);background:rgba(203,161,78,.08)">
+    <b style="color:var(--gold)">Seed first, or these labels lie.</b> The QUIET labels below
+    assume a 40-follow baseline from section 1. If the account already has a real follow
+    list — Sidecar seeds baselines from relays when the panel loads a profile — then e.g.
+    <em>195 → 21</em> is a genuine gutting and <b>will</b> warn, correctly. Either sign the
+    40-follow seed first, or read these against the real baseline.
+  </div>
   <div class="grid">
     <div class="case">
       <h3>Unfollow a few <span class="tag quiet">expect quiet</span></h3>

--- a/test/destructive-guard.html
+++ b/test/destructive-guard.html
@@ -1,0 +1,331 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Sidecar — destructive-guard test bench</title>
+<style>
+  :root {
+    --bg: #0f1115; --card: #171b21; --line: #262c35; --ink: #e6ebf2;
+    --dim: #8b95a3; --warn: #f0566b; --ok: #4ade80; --gold: #cba14e;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; padding: 28px; background: var(--bg); color: var(--ink);
+    font: 15px/1.55 system-ui, -apple-system, sans-serif;
+  }
+  .wrap { max-width: 900px; margin: 0 auto; }
+  h1 { font-size: 21px; margin: 0 0 4px; }
+  h2 { font-size: 15px; margin: 26px 0 10px; color: var(--gold); letter-spacing: .02em; }
+  .lede { color: var(--dim); margin: 0 0 18px; }
+  .warnbox {
+    border: 1px solid var(--warn); background: rgba(240,86,107,.08);
+    border-radius: 10px; padding: 12px 14px; margin: 0 0 20px; font-size: 13.5px;
+  }
+  .warnbox b { color: var(--warn); }
+  .status {
+    border: 1px solid var(--line); background: var(--card); border-radius: 10px;
+    padding: 11px 13px; margin: 0 0 18px; font-size: 13.5px;
+  }
+  #pubkey { font-family: ui-monospace, Menlo, monospace; font-size: 12px; color: var(--dim); word-break: break-all; }
+  .grid { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
+  @media (max-width: 720px) { .grid { grid-template-columns: 1fr; } }
+  .case {
+    border: 1px solid var(--line); background: var(--card); border-radius: 10px; padding: 12px 13px;
+  }
+  .case h3 { margin: 0 0 3px; font-size: 13.5px; }
+  .case p { margin: 0 0 10px; color: var(--dim); font-size: 12.5px; }
+  .tag {
+    display: inline-block; font-size: 10.5px; letter-spacing: .05em; text-transform: uppercase;
+    padding: 2px 6px; border-radius: 4px; margin-left: 6px; vertical-align: 1px;
+  }
+  .tag.warn { background: rgba(240,86,107,.16); color: var(--warn); }
+  .tag.quiet { background: rgba(74,222,128,.14); color: var(--ok); }
+  button {
+    font: inherit; font-size: 13px; padding: 7px 12px; border-radius: 7px; cursor: pointer;
+    background: #222831; color: var(--ink); border: 1px solid var(--line);
+  }
+  button:hover:not(:disabled) { border-color: var(--gold); color: var(--gold); }
+  button:disabled { opacity: .45; cursor: not-allowed; }
+  .row { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
+  .primary { background: var(--gold); color: #1a1206; border-color: var(--gold); font-weight: 600; }
+  .primary:hover:not(:disabled) { filter: brightness(1.08); color: #1a1206; }
+  #log {
+    margin-top: 20px; border: 1px solid var(--line); background: #0b0d11; border-radius: 10px;
+    padding: 12px; font-family: ui-monospace, Menlo, monospace; font-size: 12px;
+    max-height: 320px; overflow: auto; white-space: pre-wrap;
+  }
+  .l-ok { color: var(--ok); } .l-err { color: var(--warn); } .l-dim { color: var(--dim); }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>Destructive-guard test bench</h1>
+  <p class="lede">Exercises Sidecar's replaceable-overwrite warning (kinds 0, 3, 10000).</p>
+
+  <div class="warnbox">
+    <b>Use a throwaway account.</b> Every button below asks Sidecar to <b>sign</b> a
+    replaceable event. If you approve one, it replaces that list <em>for that account</em>
+    on every relay it reaches — this bench does not publish, but an approved signature is
+    a real signature and a client holding it could. Reject to test the warning safely.
+  </div>
+
+  <div class="status">
+    <div class="row">
+      <button class="primary" id="connect">Connect to Sidecar</button>
+      <span id="state" class="l-dim">not connected</span>
+    </div>
+    <div id="pubkey"></div>
+  </div>
+
+  <h2>1 · Seed a baseline</h2>
+  <p class="lede" style="margin-bottom:10px">
+    The guard compares against what Sidecar last signed. Sign a healthy list first, approve
+    it, and that becomes the baseline. (Sidecar also seeds baselines from relays when the
+    panel loads a profile, so a real account may already have one.)
+  </p>
+  <div class="grid">
+    <div class="case">
+      <h3>Seed follows: 40 entries</h3>
+      <p>Establishes a 40-follow baseline.</p>
+      <button data-act="seed-follows">Sign kind 3 · 40 follows</button>
+    </div>
+    <div class="case">
+      <h3>Seed mute list: 25 entries</h3>
+      <p>Establishes a 25-entry mute baseline.</p>
+      <button data-act="seed-mutes">Sign kind 10000 · 25 muted</button>
+    </div>
+    <div class="case">
+      <h3>Seed profile: all fields</h3>
+      <p>bio, picture, nip05, Lightning address, display name.</p>
+      <button data-act="seed-profile">Sign kind 0 · full profile</button>
+    </div>
+  </div>
+
+  <h2>2 · Cases that SHOULD warn</h2>
+  <div class="grid">
+    <div class="case">
+      <h3>Wipe follows <span class="tag warn">expect warning</span></h3>
+      <p>Empty kind 3 — the classic client bug.</p>
+      <button data-act="wipe-follows">Sign kind 3 · 0 follows</button>
+    </div>
+    <div class="case">
+      <h3>Gut follows <span class="tag warn">expect warning</span></h3>
+      <p>40 → 3. Over half gone and ≥10 lost.</p>
+      <button data-act="gut-follows">Sign kind 3 · 3 follows</button>
+    </div>
+    <div class="case">
+      <h3>Clear mute list <span class="tag warn">expect warning</span></h3>
+      <p>Empty kind 10000 while entries exist.</p>
+      <button data-act="wipe-mutes">Sign kind 10000 · 0 muted</button>
+    </div>
+    <div class="case">
+      <h3>Gut mute list <span class="tag warn">expect warning</span></h3>
+      <p>25 → 2.</p>
+      <button data-act="gut-mutes">Sign kind 10000 · 2 muted</button>
+    </div>
+    <div class="case">
+      <h3>Drop bio <span class="tag warn">expect warning</span></h3>
+      <p>kind 0 keeping everything but <code>about</code>.</p>
+      <button data-act="drop-bio">Sign kind 0 · no bio</button>
+    </div>
+    <div class="case">
+      <h3>Strip profile <span class="tag warn">expect warning</span></h3>
+      <p>kind 0 with only <code>name</code> — several fields lost at once.</p>
+      <button data-act="strip-profile">Sign kind 0 · name only</button>
+    </div>
+  </div>
+
+  <h2>3 · Cases that should stay QUIET</h2>
+  <p class="lede" style="margin-bottom:10px">
+    Just as important: a guard that fires on ordinary edits gets trained away. These must
+    <em>not</em> warn.
+  </p>
+  <div class="grid">
+    <div class="case">
+      <h3>Unfollow a few <span class="tag quiet">expect quiet</span></h3>
+      <p>40 → 36. Small, ordinary.</p>
+      <button data-act="unfollow-few">Sign kind 3 · 36 follows</button>
+    </div>
+    <div class="case">
+      <h3>Just under half <span class="tag quiet">expect quiet</span></h3>
+      <p>40 → 21. Big but under the ratio.</p>
+      <button data-act="unfollow-half">Sign kind 3 · 21 follows</button>
+    </div>
+    <div class="case">
+      <h3>Grow the list <span class="tag quiet">expect quiet</span></h3>
+      <p>40 → 55.</p>
+      <button data-act="grow-follows">Sign kind 3 · 55 follows</button>
+    </div>
+    <div class="case">
+      <h3>Edit bio text <span class="tag quiet">expect quiet</span></h3>
+      <p>All fields still present, bio reworded.</p>
+      <button data-act="edit-bio">Sign kind 0 · new bio text</button>
+    </div>
+    <div class="case">
+      <h3>Drop unknown field <span class="tag quiet">expect quiet</span></h3>
+      <p>Removes a custom key Sidecar doesn't track.</p>
+      <button data-act="drop-custom">Sign kind 0 · no custom key</button>
+    </div>
+    <div class="case">
+      <h3>Add a field <span class="tag quiet">expect quiet</span></h3>
+      <p>Adds a website; nothing lost.</p>
+      <button data-act="add-field">Sign kind 0 · + website</button>
+    </div>
+  </div>
+
+  <h2>4 · Edge cases</h2>
+  <div class="grid">
+    <div class="case">
+      <h3>Malformed kind 3 <span class="tag quiet">expect quiet</span></h3>
+      <p>No <code>tags</code> array at all — should read as unknown, not as a wipe.</p>
+      <button data-act="malformed-follows">Sign kind 3 · no tags</button>
+    </div>
+    <div class="case">
+      <h3>Unreadable kind 0 <span class="tag quiet">expect quiet</span></h3>
+      <p><code>content</code> isn't JSON — unknown, not empty.</p>
+      <button data-act="malformed-profile">Sign kind 0 · bad JSON</button>
+    </div>
+    <div class="case">
+      <h3>Duplicate p-tags <span class="tag warn">expect warning</span></h3>
+      <p>40 tags but only 2 unique — dedupe should see a gutting.</p>
+      <button data-act="dupe-follows">Sign kind 3 · 2 unique</button>
+    </div>
+    <div class="case">
+      <h3>Untracked kind <span class="tag quiet">expect quiet</span></h3>
+      <p>kind 10002 (relay list) is replaceable but not guarded.</p>
+      <button data-act="relay-list">Sign kind 10002 · 1 relay</button>
+    </div>
+  </div>
+
+  <div id="log"><span class="l-dim">Ready. Connect, seed a baseline, then try a case.</span></div>
+</div>
+
+<script>
+(function () {
+  'use strict';
+  const $ = (id) => document.getElementById(id);
+  const logEl = $('log');
+
+  function log(msg, cls) {
+    const line = document.createElement('div');
+    if (cls) line.className = cls;
+    line.textContent = new Date().toLocaleTimeString() + '  ' + msg;
+    logEl.appendChild(line);
+    logEl.scrollTop = logEl.scrollHeight;
+  }
+
+  // Deterministic 64-hex pubkeys so repeat runs produce identical lists — the
+  // baseline comparison is about COUNTS, and stable values keep runs comparable.
+  function fakePubkey(i) {
+    return (i + 1).toString(16).padStart(2, '0').repeat(32).slice(0, 64);
+  }
+  function pTags(n, opts) {
+    const tags = [];
+    for (let i = 0; i < n; i++) tags.push(['p', fakePubkey(opts && opts.same ? 0 : i)]);
+    return tags;
+  }
+
+  const FULL_PROFILE = {
+    name: 'guard-test',
+    display_name: 'Guard Test',
+    about: 'Throwaway account for exercising Sidecar’s destructive-overwrite guard.',
+    picture: 'https://example.invalid/avatar.png',
+    nip05: 'guard@example.invalid',
+    lud16: 'guard@example.invalid',
+    customThing: 'not a tracked field',
+  };
+  const profile = (over, drop) => {
+    const o = Object.assign({}, FULL_PROFILE, over || {});
+    for (const k of (drop || [])) delete o[k];
+    return JSON.stringify(o);
+  };
+
+  const CASES = {
+    'seed-follows':      () => ({ kind: 3, tags: pTags(40), content: '' }),
+    'seed-mutes':        () => ({ kind: 10000, tags: pTags(25), content: '' }),
+    'seed-profile':      () => ({ kind: 0, tags: [], content: profile() }),
+
+    'wipe-follows':      () => ({ kind: 3, tags: [], content: '' }),
+    'gut-follows':       () => ({ kind: 3, tags: pTags(3), content: '' }),
+    'wipe-mutes':        () => ({ kind: 10000, tags: [], content: '' }),
+    'gut-mutes':         () => ({ kind: 10000, tags: pTags(2), content: '' }),
+    'drop-bio':          () => ({ kind: 0, tags: [], content: profile(null, ['about']) }),
+    'strip-profile':     () => ({ kind: 0, tags: [], content: JSON.stringify({ name: 'guard-test' }) }),
+
+    'unfollow-few':      () => ({ kind: 3, tags: pTags(36), content: '' }),
+    'unfollow-half':     () => ({ kind: 3, tags: pTags(21), content: '' }),
+    'grow-follows':      () => ({ kind: 3, tags: pTags(55), content: '' }),
+    'edit-bio':          () => ({ kind: 0, tags: [], content: profile({ about: 'Reworded bio, same fields.' }) }),
+    'drop-custom':       () => ({ kind: 0, tags: [], content: profile(null, ['customThing']) }),
+    'add-field':         () => ({ kind: 0, tags: [], content: profile({ website: 'https://example.invalid' }) }),
+
+    // No `tags` key at all — the malformed case that used to read as a wipe.
+    'malformed-follows': () => ({ kind: 3, content: '' }),
+    'malformed-profile': () => ({ kind: 0, tags: [], content: '<not json at all>' }),
+    'dupe-follows':      () => {
+      const tags = pTags(39, { same: true }); // 39 copies of one pubkey
+      tags.push(['p', fakePubkey(7)]);        // + one other = 2 unique
+      return { kind: 3, tags, content: '' };
+    },
+    'relay-list':        () => ({ kind: 10002, tags: [['r', 'wss://relay.example.invalid']], content: '' }),
+  };
+
+  function setConnected(pk) {
+    $('state').textContent = 'connected';
+    $('state').className = 'l-ok';
+    $('pubkey').textContent = pk;
+    document.querySelectorAll('button[data-act]').forEach((b) => (b.disabled = false));
+  }
+
+  document.querySelectorAll('button[data-act]').forEach((b) => (b.disabled = true));
+
+  $('connect').addEventListener('click', async () => {
+    if (!window.nostr) {
+      log('window.nostr is missing — is Sidecar installed and allowed on this URL?', 'l-err');
+      return;
+    }
+    try {
+      const pk = await window.nostr.getPublicKey();
+      setConnected(pk);
+      log('connected as ' + pk.slice(0, 16) + '…', 'l-ok');
+    } catch (e) {
+      log('connect rejected: ' + (e && e.message ? e.message : e), 'l-err');
+    }
+  });
+
+  document.querySelectorAll('button[data-act]').forEach((btn) => {
+    btn.addEventListener('click', async () => {
+      const act = btn.dataset.act;
+      const build = CASES[act];
+      if (!build) return;
+      const tpl = build();
+      const ev = Object.assign({ created_at: Math.floor(Date.now() / 1000) }, tpl);
+      const n = Array.isArray(ev.tags) ? ev.tags.filter((t) => t[0] === 'p').length : 'n/a';
+      log('→ ' + act + ' (kind ' + ev.kind + ', p-tags: ' + n + ') — watch for the warning, then reject', 'l-dim');
+      btn.disabled = true;
+      try {
+        const signed = await window.nostr.signEvent(ev);
+        log('✓ SIGNED ' + act + ' — id ' + String(signed.id).slice(0, 16) + '… (NOT published by this page)', 'l-ok');
+      } catch (e) {
+        log('✗ rejected/failed: ' + (e && e.message ? e.message : e), 'l-err');
+      } finally {
+        btn.disabled = false;
+      }
+    });
+  });
+
+  // Auto-detect an already-authorized session so the bench is usable immediately.
+  window.addEventListener('load', () => {
+    setTimeout(() => {
+      if (!window.nostr) {
+        log('window.nostr not found. Serve this file over http:// or file:// with Sidecar enabled for the URL.', 'l-err');
+      } else {
+        log('window.nostr detected. Click Connect to begin.', 'l-dim');
+      }
+    }, 400);
+  });
+})();
+</script>
+</body>
+</html>

--- a/test/replaceable-baseline.test.js
+++ b/test/replaceable-baseline.test.js
@@ -1,0 +1,258 @@
+'use strict';
+
+// Unit coverage for destructive-overwrite detection (replaceable-baseline.js).
+//
+// Kinds 0/3/10000 are replaceable: the signed event wholly REPLACES the previous one,
+// so a client publishing a short or empty list destroys the real one everywhere. This
+// module compares an incoming event against a locally-kept baseline of what Sidecar
+// last signed and reports a plain-language warning for the prompt.
+//
+// The invariants worth pinning, because the feature's usefulness AND its
+// trustworthiness both rest on them:
+//   - a total wipe is always flagged, however small the original list;
+//   - a big proportional loss is flagged, but routine unfollowing is NOT (or the
+//     warning gets trained away — the failure mode that would make this worse than
+//     nothing);
+//   - kind:0 flags only known meaningful fields going missing, since many clients
+//     legitimately don't round-trip fields they don't understand;
+//   - no baseline ⇒ no warning (absence of a warning never means "safe");
+//   - check() NEVER throws — it must not be able to block a signature.
+//
+// replaceable-baseline.js is isolated (talks only to globalThis.chrome), so we load it
+// in a vm against a small chrome mock — same approach as test/relax-grant.test.js.
+
+const { test, before, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const ROOT = path.join(__dirname, '..');
+
+function makeStorageArea() {
+  const data = {};
+  return {
+    get(keys, cb) {
+      let out = {};
+      if (keys == null) out = { ...data };
+      else if (typeof keys === 'string') { if (keys in data) out[keys] = data[keys]; }
+      else if (Array.isArray(keys)) { for (const k of keys) if (k in data) out[k] = data[k]; }
+      else { for (const k of Object.keys(keys)) out[k] = (k in data) ? data[k] : keys[k]; }
+      cb(out);
+    },
+    set(obj, cb) { Object.assign(data, obj); cb && cb(); },
+    remove(keys, cb) { for (const k of (Array.isArray(keys) ? keys : [keys])) delete data[k]; cb && cb(); },
+    clear(cb) { for (const k of Object.keys(data)) delete data[k]; cb && cb(); },
+  };
+}
+
+let B;
+const pk = 'a'.repeat(64);
+const pk2 = 'b'.repeat(64);
+
+// A kind:3 (or 10000) carrying `n` distinct p-tags.
+function listEvent(kind, n, extraTags) {
+  const tags = [];
+  for (let i = 0; i < n; i++) tags.push(['p', String(i).padStart(64, '0')]);
+  return { kind, tags: tags.concat(extraTags || []), content: '' };
+}
+function profileEvent(obj) {
+  return { kind: 0, tags: [], content: JSON.stringify(obj) };
+}
+
+before(() => {
+  globalThis.self = globalThis;
+  globalThis.chrome = { storage: { local: makeStorageArea() } };
+  vm.runInThisContext(
+    fs.readFileSync(path.join(ROOT, 'replaceable-baseline.js'), 'utf8'),
+    { filename: 'replaceable-baseline.js' }
+  );
+  B = globalThis.SidecarBaseline;
+  assert.ok(B, 'SidecarBaseline loaded');
+});
+
+beforeEach(async () => {
+  await B.forget(pk);
+  await B.forget(pk2);
+});
+
+// ---- summarize ----
+
+test('summarize counts unique p-tags and ignores other tags', () => {
+  const ev = listEvent(3, 5, [['e', 'x'], ['t', 'nostr']]);
+  assert.equal(B.summarize(ev).count, 5);
+});
+
+test('summarize dedupes repeated p-tags — the same pubkey twice is one follow', () => {
+  const dup = 'c'.repeat(64);
+  const ev = { kind: 3, tags: [['p', dup], ['p', dup], ['p', 'd'.repeat(64)]], content: '' };
+  assert.equal(B.summarize(ev).count, 2);
+});
+
+test('summarize ignores untracked kinds', () => {
+  assert.equal(B.summarize({ kind: 1, tags: [], content: 'hi' }), null);
+  assert.equal(B.summarize({ kind: 10002, tags: [], content: '' }), null);
+});
+
+test('summarize reports only known meaningful profile fields', () => {
+  const s = B.summarize(profileEvent({ name: 'x', about: 'bio', picture: 'u', weird: 'v' }));
+  assert.deepEqual(s.fields.sort(), ['about', 'picture']);
+});
+
+test('summarize treats empty-string profile fields as absent', () => {
+  const s = B.summarize(profileEvent({ about: '   ', picture: 'u' }));
+  assert.deepEqual(s.fields, ['picture']);
+});
+
+test('summarize returns null for unreadable kind:0 content (unknown, not empty)', () => {
+  assert.equal(B.summarize({ kind: 0, tags: [], content: 'not json' }), null);
+});
+
+// ---- no baseline ----
+
+test('no baseline means no warning — a first-ever sign cannot be judged', async () => {
+  assert.equal(await B.check(pk, listEvent(3, 0)), null);
+});
+
+test('baselines are per account', async () => {
+  await B.record(pk, listEvent(3, 500), 1);
+  // pk2 has no baseline of its own, so its wipe is unjudgeable.
+  assert.equal(await B.check(pk2, listEvent(3, 0)), null);
+});
+
+// ---- follows ----
+
+test('emptying a follow list is always flagged', async () => {
+  await B.record(pk, listEvent(3, 814), 1);
+  const w = await B.check(pk, listEvent(3, 0));
+  assert.equal(w.type, 'emptied');
+  assert.equal(w.from, 814);
+  assert.match(w.message, /all 814 accounts you follow/);
+});
+
+test('emptying is flagged even for a tiny list (the total-wipe case)', async () => {
+  await B.record(pk, listEvent(3, 2), 1);
+  const w = await B.check(pk, listEvent(3, 0));
+  assert.equal(w.type, 'emptied');
+});
+
+test('a large proportional loss is flagged', async () => {
+  await B.record(pk, listEvent(3, 814), 1);
+  const w = await B.check(pk, listEvent(3, 12));
+  assert.equal(w.type, 'shrink');
+  assert.equal(w.lost, 802);
+  assert.match(w.message, /from 814 to 12/);
+});
+
+test('routine unfollowing is NOT flagged — the warning must not be trained away', async () => {
+  await B.record(pk, listEvent(3, 500), 1);
+  assert.equal(await B.check(pk, listEvent(3, 495)), null); // unfollowed five
+  assert.equal(await B.check(pk, listEvent(3, 260)), null); // just under half lost
+});
+
+test('a small list losing a few is NOT flagged (floor guards new accounts)', async () => {
+  await B.record(pk, listEvent(3, 6), 1);
+  // 6 -> 2 is a two-thirds loss but only 4 entries; below the floor, so quiet.
+  assert.equal(await B.check(pk, listEvent(3, 2)), null);
+});
+
+test('growing or unchanged lists are never flagged', async () => {
+  await B.record(pk, listEvent(3, 100), 1);
+  assert.equal(await B.check(pk, listEvent(3, 100)), null);
+  assert.equal(await B.check(pk, listEvent(3, 140)), null);
+});
+
+// ---- mute list ----
+
+test('clearing a mute list is flagged with mute-specific wording', async () => {
+  await B.record(pk, listEvent(10000, 40), 1);
+  const w = await B.check(pk, listEvent(10000, 0));
+  assert.equal(w.type, 'emptied');
+  assert.equal(w.kind, 10000);
+  assert.match(w.message, /mute list of 40 accounts/);
+});
+
+test('a mute list that was already empty is not flagged', async () => {
+  await B.record(pk, listEvent(10000, 0), 1);
+  assert.equal(await B.check(pk, listEvent(10000, 0)), null);
+});
+
+// ---- profile ----
+
+test('losing a profile field is flagged in plain language', async () => {
+  await B.record(pk, profileEvent({ about: 'bio', picture: 'u', nip05: 'a@b' }), 1);
+  const w = await B.check(pk, profileEvent({ picture: 'u', nip05: 'a@b' }));
+  assert.equal(w.type, 'profile-fields');
+  assert.deepEqual(w.lost, ['about']);
+  assert.match(w.message, /clear your bio/);
+});
+
+test('losing several fields reads as a list', async () => {
+  await B.record(pk, profileEvent({ about: 'b', picture: 'u', lud16: 'a@b' }), 1);
+  const w = await B.check(pk, profileEvent({ picture: 'u' }));
+  assert.match(w.message, /bio and Lightning address|Lightning address and bio/);
+});
+
+test('unknown custom fields disappearing is NOT flagged', async () => {
+  await B.record(pk, profileEvent({ about: 'b', myCustomThing: 'x' }), 1);
+  assert.equal(await B.check(pk, profileEvent({ about: 'b' })), null);
+});
+
+test('adding or keeping profile fields is not flagged', async () => {
+  await B.record(pk, profileEvent({ about: 'b' }), 1);
+  assert.equal(await B.check(pk, profileEvent({ about: 'b', picture: 'u' })), null);
+});
+
+test('an unreadable incoming kind:0 is not flagged as field loss', async () => {
+  await B.record(pk, profileEvent({ about: 'b', picture: 'u' }), 1);
+  assert.equal(await B.check(pk, { kind: 0, tags: [], content: '<html>' }), null);
+});
+
+// ---- baseline bookkeeping ----
+
+test('record overwrites the baseline so the next check compares against it', async () => {
+  await B.record(pk, listEvent(3, 800), 1);
+  await B.record(pk, listEvent(3, 20), 2); // user really did cut the list
+  // 20 is the new normal; going to 18 is now unremarkable.
+  assert.equal(await B.check(pk, listEvent(3, 18)), null);
+});
+
+test('recordIfNewer will not clobber a fresher baseline', async () => {
+  await B.record(pk, listEvent(3, 800), 500);
+  await B.recordIfNewer(pk, listEvent(3, 3), 100); // older relay copy arriving late
+  const w = await B.check(pk, listEvent(3, 0));
+  assert.equal(w.from, 800, 'still comparing against the fresher 800-entry baseline');
+});
+
+test('recordIfNewer does update when the event is newer', async () => {
+  await B.record(pk, listEvent(3, 800), 100);
+  const updated = await B.recordIfNewer(pk, listEvent(3, 900), 500);
+  assert.equal(updated, true);
+  assert.equal(await B.check(pk, listEvent(3, 880)), null);
+});
+
+test('record ignores untracked kinds', async () => {
+  assert.equal(await B.record(pk, { kind: 1, tags: [], content: 'note' }, 1), false);
+});
+
+test('forget drops only that account’s baselines', async () => {
+  await B.record(pk, listEvent(3, 500), 1);
+  await B.record(pk2, listEvent(3, 500), 1);
+  await B.forget(pk);
+  assert.equal(await B.check(pk, listEvent(3, 0)), null);      // gone
+  assert.ok(await B.check(pk2, listEvent(3, 0)), 'pk2 kept');  // intact
+});
+
+// ---- fail open ----
+
+test('check never throws on malformed input', async () => {
+  await B.record(pk, listEvent(3, 100), 1);
+  for (const bad of [null, undefined, {}, { kind: 3 }, { kind: 3, tags: 'nope' }, 42, 'x']) {
+    assert.equal(await B.check(pk, bad), null, 'returned null for ' + JSON.stringify(bad));
+  }
+});
+
+test('check returns null when pubkey is missing', async () => {
+  await B.record(pk, listEvent(3, 100), 1);
+  assert.equal(await B.check(null, listEvent(3, 0)), null);
+});

--- a/test/replaceable-baseline.test.js
+++ b/test/replaceable-baseline.test.js
@@ -184,7 +184,7 @@ test('losing a profile field is flagged in plain language', async () => {
   const w = await B.check(pk, profileEvent({ picture: 'u', nip05: 'a@b' }));
   assert.equal(w.type, 'profile-fields');
   assert.deepEqual(w.lost, ['about']);
-  assert.match(w.message, /clear your bio/);
+  assert.match(w.message, /Clears your bio/);
 });
 
 test('losing several fields reads as a list', async () => {


### PR DESCRIPTION
> **Independent of #134/#135/#136** — branched off `main`, so it can be reviewed, tested, and merged in any order relative to the wallet features.

Kinds **0** (profile), **3** (follows) and **10000** (mute list) are *replaceable*: the signed event wholly **replaces** its previous version on every relay. A client publishing a short or empty list destroys the real one everywhere — the most common data-loss complaint on Nostr, and the reason Sidecar already ships follow-list recovery. This is the prevention half.

`replaceable-baseline.js` compares an incoming event against a baseline of what Sidecar last signed for that account+kind and, when the change looks destructive, forces a confirm carrying the concrete numbers: *"This will drop your follows from 814 to 12."*

## How the baseline is obtained — the crux of the design

The obvious approach (fetch the current version from relays when the prompt opens) **doesn't work here**:

1. The approval prompt must never block on the network — clients time out with "Signer did not respond in time".
2. The standalone prompt window (`prompt.js`) has **no relay access at all**; it only talks to the background. The background loads `nostr-tools` but never opens a pool.

So the baseline is **local state**, which makes the check synchronous, offline, and identical on both prompt surfaces. The panel — which does have relays — seeds baselines from fetches it already performs (follow count, mute list, own profile), so a fresh install isn't blind until its first sign of that kind.

## Tuned to stay credible, not maximally loud

A warning that fires on ordinary edits gets trained away, which would be **worse than no warning**. So:

| Case | Warns? |
|---|---|
| Total wipe (any list size) | yes — the case people actually get burned by |
| >half gone **and** 10+ entries lost | yes |
| Unfollowing a handful | no |
| Small list losing a few (6 → 2) | no — the floor guards new accounts still building a list |
| Growing or unchanged | no |
| kind 0: known field cleared (bio, picture, nip05, Lightning address, display name) | yes |
| kind 0: unknown custom field missing | no — many clients don't round-trip fields they don't understand |
| Malformed event | no — treated as *unknown*, not as an empty list |

A flagged event confirms **even on a trusted site and even mid relax window** — same reasoning that exempts the account/wallet-control kinds.

## Fails open, by design

No baseline, an unreadable event, or any thrown error means no warning. Stated plainly, because it matters: **the absence of a warning never means "this event is safe."** It's a safety net, not a gate — it can raise a confirm but never suppress one, and it never blocks a signature on its own.

## Tests

28 new unit tests (suite goes 22 → 50) covering the thresholds, per-account isolation, stale-baseline ordering, and that `check()` cannot throw. One of them caught a real bug during development: a tagless kind:3 was counting as an intentional wipe, which would have thrown a scary warning on a malformed event.

Also adds the module to `manifest.json`'s `background.scripts` — Chrome uses `importScripts`, but Firefox needs the explicit list, so omitting it would break the Firefox build.

**Not yet run in the extension.** Verified by unit tests, an end-to-end simulation of the reported scenario, and rendered UI.

🥂 Toasted with [Claude Code](https://claude.com/claude-code)