### PR TITLE
fix: stop losing payments to silence, and repair auto-approve zaps

### DIFF
--- a/background.js
+++ b/background.js
@@ -15,7 +15,7 @@
 // survive-restart machinery below applies equally to both.
 
 if (typeof importScripts === 'function') {
-  importScripts('nostr-tools.js', 'crypto.js', 'keystore.js', 'permissions.js', 'signer.js', 'wallet-budgets.js', 'nwc-client.js', 'relax-grants.js', 'replaceable-baseline.js');
+  importScripts('nostr-tools.js', 'crypto.js', 'keystore.js', 'permissions.js', 'signer.js', 'wallet-budgets.js', 'nwc-client.js', 'relax-grants.js', 'replaceable-baseline.js', 'zap-requests.js');
 }
 
 const KS = self.SidecarKeystore;
@@ -25,6 +25,7 @@ const BUDGETS = self.SidecarBudgets;
 const NWC = self.SidecarNWC;
 const RELAX = self.SidecarRelax;
 const BASELINE = self.SidecarBaseline;
+const ZAPREQ = self.SidecarZapRequests;
 
 const DEFAULT_RELAYS = {
   'wss://nos.lol': { read: true, write: true },
@@ -355,6 +356,29 @@ function pendingView() {
 
 // ---- keepalive (best-effort; correctness rests on the queue + reconcile) ----
 let keepaliveOn = false;
+// Payments in flight. An approved payment outlives the queue entry that authorized
+// it: settleEntry() splices the entry and resolves the prompt, and only THEN does
+// the NWC round trip begin. Without this counter, liveEntries() is already empty at
+// that moment, so approving a payment cleared the keepalive alarm at exactly the
+// instant the money was about to move — leaving the worker eligible for recycling
+// during a wait that can run to the full 30s NWC timeout. See issue #138.
+let payInFlight = 0;
+// The queue alarm fires at most every 30s, which is a coin-flip against MV3's own
+// ~30s idle timeout — fine for a prompt the user is looking at, not good enough to
+// carry a payment. Touching a chrome API on a shorter cycle is the documented way to
+// hold the worker up, so payments get a real heartbeat rather than a hopeful alarm.
+let payHeartbeat = null;
+function startPayHeartbeat() {
+  if (payHeartbeat) return;
+  payHeartbeat = setInterval(() => {
+    try { chrome.runtime.getPlatformInfo(() => void chrome.runtime.lastError); } catch (_) {}
+  }, 20000);
+}
+function stopPayHeartbeat() {
+  if (!payHeartbeat) return;
+  clearInterval(payHeartbeat);
+  payHeartbeat = null;
+}
 function ensureKeepalive() {
   if (keepaliveOn) return;
   keepaliveOn = true;
@@ -362,6 +386,7 @@ function ensureKeepalive() {
 }
 function stopKeepaliveIfIdle() {
   if (liveEntries().length) return;
+  if (payInFlight > 0) return; // never go idle with money in the air
   if (!keepaliveOn) return;
   keepaliveOn = false;
   chrome.alarms.clear(QUEUE_KEEPALIVE_ALARM);
@@ -1057,6 +1082,12 @@ async function handleNostrRpc(method, params, host, sendResponse, originWindowId
       try { await BASELINE.record(activePubkey, result, result.created_at || 0); } catch (_) {}
     }
 
+    // A zap request the user just authorized. Remember it so the payment that follows
+    // can be recognized as that zap (see zap-requests.js). Best-effort, same as above.
+    if (method === 'signEvent' && !isRelayAuth && result && result.kind === 9734) {
+      try { await ZAPREQ.record(host, activePubkey, result); } catch (_) {}
+    }
+
     // Pin this host to the account it just successfully used. Only an explicit
     // identity choice may MOVE an existing binding: a login (getPublicKey) or a
     // template that named its author (authorSwitched). A session-shaped request
@@ -1233,19 +1264,18 @@ async function weblnSendPayment(params, host, pubkey, originWindowId) {
   return payInvoiceCore(invoice, host, pubkey, params && params.memo, originWindowId);
 }
 
-// Decode just the BOLT11 description ('d', tag 13) — bech32, no deps. A zap
-// invoice carries the NIP-57 zap request (kind 9734) JSON there, which is how we
-// tell a genuine zap apart from any other payment for the auto-approve setting.
+// Minimal BOLT11 tagged-field reader — bech32, no deps.
 const BECH32_CHARS = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l';
-function bolt11Description(invoice) {
+// Read one BOLT11 tagged field as raw bytes; null when absent or malformed.
+function bolt11Field(invoice, wantTag) {
   try {
     const s = String(invoice).toLowerCase();
     const sep = s.lastIndexOf('1');
-    if (sep < 1) return '';
+    if (sep < 1) return null;
     const words = [];
     for (const c of s.slice(sep + 1)) {
       const v = BECH32_CHARS.indexOf(c);
-      if (v < 0) return '';
+      if (v < 0) return null;
       words.push(v);
     }
     const body = words.slice(0, words.length - 6); // drop checksum
@@ -1256,7 +1286,7 @@ function bolt11Description(invoice) {
       const len = body[i + 1] * 32 + body[i + 2];
       const start = i + 3;
       if (start + len > end) break;
-      if (tag === 13) {
+      if (tag === wantTag) {
         let acc = 0, bits = 0;
         const bytes = [];
         for (let k = start; k < start + len; k++) {
@@ -1264,22 +1294,19 @@ function bolt11Description(invoice) {
           bits += 5;
           if (bits >= 8) { bits -= 8; bytes.push((acc >> bits) & 0xff); }
         }
-        return new TextDecoder().decode(new Uint8Array(bytes));
+        return new Uint8Array(bytes);
       }
       i = start + len;
     }
   } catch (_) {}
-  return '';
+  return null;
 }
-function isZapInvoice(invoice) {
-  const desc = bolt11Description(invoice);
-  if (!desc || desc[0] !== '{') return false;
-  try {
-    const ev = JSON.parse(desc);
-    return !!ev && ev.kind === 9734;
-  } catch (_) {
-    return false;
-  }
+// The 'p' field — the one identifier that lets us ask a wallet, after the fact,
+// whether an invoice was actually paid.
+function bolt11PaymentHash(invoice) {
+  const b = bolt11Field(invoice, 1); // 'p'
+  if (!b || b.length !== 32) return '';
+  return Array.from(b, (x) => x.toString(16).padStart(2, '0')).join('');
 }
 
 // ---- payment serialization + auto-zap aggregate cap ----
@@ -1310,12 +1337,96 @@ async function recordAutoZap(sats) {
   await sset({ [AUTOZAP_WINDOW_KEY]: { spent: spent + Math.max(0, Math.floor(sats || 0)), resetAt } });
 }
 
+// Ask the wallet whether an invoice actually settled. Called ONLY to resolve a
+// pay_invoice whose outcome we couldn't hear — never to decide whether to pay.
+// lookup_invoice is read-only, so this can't double-spend.
+//
+// A payment can still be in flight when we first ask (a slow route is the very
+// reason the response was missed), so poll briefly rather than taking one "not yet"
+// as a no. An explicit 'failed' is authoritative and stops early.
+const naptime = (ms) => new Promise((r) => setTimeout(r, ms));
+const invSettled = (inv) => !!(inv && (inv.settled_at || inv.preimage || inv.state === 'settled'));
+const invFailed = (inv) => !!(inv && (inv.state === 'failed' || inv.state === 'expired'));
+
+// When to stop trusting silence. Most zaps settle in a few seconds; past that the
+// ephemeral response is more likely lost than late, and the wallet's own record is
+// both faster and more truthful than waiting out the 30s NWC timeout.
+const LOOKUP_START_MS = 8000;
+const LOOKUP_EVERY_MS = 3000;
+// How long to keep asking after pay_invoice has given up. A payment that outran the
+// NWC timeout is usually a slow route still completing, so it's worth a bounded wait
+// rather than immediately reporting a failure we haven't verified.
+const CONFIRM_GRACE_MS = 12000;
+
+// Pay, and watch the wallet's own ledger at the same time.
+//
+// pay_invoice alone is a single point of failure: the kind:23195 reply is ephemeral,
+// so if it goes missing the request just sits there until the 30s timeout, and the
+// page waits the whole time for an answer that already exists. Polling lookup_invoice
+// in parallel from 8s means the usual outcome is "we found out at ~8s" rather than
+// "we gave up at 30s" — and what we report is what the wallet actually did.
+//
+// One watcher serves both jobs: racing the payment, and confirming an indeterminate
+// failure afterwards. Running a second poller for the latter would just double the
+// traffic to the wallet relay. lookup_invoice is read-only, so watching a payment
+// alongside it can never cause a second one.
+async function payAndConfirm(c, invoice) {
+  const hash = bolt11PaymentHash(invoice);
+  const arg = hash ? { payment_hash: hash } : { invoice };
+  let stop = false;
+  let deadline = Infinity; // tightened once pay_invoice gives up
+
+  const paying = c.payInvoice(invoice).then(
+    (res) => ({ kind: 'paid', res }),
+    (err) => ({ kind: 'error', err })
+  );
+
+  const watching = (async () => {
+    await naptime(LOOKUP_START_MS);
+    while (!stop && Date.now() < deadline) {
+      try {
+        const inv = await c.lookupInvoice(arg);
+        if (invSettled(inv)) return { kind: 'paid', res: inv };
+        if (invFailed(inv)) return { kind: 'error', err: new Error('The payment failed') };
+      } catch (_) {
+        // Early on the wallet may not know this invoice yet ("not found"), and the
+        // lookup can fail on the same connection that lost the reply. Keep watching.
+      }
+      await naptime(LOOKUP_EVERY_MS);
+    }
+    return { kind: 'unknown' };
+  })();
+
+  try {
+    const first = await Promise.race([paying, watching]);
+    if (first.kind === 'paid') return first.res;
+    // The wallet gave a definitive no. Nothing moved, so don't go looking.
+    if (first.kind === 'error' && first.err && first.err.walletDenied) throw first.err;
+    // Indeterminate. Let the watcher already in flight run on a little longer.
+    deadline = Date.now() + CONFIRM_GRACE_MS;
+    const second = await watching;
+    if (second.kind === 'paid') return second.res;
+    throw first.err || (second.kind === 'error' ? second.err : new Error('Payment status unknown'));
+  } finally {
+    stop = true;
+  }
+}
+
 // Shared payment core: budget-gate (prompt if needed), pay via NWC, decrement
 // budget, log, and notify the panel. Used by window.webln.sendPayment AND the
 // "Pay with Sidecar" context menu. Assumes the caller resolved `pubkey` and
 // checked the account/site is usable. Serialized per account (see withPayLock).
 function payInvoiceCore(invoiceRaw, host, pubkey, memo, originWindowId) {
-  return withPayLock(pubkey, () => payInvoiceLocked(invoiceRaw, host, pubkey, memo, originWindowId));
+  // Hold the worker up for the whole payment, approval prompt included.
+  payInFlight++;
+  ensureKeepalive();
+  startPayHeartbeat();
+  return withPayLock(pubkey, () => payInvoiceLocked(invoiceRaw, host, pubkey, memo, originWindowId))
+    .finally(() => {
+      payInFlight--;
+      if (payInFlight === 0) stopPayHeartbeat();
+      stopKeepaliveIfIdle();
+    });
 }
 async function payInvoiceLocked(invoiceRaw, host, pubkey, memo, originWindowId) {
   const invoice = String(invoiceRaw || '').replace(/^lightning:/i, '').trim();
@@ -1337,7 +1448,8 @@ async function payInvoiceLocked(invoiceRaw, host, pubkey, memo, originWindowId) 
     ? (dailyMaxSet > 0 ? dailyMaxSet : zapMax * AUTOZAP_DAILY_MULTIPLE)
     : 0;
   let zapOk = false;
-  if (unlocked && zapMax > 0 && sats <= zapMax && isZapInvoice(invoice)) {
+  // Amount is checked before claiming so an over-cap payment doesn't burn the record.
+  if (unlocked && zapMax > 0 && sats <= zapMax && (await ZAPREQ.claim(host, pubkey, sats))) {
     const { spent } = await autoZapWindow();
     zapOk = zapDailyMax > 0 && spent + sats <= zapDailyMax;
   }
@@ -1372,7 +1484,14 @@ async function payInvoiceLocked(invoiceRaw, host, pubkey, memo, originWindowId) 
   bumpAutoLock();
   const c = await getSwNwc(pubkey);
   if (!c) throw new Error('No wallet connected in Sidecar');
-  const res = await c.payInvoice(invoice);
+  // Never report a payment as failed on the strength of not having heard back.
+  // Publishing the NIP-47 request is what commits the money; hearing the reply is a
+  // separate thing that can fail on its own (a slow route outrunning the 30s timeout,
+  // a relay blip losing the ephemeral kind:23195, an undecryptable response). Each of
+  // those used to surface to the page as an error while the sats were gone, or hang
+  // it for the full 180s — issue #138. The wallet is the only authority on what
+  // actually happened, so payAndConfirm asks it rather than inferring from silence.
+  const res = await payAndConfirm(c, invoice);
   const preimage = res && (res.preimage || res.payment_preimage);
 
   // ---- the money has moved; from here nothing may delay the caller ----
@@ -1592,6 +1711,9 @@ async function lockKeystore(auto = false) {
   // signs makes no sense, and idle auto-lock is exactly the "walked away" case
   // where a lingering auto-sign shouldn't survive.
   RELAX.revokeAll().then(syncRelaxBadge);
+  // Same reasoning for pending zap requests: they authorize a payment to go out with
+  // no prompt, so a locked keystore must not leave any of them spendable.
+  ZAPREQ.clear().catch(() => {});
   // Tell any open panel/popup to drop to the unlock screen immediately — otherwise
   // it keeps showing whatever was open (e.g. the composer) and only discovers the
   // lock on its next action, which then fails with a "locked" error. `auto` marks an

--- a/background.js
+++ b/background.js
@@ -970,9 +970,15 @@ async function handleNostrRpc(method, params, host, sendResponse, originWindowId
     // A shared-identity content sign always confirms, regardless of trust tier —
     // unless it's a coalesced app-data sign, under an active relax window, etc.
     // A destructive overwrite overrides every skip.
+    // A zap request within the auto-zap caps signs without asking, so "auto-approve
+    // zaps" covers the whole zap rather than just its second half. See autoZapMaySign.
+    const zapAutoSign = method === 'signEvent' && signKind === 9734
+      ? await autoZapMaySign(signEvent)
+      : false;
+
     const needApproval = destructive
       ? true
-      : (coalesced || appDataAutoAllow || decryptCoalesced || relaxActive
+      : (coalesced || appDataAutoAllow || decryptCoalesced || relaxActive || zapAutoSign
           ? false
           : ((status === 'ask' && !isRelayAuth) || sharedIdentity));
 
@@ -1337,6 +1343,95 @@ async function recordAutoZap(sats) {
   await sset({ [AUTOZAP_WINDOW_KEY]: { spent: spent + Math.max(0, Math.floor(sats || 0)), resetAt } });
 }
 
+// Auto-zap covers BOTH gates of a zap: signing the kind:9734 request, and paying the
+// invoice the lnurl server returns for it. Raising the cap only ever silenced the
+// second one, which is why a small zap could still stop to ask — the signing prompt is
+// governed by the site's permission tier and the shared-host override, not by any
+// wallet setting.
+//
+// A zap request carries its own `amount` tag, so the very same per-zap and daily caps
+// can be applied at signing time. This check is advisory: the payment path re-checks
+// and is the thing that actually records the spend, so the caps are still enforced
+// there even if several requests get signed before any of them is paid.
+//
+// Like relax mode, this overrides the shared-host confirm — and unlike relax mode it
+// is bounded by an amount, not just a clock. Fails closed on anything unexpected.
+async function autoZapMaySign(ev) {
+  try {
+    if (!ev || ev.kind !== 9734) return false;
+    if (KS.isLocked()) return false;
+    const settings = (await sget('sidecar_settings')).sidecar_settings || {};
+    if (settings.autoZap !== true) return false;
+    const zapMax = Number(settings.autoZapMaxSats) || 0;
+    if (zapMax <= 0) return false;
+    const tag = Array.isArray(ev.tags) ? ev.tags.find((t) => Array.isArray(t) && t[0] === 'amount') : null;
+    const msat = tag ? Number(tag[1]) : 0;
+    // NIP-57 makes `amount` optional, and a request that declares no amount can't be
+    // held to a cap. Ask for those.
+    if (!Number.isFinite(msat) || msat <= 0) return false;
+    const sats = Math.round(msat / 1000);
+    if (sats > zapMax) return false;
+    const dailySet = Number(settings.autoZapDailyMaxSats);
+    const dailyMax = dailySet > 0 ? dailySet : zapMax * AUTOZAP_DAILY_MULTIPLE;
+    if (dailyMax <= 0) return false;
+    const { spent } = await autoZapWindow();
+    return spent + sats <= dailyMax;
+  } catch (_) {
+    return false;
+  }
+}
+
+// The page-invoice card asks this before it appears: is this invoice simply the one
+// for a zap the user already authorized here? Jumble and other Bitcoin Connect clients
+// render a QR rather than calling window.webln, so the card — not the approval prompt —
+// is what stands between picking an amount and paying.
+//
+// Answers true only when an unconsumed zap request signed on THIS host and account,
+// for THIS exact amount, is waiting, and the auto-zap caps allow it. Then there is
+// nothing left to confirm. Every other case returns false and the card appears.
+//
+// Peeks rather than claims: payInvoiceCore does the real, single-use claim, and
+// consuming the record here would make it prompt instead.
+//
+// `host` MUST come from the sender's URL, never from the message body — see the call
+// site in the router.
+async function tryZapAutopay(invoiceRaw, host, originWindowId, tabId) {
+  const no = (why) => {
+    dlog('info', 'zap', 'auto-pay declined', { why, host });
+    return { handled: false, paid: false };
+  };
+  const inv = String(invoiceRaw || '');
+  if (!host || !inv) return no('no host or invoice');
+  if (KS.isLocked()) return no('keystore locked');
+  const settings = (await sget('sidecar_settings')).sidecar_settings || {};
+  if (settings.autoZap !== true) return no('auto-approve zaps is off');
+  const cap = Number(settings.autoZapMaxSats) || 0;
+  if (cap <= 0) return no('per-zap cap is 0');
+  const amt = invoiceSats(inv);
+  if (amt == null) return no('invoice has no amount');
+  if (amt > cap) return no(amt + ' sats exceeds the ' + cap + ' cap');
+  const who = await resolveSiteAccount(host);
+  if (!who) return no('no account resolved for ' + host);
+  if ((await PERMS.getLevel(who, host)) === 'blocked') return no('site is blocked');
+  if (!(await ZAPREQ.peek(host, who, amt))) {
+    return no('no zap request signed here matches ' + amt + ' sats (' + amt * 1000 + ' msat)');
+  }
+  // Show the card in its auto form first. Money moving with nothing on screen is the
+  // wrong trade even when the user opted out of being asked — and it means a failure
+  // has somewhere to be reported instead of vanishing.
+  notifyTabAutopaying(tabId, inv);
+  try {
+    await payInvoiceCore(inv, host, who, undefined, originWindowId);
+    notifyTabPaid(tabId, inv);
+    return { handled: true, paid: true };
+  } catch (e) {
+    // Still handled: the auto card is up and is where this error belongs. Replacing it
+    // with a fresh manual card would throw the reason away.
+    notifyTabPayFailed(tabId, inv, e && e.message);
+    return { handled: true, paid: false };
+  }
+}
+
 // Ask the wallet whether an invoice actually settled. Called ONLY to resolve a
 // pay_invoice whose outcome we couldn't hear — never to decide whether to pay.
 // lookup_invoice is read-only, so this can't double-spend.
@@ -1352,7 +1447,9 @@ const invFailed = (inv) => !!(inv && (inv.state === 'failed' || inv.state === 'e
 // ephemeral response is more likely lost than late, and the wallet's own record is
 // both faster and more truthful than waiting out the 30s NWC timeout.
 const LOOKUP_START_MS = 8000;
-const LOOKUP_EVERY_MS = 3000;
+// NIP-47 defines a RATE_LIMITED error ("sending commands too fast"), so poll at a
+// pace that answers quickly without giving the wallet a reason to start refusing.
+const LOOKUP_EVERY_MS = 5000;
 // How long to keep asking after pay_invoice has given up. A payment that outran the
 // NWC timeout is usually a slow route still completing, so it's worth a bounded wait
 // rather than immediately reporting a failure we haven't verified.
@@ -1383,14 +1480,18 @@ async function payAndConfirm(c, invoice) {
 
   const watching = (async () => {
     await naptime(LOOKUP_START_MS);
+    let attempt = 0;
     while (!stop && Date.now() < deadline) {
       try {
+        attempt++;
         const inv = await c.lookupInvoice(arg);
+        dlog('info', 'pay', 'lookup_invoice', { attempt, state: inv && inv.state, type: inv && inv.type });
         if (invSettled(inv)) return { kind: 'paid', res: inv };
         if (invFailed(inv)) return { kind: 'error', err: new Error('The payment failed') };
-      } catch (_) {
+      } catch (e) {
         // Early on the wallet may not know this invoice yet ("not found"), and the
         // lookup can fail on the same connection that lost the reply. Keep watching.
+        dlog('info', 'pay', 'lookup_invoice failed', { attempt, error: (e && e.message) || String(e) });
       }
       await naptime(LOOKUP_EVERY_MS);
     }
@@ -1403,9 +1504,21 @@ async function payAndConfirm(c, invoice) {
     // The wallet gave a definitive no. Nothing moved, so don't go looking.
     if (first.kind === 'error' && first.err && first.err.walletDenied) throw first.err;
     // Indeterminate. Let the watcher already in flight run on a little longer.
+    dlog('info', 'pay', 'no usable answer from pay_invoice; confirming', {
+      error: (first.err && first.err.message) || first.kind,
+      graceMs: CONFIRM_GRACE_MS,
+    });
     deadline = Date.now() + CONFIRM_GRACE_MS;
     const second = await watching;
-    if (second.kind === 'paid') return second.res;
+    if (second.kind === 'paid') {
+      dlog('info', 'pay', 'rescued — wallet confirms the payment settled');
+      return second.res;
+    }
+    // The one outcome worth finding in a log later: we are about to tell the page a
+    // payment failed without the wallet ever having confirmed it either way.
+    dlog('error', 'pay', 'reporting failure; wallet never confirmed a settlement', {
+      error: (first.err && first.err.message) || 'unknown',
+    });
     throw first.err || (second.kind === 'error' ? second.err : new Error('Payment status unknown'));
   } finally {
     stop = true;
@@ -1448,8 +1561,11 @@ async function payInvoiceLocked(invoiceRaw, host, pubkey, memo, originWindowId) 
     ? (dailyMaxSet > 0 ? dailyMaxSet : zapMax * AUTOZAP_DAILY_MULTIPLE)
     : 0;
   let zapOk = false;
-  // Amount is checked before claiming so an over-cap payment doesn't burn the record.
-  if (unlocked && zapMax > 0 && sats <= zapMax && (await ZAPREQ.claim(host, pubkey, sats))) {
+  // Claim only if the payment actually needs it: the site's budget already covering
+  // this one makes autoOk true either way, and a zap approval is single-use, so
+  // spending one here would be for nothing. The amount is likewise checked first so
+  // an over-cap payment doesn't burn a record it can't use.
+  if (!budgetOk && unlocked && zapMax > 0 && sats <= zapMax && (await ZAPREQ.claim(host, pubkey, sats))) {
     const { spent } = await autoZapWindow();
     zapOk = zapDailyMax > 0 && spent + sats <= zapDailyMax;
   }
@@ -1505,6 +1621,13 @@ async function payInvoiceLocked(invoiceRaw, host, pubkey, memo, originWindowId) 
   // These still run, and still run in order where order matters (budget accounting
   // must not be dropped or the spend under-counts). They just no longer stand
   // between the payment and the reply.
+  // Counted as still in flight until the bookkeeping lands. Without this the
+  // heartbeat stopped the moment the payment resolved — while these writes were
+  // still pending — so a worker recycled in that gap would drop the budget debit
+  // and the auto-zap daily total. Both are spending limits: dropping them lets the
+  // next payment through on a stale count. The reply is not delayed by this; only
+  // the worker's eligibility to sleep is.
+  payInFlight++;
   (async () => {
     // Decrement the budget by the paid amount (known amount only).
     if (sats != null) await BUDGETS.consume(pubkey, host, sats);
@@ -1512,7 +1635,13 @@ async function payInvoiceLocked(invoiceRaw, host, pubkey, memo, originWindowId) 
     // rolling daily total, so the aggregate cap is enforced across the window.
     if (zapOk && !budgetOk && sats != null) await recordAutoZap(sats);
     await setSiteAccount(host, pubkey);
-  })().catch(() => {});
+  })()
+    .catch(() => {})
+    .then(() => {
+      payInFlight--;
+      if (payInFlight === 0) stopPayHeartbeat();
+      stopKeepaliveIfIdle();
+    });
   logActivity({ ts: Date.now(), host, method: 'webln.sendPayment', amountSats: sats, pubkey });
   // Tell an open side panel to refresh its balance/history.
   chrome.runtime.sendMessage({ type: 'SIDECAR_EVENT', event: 'walletChanged' }).catch(() => {});
@@ -1565,6 +1694,15 @@ async function notifyTabsPaidByHost(host) {
       }
     });
   } catch (_) {}
+}
+
+// Tell a tab an auto-zap is going out, so the page-invoice card can show what's
+// happening instead of money moving with nothing on screen. Sent BEFORE the payment,
+// so the card is already up when the result lands on it.
+function notifyTabAutopaying(tabId, invoice) {
+  if (tabId != null && chrome.tabs) {
+    chrome.tabs.sendMessage(tabId, { type: 'SIDECAR_EVENT', event: 'autopaying', invoice }, () => void chrome.runtime.lastError);
+  }
 }
 
 function notifyTabPaid(tabId, invoice) {
@@ -2115,6 +2253,16 @@ async function handleControl(message, sendResponse) {
         await clearSiteAccount(message.host);
         result = true;
         break;
+      // The page-invoice card asks before it appears: is this invoice simply the one
+      // for a zap the user already authorized here? Jumble and other Bitcoin Connect
+      // clients render a QR rather than calling window.webln, so the card — not the
+      // approval prompt — is what stands between picking an amount and paying. When
+      // the invoice matches a zap request signed moments ago on this same host and
+      // account, for this exact amount, and the auto-zap caps allow it, there is
+      // nothing left to confirm: pay it and let the card stay away.
+      //
+      // Peek rather than claim — payInvoiceCore does the real, single-use claim, and
+      // consuming the record here would make it prompt instead.
       case 'SIDECAR_GET_ACTIVITY': {
         const me = await KS.getActivePubkey();
         const all = (await sget(ACTIVITY_KEY))[ACTIVITY_KEY] || [];
@@ -2224,8 +2372,15 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     (typeof sender.url === 'string' && sender.url.startsWith(EXT_URL_PREFIX)) ||
     (typeof sender.origin === 'string' && sender.origin + '/' === EXT_URL_PREFIX)
   );
+  // SIDECAR_TRY_ZAP_AUTOPAY belongs here for the same reason SIDECAR_PAY_PAGE_INVOICE
+  // does — the page-invoice card lives in the content script — and it is strictly
+  // more restrictive than that one: it pays only when auto-zap is on, the amount is
+  // inside both caps, and an unconsumed zap request signed on THIS host and account
+  // for THIS exact amount is waiting. A content script can't forge that record; only
+  // a signature the user authorized through Sidecar creates one.
   const CONTENT_OK = new Set([
     'SIDECAR_NOSTR_RPC', 'SIDECAR_WEBLN_RPC', 'SIDECAR_PAY_PAGE_INVOICE',
+    'SIDECAR_TRY_ZAP_AUTOPAY',
     'SIDECAR_IS_CONNECTED', 'SIDECAR_GET_SETTINGS', 'SIDECAR_SET_SETTINGS',
   ]);
   if (!fromExtPage && !CONTENT_OK.has(message.type)) {
@@ -2275,6 +2430,18 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   // whether to nudge the user to open/pin Sidecar from the toolbar.
   if (message.type === 'SIDECAR_PANEL_OPEN') {
     waitForPanelPort(300).then((port) => sendResponse({ ok: true, open: !!port }));
+    return true; // async response
+  }
+
+  // Card auto-pay probe. Host comes from the sender's own URL, like the handlers
+  // around it — a content script must not be able to name a different site and spend
+  // against its zap approvals.
+  if (message.type === 'SIDECAR_TRY_ZAP_AUTOPAY') {
+    let h = '';
+    try { h = new URL((sender && sender.url) || '').host; } catch (_) {}
+    tryZapAutopay(message.invoice, h, originWindowId, sender && sender.tab && sender.tab.id)
+      .then((r) => sendResponse({ ok: true, result: r }))
+      .catch((e) => sendResponse({ ok: false, error: e.message }));
     return true; // async response
   }
 

--- a/background.js
+++ b/background.js
@@ -1213,8 +1213,16 @@ async function handleWeblnRpc(method, params, host, sendResponse, originWindowId
       throw new Error('Sidecar does not support webln.' + method);
     }
 
-    await setSiteAccount(host, pubkey);
+    // Answer the page FIRST, then do bookkeeping. setSiteAccount is a storage read
+    // plus a write, and it used to sit between a completed payment and the reply —
+    // so if MV3 recycled the worker in that gap the sats had already moved, the
+    // Activity log already had it, and the page's webln.sendPayment promise was left
+    // hanging forever. That's issue #138: a stuck Bitcoin Connect modal on a payment
+    // that demonstrably succeeded (valid preimage, balance decremented).
     sendResponse({ ok: true, result });
+    // Fire-and-forget: the binding is useful but must never be able to cost the page
+    // its answer. A failure here is invisible and self-heals on the next request.
+    setSiteAccount(host, pubkey).catch(() => {});
   } catch (e) {
     sendResponse({ ok: false, error: e.message });
   }
@@ -1367,13 +1375,25 @@ async function payInvoiceLocked(invoiceRaw, host, pubkey, memo, originWindowId) 
   const res = await c.payInvoice(invoice);
   const preimage = res && (res.preimage || res.payment_preimage);
 
-  // Decrement the budget by the paid amount (known amount only).
-  if (sats != null) await BUDGETS.consume(pubkey, host, sats);
-  // Count an auto-zap (one authorized solely by the zap allowance) against the
-  // rolling daily total, so the aggregate cap is enforced across the window.
-  if (zapOk && !budgetOk && sats != null) await recordAutoZap(sats);
-
-  await setSiteAccount(host, pubkey);
+  // ---- the money has moved; from here nothing may delay the caller ----
+  // Everything below is bookkeeping. It used to be awaited one item at a time
+  // BEFORE returning, which meant several storage round-trips sat between a
+  // settled payment and the page hearing about it. If MV3 recycled the worker in
+  // that window the sats were gone, the balance was right, the Activity log had the
+  // entry — and the page's promise never resolved. See issue #138: a Bitcoin
+  // Connect modal stuck on "waiting" for a payment with a valid preimage.
+  //
+  // These still run, and still run in order where order matters (budget accounting
+  // must not be dropped or the spend under-counts). They just no longer stand
+  // between the payment and the reply.
+  (async () => {
+    // Decrement the budget by the paid amount (known amount only).
+    if (sats != null) await BUDGETS.consume(pubkey, host, sats);
+    // Count an auto-zap (one authorized solely by the zap allowance) against the
+    // rolling daily total, so the aggregate cap is enforced across the window.
+    if (zapOk && !budgetOk && sats != null) await recordAutoZap(sats);
+    await setSiteAccount(host, pubkey);
+  })().catch(() => {});
   logActivity({ ts: Date.now(), host, method: 'webln.sendPayment', amountSats: sats, pubkey });
   // Tell an open side panel to refresh its balance/history.
   chrome.runtime.sendMessage({ type: 'SIDECAR_EVENT', event: 'walletChanged' }).catch(() => {});

--- a/content.js
+++ b/content.js
@@ -318,6 +318,14 @@
     '.pay:active{transform:translateY(1px);}' +
     '.pay.pending{cursor:default;opacity:.94;}' +
     '.pay.done{cursor:default;background:none;box-shadow:none;{CARD_SUCCESS};}' +
+    // Auto-zap: nothing here is pressable, so it must not read as a button. Strip the
+    // fill, the shadow and the bold weight and let it sit as a status line — the same
+    // treatment .done already uses. The spinner is drawn in the button-text color, so
+    // on a flat card it has to switch to currentColor or it disappears.
+    '.auto .pay{background:none;box-shadow:none;cursor:default;font-weight:600;padding:12px 14px 4px;color:{CARD_TEXT};}' +
+    '.auto .pay:hover{filter:none;}' +
+    '.auto .pay.pending{opacity:1;}' +
+    '.auto .pay.pending .pay-spin{border:2px solid currentColor;border-top-color:transparent;opacity:.55;}' +
     '.pay-bolt{height:16px;width:auto;display:block;}' +
     '.pay.pending .pay-bolt,.pay.done .pay-bolt{display:none;}' +
     '.pay-check{display:none;width:18px;height:18px;}' +
@@ -554,14 +562,17 @@
     }
   }
 
-  function renderCard(invoice) {
+  // `auto` renders the same card for a zap going out under the auto-zap limits: no
+  // decision to make, but the spend is still shown, and a failure has somewhere to
+  // land. It drops straight into the sending state and reuses setPaid/setError.
+  function renderCard(invoice, auto) {
     removeCard();
     shownInvoice = invoice;
     const sats = invoiceSats(invoice);
     const memo = invoiceMemo(invoice);
     const site = location.host.replace(/^www\./, '');
 
-    const eyebrow = sats != null ? "You're paying" : 'Pay with Sidecar';
+    const eyebrow = auto ? 'Auto-zapping' : sats != null ? "You're paying" : 'Pay with Sidecar';
     const amountBlock =
       sats != null
         ? '<div class="amt"><span class="num">' + sats.toLocaleString('en-US') + '</span><span class="unit">sats</span></div>'
@@ -582,7 +593,8 @@
     s.innerHTML =
       '<style>' + cardCss + '</style>' +
       '<div class="ov">' +
-      '<div class="card" role="dialog" aria-label="Pay with Sidecar">' +
+      '<div class="card' + (auto ? ' auto' : '') + '" role="dialog" aria-label="' +
+      (auto ? 'Auto-zap in progress' : 'Pay with Sidecar') + '">' +
       '<div class="brand">' + logoSvg + '</div>' +
       '<div class="eyebrow">' + eyebrow + '</div>' +
       amountBlock +
@@ -614,16 +626,18 @@
     // back or re-tap. The background reports the outcome via 'paid' / 'payfailed'.
     const label = s.querySelector('.pay-label');
     const status = s.querySelector('.pay-status');
-    function setSending() {
+    function setSending(isAuto) {
       sending = true;
       card.classList.add('busy'); // dims + disables Not now / the toggle
       payBtn.classList.remove('done');
       payBtn.classList.add('pending');
       payBtn.disabled = true;
-      label.textContent = 'Sending payment…';
+      label.textContent = isAuto ? 'Zapping…' : 'Sending payment…';
       status.hidden = false;
       status.className = 'pay-status';
-      status.textContent = 'Confirming with your wallet. This can take a few seconds.';
+      status.textContent = isAuto
+        ? 'Inside your auto-zap limits, so Sidecar is paying this without asking.'
+        : 'Confirming with your wallet. This can take a few seconds.';
     }
     function setPaid() {
       payBtn.classList.remove('pending');
@@ -676,13 +690,54 @@
 
     (document.documentElement || document.body).appendChild(cardHost);
     requestAnimationFrame(() => ov.classList.add('in'));
+    // Auto-zap: the payment is already on its way, so open in the sending state. A
+    // failure re-enables Try again / Not now via setError, which is the right
+    // affordance once there's a decision to make again.
+    if (auto) setSending(true);
   }
+
+  // Auto-pay bookkeeping. The MutationObserver re-scans constantly, so a decision
+  // in flight must not spawn a second attempt, and a decline must be remembered or
+  // the card would never get to appear.
+  let autopayPending = '';
+  let autopayDeclined = '';
 
   function scanForInvoice() {
     if (!showCard || !connectedToSite) return removeCard();
     const invoice = findPageInvoice();
     if (!invoice || invoice === dismissedInvoice) return removeCard();
     if (invoice === shownInvoice && cardHost) return; // already showing this one
+    if (invoice === autopayPending) return; // asking the worker; show nothing yet
+    if (invoice !== autopayDeclined) {
+      // Ask first whether this is just the invoice for a zap already authorized on
+      // this page. If it is, the worker pays it and no card is ever needed.
+      autopayPending = invoice;
+      chrome.runtime
+        .sendMessage({ type: 'SIDECAR_TRY_ZAP_AUTOPAY', invoice, host })
+        .then((res) => {
+          autopayPending = '';
+          const r = (res && res.ok && res.result) || null;
+          if (r && r.handled) {
+            // Either way the auto card has already been shown and carries the result.
+            // Mark the invoice spent so the next DOM mutation can't re-probe it — the
+            // approval is single-use, so that second probe would be declined and would
+            // replace the card (and, on failure, throw the error message away).
+            autopayDeclined = invoice;
+            if (r.paid) dismissedInvoice = invoice;
+            return;
+          }
+          autopayDeclined = invoice;
+          scanForInvoice();
+        })
+        .catch(() => {
+          // Worker asleep or updating — fall back to asking the user, never to
+          // paying silently.
+          autopayPending = '';
+          autopayDeclined = invoice;
+          scanForInvoice();
+        });
+      return;
+    }
     renderCard(invoice);
   }
 
@@ -699,6 +754,10 @@
     if (msg.event === 'settings') {
       showCard = msg.showPayButton !== false;
       scanForInvoice();
+    } else if (msg.event === 'autopaying') {
+      // An auto-zap is going out for this invoice — show it, with no action to take.
+      // The 'paid' / 'payfailed' events below then land on this same card.
+      if (msg.invoice) renderCard(msg.invoice, true);
     } else if (msg.event === 'paid') {
       dismissedInvoice = msg.invoice; // don't resurface even if the link lingers
       // Throw the bolt across the page whether or not our own card was up — a zap

--- a/manifest.json
+++ b/manifest.json
@@ -26,6 +26,7 @@
       "nwc-client.js",
       "relax-grants.js",
       "replaceable-baseline.js",
+      "zap-requests.js",
       "jsqr.js",
       "background.js"
     ]

--- a/nwc-client.js
+++ b/nwc-client.js
@@ -24,6 +24,7 @@
   }
 
   const REQUEST_TIMEOUT = 30000;
+  const LOOKUP_TIMEOUT = 10000;
 
   function makeClient(connectionString) {
     const conn = NT.nip47.parseConnectionString(connectionString); // { pubkey, relay, secret }
@@ -42,7 +43,7 @@
     // with an error) means no money moved. Every other rejection — timeout, dropped
     // relay, undecryptable response — is INDETERMINATE, and a caller that spends
     // money must verify with lookup_invoice before reporting failure.
-    function request(method, params) {
+    function request(method, params, timeoutMs) {
       return new Promise((resolve, reject) => {
         (async () => {
           const content = await encrypt(JSON.stringify({ method, params: params || {} }));
@@ -83,7 +84,7 @@
             settled = true;
             try { sub.close(); } catch (_) {}
             reject(new Error('Wallet did not respond (timed out)'));
-          }, REQUEST_TIMEOUT);
+          }, timeoutMs || REQUEST_TIMEOUT);
           try {
             await Promise.any(pool().publish([relay], reqEvent));
           } catch (_) {
@@ -133,7 +134,10 @@
       makeInvoice: (amountMsat, description) =>
         request('make_invoice', { amount: amountMsat, description: description || '' }),
       listTransactions: (params) => request('list_transactions', params || { limit: 20, unpaid: false }),
-      lookupInvoice: (params) => request('lookup_invoice', params),
+      // Short timeout: a lookup is a status poll, and one that hangs for the full 30s
+      // would stall the watcher that's meant to be checking on a payment in flight.
+      // Failing fast just means the next poll asks again.
+      lookupInvoice: (params, timeoutMs) => request('lookup_invoice', params, timeoutMs || LOOKUP_TIMEOUT),
       subscribeNotifications,
       close: () => { try { pool().close([relay]); } catch (_) {} },
     };

--- a/nwc-client.js
+++ b/nwc-client.js
@@ -34,6 +34,14 @@
     const encrypt = (text) => NT.nip04.encrypt(sk, walletPubkey, text);
     const decrypt = (cipher) => NT.nip04.decrypt(sk, walletPubkey, cipher);
 
+    // Rejection contract, which matters for pay_invoice: a rejected request does
+    // NOT mean the wallet did nothing. Once the kind:23194 request is published the
+    // wallet may act on it, and our ability to hear the kind:23195 answer is a
+    // separate, fallible thing — 23195 is ephemeral, so relays don't replay it if
+    // the connection blips. Only `err.walletDenied` (the wallet explicitly answered
+    // with an error) means no money moved. Every other rejection — timeout, dropped
+    // relay, undecryptable response — is INDETERMINATE, and a caller that spends
+    // money must verify with lookup_invoice before reporting failure.
     function request(method, params) {
       return new Promise((resolve, reject) => {
         (async () => {
@@ -56,8 +64,14 @@
                 try { sub.close(); } catch (_) {}
                 try {
                   const res = JSON.parse(await decrypt(ev.content));
-                  if (res.error) reject(new Error(res.error.message || res.error.code || 'Wallet error'));
-                  else resolve(res.result);
+                  if (res.error) {
+                    // The wallet answered, and the answer was no. This is the ONLY
+                    // failure we can be certain left the money where it was — see
+                    // the rejection contract above.
+                    const err = new Error(res.error.message || res.error.code || 'Wallet error');
+                    err.walletDenied = true;
+                    reject(err);
+                  } else resolve(res.result);
                 } catch (e) {
                   reject(new Error('Could not read wallet response'));
                 }

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -331,6 +331,7 @@
           <input type="text" inputmode="numeric" id="autozap-daily-max" class="autozap-max-input" />
           <span>sats</span>
         </label>
+        <p class="hint">Covers zaps you start in a client. For other payments, give a site its own daily budget under <strong>Sites</strong>.</p>
       </div>
 
       <div class="setting">

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -319,7 +319,7 @@
 
       <div class="setting">
         <h3>Automatic zaps</h3>
-        <p class="hint">Pay zaps without a prompt, up to a limit per zap and a daily total across all sites. Larger zaps, anything over the daily total, and all other payments still ask.</p>
+        <p class="hint">Zaps within these limits go through with no confirmation at all: Sidecar signs them, pays them, and skips its payment card. Only zaps you start in a client qualify, matched to the request Sidecar signed. Larger zaps, anything over the daily total, and every other payment still ask.</p>
         <label class="toggle-row"><input type="checkbox" id="autozap-toggle" /> <span>Auto-approve zaps</span></label>
         <label class="toggle-row hidden" id="autozap-max-row">
           <span>Max per zap</span>

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -7358,7 +7358,13 @@
     call({ type: 'SIDECAR_GET_BUDGETS' })
       .then((budgets) => {
         const hosts = Object.keys(budgets || {}).sort();
-        if (!hosts.length) { list.classList.add('empty'); listState(list, 'No sites have a spending budget.'); return; }
+        // Budgets can only be created from a payment prompt, so an empty list has to
+        // say how — otherwise the feature is invisible to anyone who ever unticked it.
+        if (!hosts.length) {
+          list.classList.add('empty');
+          listState(list, 'No sites have a spending budget. Tick “remember a budget” when you approve a payment.');
+          return;
+        }
         list.classList.remove('empty');
         list.innerHTML = '';
         hosts.forEach((host) => list.append(budgetRow(host, budgets[host])));

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -581,7 +581,6 @@
     if (typeof syncApprovalOverlay === 'function') syncApprovalOverlay();
   }
 
-
   // ---- onboarding ----
   const validateOnboardingPin = attachPinValidation($('ob-pin'), $('ob-pin2'), $('ob-submit'));
   $('onboarding-form').addEventListener('submit', async (e) => {
@@ -6257,7 +6256,6 @@
   // stale exchange rate can never misrepresent what's being paid.
   const DENOM_ORDER = ['sats', 'btc', 'fiat'];
   let denom = 'sats';
-
 
   // Bitcoin's smallest unit is one sat, so 8 decimals is exact, not a rounding choice.
   const fmtBtc = (sats) => (Math.round(sats) / 1e8).toFixed(8);

--- a/test/zap-requests.test.js
+++ b/test/zap-requests.test.js
@@ -166,6 +166,36 @@ test('malformed events are refused without throwing', async () => {
   assert.deepEqual(await Z.pending(), []);
 });
 
+// ---- peek: decides whether the page-invoice card can be skipped ----
+
+test('peek matches without consuming, so the payment can still claim', async () => {
+  await Z.record(SITE, ALICE, zapRequest(21000));
+  assert.equal(await Z.peek(SITE, ALICE, 21), true);
+  assert.equal(await Z.peek(SITE, ALICE, 21), true, 'repeatable — peeking is not spending');
+  assert.equal((await Z.pending()).length, 1);
+  assert.equal(await Z.claim(SITE, ALICE, 21), true, 'the record survived to be claimed');
+});
+
+test('peek is scoped exactly like claim', async () => {
+  await Z.record(SITE, ALICE, zapRequest(21000));
+  assert.equal(await Z.peek(OTHER, ALICE, 21), false, 'wrong site');
+  assert.equal(await Z.peek(SITE, BOB, 21), false, 'wrong account');
+  assert.equal(await Z.peek(SITE, ALICE, 22), false, 'wrong amount');
+  assert.equal(await Z.peek(SITE, ALICE, null), false, 'amountless');
+  assert.equal(await Z.peek(SITE, ALICE, 21), true);
+});
+
+test('peek finds nothing when no zap was authorized', async () => {
+  assert.equal(await Z.peek(SITE, ALICE, 21), false);
+});
+
+test('peek refuses an expired record', async () => {
+  await Z.record(SITE, ALICE, zapRequest(21000));
+  const stale = (await Z.pending()).map((z) => ({ ...z, ts: z.ts - Z.TTL_MS - 1000 }));
+  await new Promise((r) => chrome.storage.session.set({ [Z.STORAGE_KEY]: stale }, r));
+  assert.equal(await Z.peek(SITE, ALICE, 21), false);
+});
+
 // ---- expiry and lock ----
 
 test('an expired record is refused', async () => {

--- a/test/zap-requests.test.js
+++ b/test/zap-requests.test.js
@@ -1,0 +1,229 @@
+'use strict';
+
+// Unit coverage for zap-request correlation (zap-requests.js).
+//
+// This module decides whether a Lightning payment may go out with NO prompt, so its
+// invariants are spending controls, not conveniences:
+//   - a payment only auto-approves against a zap request THIS user signed, for this
+//     site, this account, and this exact amount;
+//   - single-use — one signed request authorizes one payment, never a run of them;
+//   - anything that can't be bound tightly (no amount tag, no invoice amount) is
+//     refused rather than stored loosely: the cost of refusing is a prompt;
+//   - records expire, and a lock clears them outright.
+//
+// The check it replaces looked for a kind:9734 zap request inline in the invoice
+// description. NIP-57 step 6 issues a description HASH invoice, so that field is empty
+// on every spec-compliant zap and the old check never fired at all — "Auto-approve
+// zaps" was dead. It was also weaker in principle: any site could paste a real-looking
+// 9734 into a description it wrote itself, with nothing tying it to the user. The
+// no-inline-description case is pinned below so that regression can't come back.
+//
+// zap-requests.js is isolated (talks only to globalThis.chrome), so we load it in a vm
+// against a small chrome mock — same approach as test/replaceable-baseline.test.js.
+
+const { test, before, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const ROOT = path.join(__dirname, '..');
+
+function makeStorageArea() {
+  const data = {};
+  return {
+    get(keys, cb) {
+      let out = {};
+      if (keys == null) out = { ...data };
+      else if (typeof keys === 'string') { if (keys in data) out[keys] = data[keys]; }
+      else if (Array.isArray(keys)) { for (const k of keys) if (k in data) out[k] = data[k]; }
+      else { for (const k of Object.keys(keys)) out[k] = (k in data) ? data[k] : keys[k]; }
+      cb(out);
+    },
+    set(obj, cb) { Object.assign(data, obj); cb && cb(); },
+    remove(keys, cb) { for (const k of (Array.isArray(keys) ? keys : [keys])) delete data[k]; cb && cb(); },
+    clear(cb) { for (const k of Object.keys(data)) delete data[k]; cb && cb(); },
+  };
+}
+
+let Z;
+const ALICE = 'a'.repeat(64);
+const BOB = 'b'.repeat(64);
+const SITE = 'jumble.social';
+const OTHER = 'evil.example';
+
+// A kind:9734 zap request for `msat` millisats. `amount` is optional per NIP-57, so
+// passing null models the request that carries none.
+function zapRequest(msat, extraTags) {
+  const tags = [['p', 'c'.repeat(64)], ['relays', 'wss://relay.example']];
+  if (msat != null) tags.push(['amount', String(msat)]);
+  return { kind: 9734, content: '', tags: tags.concat(extraTags || []) };
+}
+
+before(() => {
+  globalThis.self = globalThis;
+  globalThis.chrome = { storage: { session: makeStorageArea() }, runtime: {} };
+  vm.runInThisContext(fs.readFileSync(path.join(ROOT, 'zap-requests.js'), 'utf8'), {
+    filename: 'zap-requests.js',
+  });
+  Z = globalThis.SidecarZapRequests;
+  assert.ok(Z, 'SidecarZapRequests loaded');
+});
+
+beforeEach(async () => {
+  await Z.clear();
+});
+
+// ---- the happy path ----
+
+test('a signed zap request lets the matching payment through', async () => {
+  assert.equal(await Z.record(SITE, ALICE, zapRequest(212000)), true);
+  assert.equal(await Z.claim(SITE, ALICE, 212), true);
+});
+
+test('sub-sat rounding still matches (invoice sats -> millisats)', async () => {
+  await Z.record(SITE, ALICE, zapRequest(1000));
+  assert.equal(await Z.claim(SITE, ALICE, 1), true);
+});
+
+test('several queued zaps each pay exactly once', async () => {
+  await Z.record(SITE, ALICE, zapRequest(100000));
+  await Z.record(SITE, ALICE, zapRequest(212000));
+  assert.equal(await Z.claim(SITE, ALICE, 212), true);
+  assert.equal(await Z.claim(SITE, ALICE, 100), true);
+  assert.equal(await Z.claim(SITE, ALICE, 100), false, 'no third payment');
+});
+
+// ---- single use ----
+
+test('one signed request cannot authorize two payments', async () => {
+  await Z.record(SITE, ALICE, zapRequest(212000));
+  assert.equal(await Z.claim(SITE, ALICE, 212), true);
+  assert.equal(await Z.claim(SITE, ALICE, 212), false, 'replay must be refused');
+});
+
+// ---- scoping: the abuse cases ----
+
+test('a different site cannot spend my zap request', async () => {
+  await Z.record(SITE, ALICE, zapRequest(212000));
+  assert.equal(await Z.claim(OTHER, ALICE, 212), false);
+  assert.equal(await Z.claim(SITE, ALICE, 212), true, 'still there for the real site');
+});
+
+test('a different account cannot spend it', async () => {
+  await Z.record(SITE, ALICE, zapRequest(212000));
+  assert.equal(await Z.claim(SITE, BOB, 212), false);
+});
+
+test('the amount must match exactly — no overpaying a small approval', async () => {
+  await Z.record(SITE, ALICE, zapRequest(212000));
+  assert.equal(await Z.claim(SITE, ALICE, 213), false);
+  assert.equal(await Z.claim(SITE, ALICE, 211), false);
+  assert.equal(await Z.claim(SITE, ALICE, 500000), false);
+  assert.equal(await Z.claim(SITE, ALICE, 212), true);
+});
+
+test('a payment with no prior zap request is never auto-approved', async () => {
+  assert.equal(await Z.claim(SITE, ALICE, 212), false);
+});
+
+// ---- refuse what cannot be bound ----
+
+test('a zap request without an amount tag is not stored', async () => {
+  assert.equal(await Z.record(SITE, ALICE, zapRequest(null)), false);
+  assert.deepEqual(await Z.pending(), [], 'a match-anything record is not a safeguard');
+});
+
+test('a non-numeric or non-positive amount is not stored', async () => {
+  for (const bad of ['abc', '0', '-5000', '']) {
+    const ev = { kind: 9734, content: '', tags: [['amount', bad]] };
+    assert.equal(await Z.record(SITE, ALICE, ev), false, 'amount ' + JSON.stringify(bad));
+  }
+  assert.deepEqual(await Z.pending(), []);
+});
+
+test('an amountless invoice never claims a record', async () => {
+  await Z.record(SITE, ALICE, zapRequest(212000));
+  assert.equal(await Z.claim(SITE, ALICE, null), false);
+  assert.equal(await Z.claim(SITE, ALICE, undefined), false);
+  assert.equal(await Z.claim(SITE, ALICE, NaN), false);
+  assert.equal((await Z.pending()).length, 1, 'and does not consume it');
+});
+
+test('only kind 9734 is recorded', async () => {
+  for (const kind of [0, 1, 3, 9735, 10000]) {
+    assert.equal(await Z.record(SITE, ALICE, { kind, tags: [['amount', '212000']] }), false);
+  }
+  assert.deepEqual(await Z.pending(), []);
+});
+
+test('malformed events are refused without throwing', async () => {
+  for (const ev of [null, undefined, {}, { kind: 9734 }, { kind: 9734, tags: 'nope' }]) {
+    assert.equal(await Z.record(SITE, ALICE, ev), false);
+  }
+  assert.equal(await Z.record('', ALICE, zapRequest(1000)), false, 'no host');
+  assert.equal(await Z.record(SITE, '', zapRequest(1000)), false, 'no account');
+  assert.deepEqual(await Z.pending(), []);
+});
+
+// ---- expiry and lock ----
+
+test('an expired record is refused', async () => {
+  await Z.record(SITE, ALICE, zapRequest(212000));
+  const stale = (await Z.pending()).map((z) => ({ ...z, ts: z.ts - Z.TTL_MS - 1000 }));
+  await new Promise((r) => chrome.storage.session.set({ [Z.STORAGE_KEY]: stale }, r));
+  assert.equal(await Z.claim(SITE, ALICE, 212), false);
+});
+
+test('recording sweeps expired records', async () => {
+  await new Promise((r) =>
+    chrome.storage.session.set(
+      { [Z.STORAGE_KEY]: [{ host: SITE, pubkey: ALICE, msat: 1, ts: Date.now() - Z.TTL_MS - 1 }] },
+      r
+    )
+  );
+  await Z.record(SITE, ALICE, zapRequest(212000));
+  const left = await Z.pending();
+  assert.equal(left.length, 1);
+  assert.equal(left[0].msat, 212000);
+});
+
+test('lock clears every pending approval', async () => {
+  await Z.record(SITE, ALICE, zapRequest(212000));
+  await Z.record(SITE, BOB, zapRequest(100000));
+  await Z.clear();
+  assert.deepEqual(await Z.pending(), []);
+  assert.equal(await Z.claim(SITE, ALICE, 212), false);
+});
+
+// ---- the regression this module exists for ----
+
+test('a real zap invoice carries NO inline description, which is why the old check never fired', () => {
+  // Tag 13 ('d') is the inline description; tag 23 ('h') is the description hash.
+  // Real NIP-57 zap invoices, as collected from a live client, carry only 'h'.
+  const REAL_ZAP_INVOICES = [
+    'lnbc2120n1p4x232wpp559ajf4ec7s4t7gef74xnsyqert3jt807dr6ydxq23ft3hdskd2rqhp5wau44uqa3az65r80rmn4ymfsqnwrex4yhzfll8aul55e48cgcjmscqzysxqrrssrzjqv3dpepm8kfdxrk3sl6wzqdf49s9c0h9ljtjrek6c08r6aejlwcnur0dwyqqvusqqqqqqqlgqqqq86qqjqsp5g5kgwuuptl7yjc7g9xxzhcs8dnejccuy8fy3z9xywz02uhnqpagq9qxpqysgqneh4h267tam88h5hqnwj6rt2u40ekwcfuevejt60kjdu6lpp0lqq7a9nwjxdmqqz8x9cxlsp75qs4wl6qgn7g3uk7p8z25u33mg8h7gq8fhzmf',
+    'lnbc840n1p4x2jvwpp5fng2eafm4m6zqj33jvquywx5edmq02sca2cfxmtlzxvddxpjlspssp5dcxdutntg573nsuwduvz5edanyh707wzkfjjha79clny7p7zhwlqxq9z0rgqnp4qvyndeaqzman7h898jxm98dzkm0mlrsx36s93smrur7h0azyyuxc5rzjq25carzepgd4vqsyn44jrk85ezrpju92xyrk9apw4cdjh6yrwt5jgqqqqrt49lmtcqqqqqqqqqqq86qq9qrzjqvt4uzpwalva67rw74e4a4qkxgvfh8z7cu68k8ctx3l5sxssr0578apyqr6zgqqqq8hxk2qqae4jsqyugqcqzpuhp5kkfy66cj2050ug3pwuc4vdwnv8wec30dqh6xz822ym2f6uvnqxtq9qyyssqdkpznl3ek82zqvjd90ru27ysx4pqpqn8jjk0uqxa8232ftdlu654djysf5dws2mpyhnejvtva3uuzpxxvg4naerm8c4m7mnxc8xnahsp94d6n7',
+  ];
+  const CHARS = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l';
+  const tagsOf = (inv) => {
+    const words = inv.slice(inv.lastIndexOf('1') + 1).split('').map((c) => CHARS.indexOf(c));
+    const body = words.slice(0, words.length - 6);
+    const end = body.length - 104;
+    const found = [];
+    let i = 7;
+    while (i + 3 <= end) {
+      const tag = body[i];
+      const len = body[i + 1] * 32 + body[i + 2];
+      if (i + 3 + len > end) break;
+      found.push(tag);
+      i += 3 + len;
+    }
+    return found;
+  };
+  for (const inv of REAL_ZAP_INVOICES) {
+    const tags = tagsOf(inv);
+    assert.ok(tags.includes(23), 'zap invoice commits via description hash (tag 23)');
+    assert.ok(!tags.includes(13), 'and carries no inline description (tag 13) to sniff');
+  }
+});

--- a/zap-requests.js
+++ b/zap-requests.js
@@ -1,0 +1,115 @@
+// Sidecar — zap-request correlation for auto-approved zaps (isolated module).
+//
+// "Auto-approve zaps" is a spending gate: under it, a site's payment goes out with no
+// prompt at all. So the test for "is this really a zap?" has to be one an unfriendly
+// site cannot satisfy on its own.
+//
+// The old test asked whether the invoice's description was a kind:9734 zap request.
+// It never once fired. NIP-57 step 6 has the lnurl server issue a description HASH
+// invoice — "the description is this zap request note and this note only" — so the
+// request is committed to, never carried. The description field is empty on every
+// spec-compliant zap, and the check always returned false. The setting did nothing.
+//
+// Matching that hash isn't a fix. It's computed over the exact JSON the client posted
+// to the lnurl callback, and Sidecar hands back a signed event which the client then
+// re-serializes in whatever key order it pleases. Sidecar cannot know those bytes, and
+// a check that silently fails closed forever is worse than no check.
+//
+// So bind to what Sidecar does know: it SIGNED the kind:9734, seconds earlier. A
+// payment qualifies only if it matches a zap request this user authorized through
+// Sidecar — same site, same account, same amount to the millisat, inside a short
+// window, redeemable exactly once. That is strictly stronger than what it replaces:
+// the old inline check could be satisfied by any site that pasted a real-looking 9734
+// into a description it wrote itself, with nothing tying it to the user at all.
+//
+// Records live in chrome.storage.session: a worker restart between signing and paying
+// must not quietly switch auto-zap off, and they never belong on disk.
+//
+// Isolated (like relax-grants.js / replaceable-baseline.js) so it can be unit-tested
+// directly against a chrome mock — see test/zap-requests.test.js.
+
+(function () {
+  'use strict';
+
+  const STORAGE_KEY = 'sidecar_pending_zaps';
+  // Generous enough for a slow lnurl round trip, short enough that a stale approval
+  // can't be spent much later. The zap flow itself is seconds.
+  const TTL_MS = 180000;
+
+  const now = () => Date.now();
+
+  function read() {
+    return new Promise((resolve) =>
+      chrome.storage.session.get(STORAGE_KEY, (got) => {
+        void chrome.runtime.lastError;
+        const list = got && got[STORAGE_KEY];
+        resolve(Array.isArray(list) ? list : []);
+      })
+    );
+  }
+
+  function write(list) {
+    return new Promise((resolve) =>
+      chrome.storage.session.set({ [STORAGE_KEY]: list }, () => {
+        void chrome.runtime.lastError;
+        resolve();
+      })
+    );
+  }
+
+  const fresh = (list, t) => list.filter((z) => z && t - z.ts <= TTL_MS);
+
+  // Remember a zap request we just signed, so the payment that follows can be tied
+  // back to it. Anything we can't bind tightly is skipped rather than stored loosely —
+  // the cost of skipping is a prompt, which is the safe direction.
+  async function record(host, pubkey, ev) {
+    if (!host || !pubkey) return false;
+    if (!ev || ev.kind !== 9734 || !Array.isArray(ev.tags)) return false;
+    const tag = ev.tags.find((t) => Array.isArray(t) && t[0] === 'amount');
+    const msat = tag ? Number(tag[1]) : 0;
+    // NIP-57 makes `amount` optional. A record that would match ANY amount is not a
+    // safeguard, so decline to store one and let the payment prompt normally.
+    if (!Number.isFinite(msat) || msat <= 0) return false;
+    const t = now();
+    const list = fresh(await read(), t);
+    list.push({ host, pubkey, msat, ts: t });
+    await write(list);
+    return true;
+  }
+
+  // Claim the zap request behind this payment, if there is one. Single-use: one signed
+  // request authorizes exactly one payment, so a site cannot replay a single approval
+  // across a run of invoices.
+  async function claim(host, pubkey, sats) {
+    if (!host || !pubkey) return false;
+    if (sats == null || !Number.isFinite(sats)) return false;
+    const t = now();
+    const msat = Math.round(sats * 1000);
+    const list = await read();
+    const i = list.findIndex(
+      (z) =>
+        z &&
+        z.host === host &&
+        z.pubkey === pubkey &&
+        z.msat === msat &&
+        t - z.ts <= TTL_MS
+    );
+    if (i < 0) return false;
+    list.splice(i, 1);
+    await write(fresh(list, t));
+    return true;
+  }
+
+  // Drop everything — used on lock, so a locked keystore leaves no spendable approvals.
+  async function clear() {
+    await write([]);
+  }
+
+  async function pending() {
+    return fresh(await read(), now());
+  }
+
+  const api = { STORAGE_KEY, TTL_MS, record, claim, clear, pending };
+  if (typeof self !== 'undefined') self.SidecarZapRequests = api;
+  if (typeof globalThis !== 'undefined') globalThis.SidecarZapRequests = api;
+})();

--- a/zap-requests.js
+++ b/zap-requests.js
@@ -100,6 +100,19 @@
     return true;
   }
 
+  // Is there a request this payment would match? Same test as claim(), but it does
+  // NOT consume: callers that only need to decide whether to offer/skip a UI must
+  // leave the record intact for the payment itself to claim.
+  async function peek(host, pubkey, sats) {
+    if (!host || !pubkey) return false;
+    if (sats == null || !Number.isFinite(sats)) return false;
+    const t = now();
+    const msat = Math.round(sats * 1000);
+    return (await read()).some(
+      (z) => z && z.host === host && z.pubkey === pubkey && z.msat === msat && t - z.ts <= TTL_MS
+    );
+  }
+
   // Drop everything — used on lock, so a locked keystore leaves no spendable approvals.
   async function clear() {
     await write([]);
@@ -109,7 +122,7 @@
     return fresh(await read(), now());
   }
 
-  const api = { STORAGE_KEY, TTL_MS, record, claim, clear, pending };
+  const api = { STORAGE_KEY, TTL_MS, record, claim, peek, clear, pending };
   if (typeof self !== 'undefined') self.SidecarZapRequests = api;
   if (typeof globalThis !== 'undefined') globalThis.SidecarZapRequests = api;
 })();


### PR DESCRIPTION
Closes #138.

Chased across three real invoices from a live client. The first commit's diagnosis was wrong and the description has been rewritten to match what the evidence actually showed.

## What was happening

**The keepalive was cleared at the exact moment money moved.** `settleEntry()` splices the queue entry, resolves the prompt, then calls `stopKeepaliveIfIdle()` — and only *after* that does the NWC round trip begin. `liveEntries()` is already empty by then, so approving a payment cancelled the keepalive alarm right as the payment started, leaving the worker eligible for recycling across a wait that can run the full 30s timeout.

**Silence was being read as failure.** Publishing the NIP-47 request is what commits the money. Hearing the `kind:23195` reply is a separate, fallible thing — and that event is ephemeral, so relays never replay it. A lost reply meant sitting out the full 30s and then reporting an error for a payment that had already succeeded, or hanging the page toward its 180s timeout. That matches the reported evidence exactly: modal stuck waiting, balance decremented, and `sha256(preimage) == payment_hash` verifying the wallet had returned valid proof promptly.

## What the three invoices showed

| | amount | route hints | outcome |
|---|---|---|---|
| #1 | 212 sats | 1 | failed |
| #2 | 100 sats | 1 | worked |
| #3 | 84 sats | **2 + payee node** | failed |

84 failing while 100 worked ruled out an amount threshold. #3 is a different, slower destination — the signature of an LSP-backed mobile wallet, which routinely takes longer to pay than the 30s NWC timeout. Two different roads to the same place: money moves, Sidecar stops listening, page never learns. The fix had to be cause-agnostic rather than another targeted patch.

## Changes

**Real heartbeat for payments.** A `payInFlight` counter that `stopKeepaliveIfIdle` respects, plus a 20s `chrome.runtime.getPlatformInfo` heartbeat held across the whole payment including the prompt. The queue alarm fires at most every 30s, which is a coin-flip against MV3's own ~30s idle timeout — fine for a prompt someone's looking at, not good enough to carry money.

**Ask the wallet instead of inferring from silence.** `payAndConfirm` polls `lookup_invoice` in parallel from 8s and takes whichever definitive answer lands first, so the usual outcome is "found out at ~8s" rather than "gave up at 30s". A wallet that explicitly answers *no* is never second-guessed. `lookup_invoice` is read-only, so watching a payment can't cause a second one.

An earlier draft of this ran the watcher *and* a separate post-failure poller concurrently — 239 lookups against the wallet relay on that path. Collapsed to one watcher with a deadline; same path now costs 3.

**"Auto-approve zaps" has never once fired.** It tested whether the invoice description was a `kind:9734` zap request. [NIP-57 step 6](https://github.com/nostr-protocol/nips/blob/master/57.md) has the lnurl server issue a description *hash* invoice — "the description is this zap request note and this note only" — so that field is empty on every spec-compliant zap. Verified false against all three real invoices.

Matching the hash isn't a fix either: it's computed over the exact JSON the client posted to the lnurl callback, and Sidecar hands back a signed event that the client re-serializes in whatever key order it likes. A check that silently fails closed forever is worse than no check.

So bind to what Sidecar *does* know — it signs the `9734` seconds earlier. A payment auto-approves only against a zap request this user authorized through Sidecar: same site, same account, same amount to the millisat, short window, single use, cleared on lock.

That is **stricter** than what it replaces. The old inline check could be satisfied by any site pasting a real-looking 9734 into a description it wrote itself, with nothing tying it to the user. Worth noting the old bug failed *closed* — it cost convenience, never safety.

**Discoverability.** Budgets can only be created from a payment prompt, so the empty budget list now says that outright, and the auto-zap setting points at per-site budgets for everything that isn't a zap.

## Deliberately not applied to the signing path

`handleNostrRpc` has the same respond-after-bookkeeping shape. Left alone on purpose: there the post-sign work feeds the wrong-account safeguards, so returning before the binding is recorded could let the *next* request resolve against a stale identity. On the payment path that state is a spend counter; on the signing path it's who you are. Same pattern, different stakes — it needs its own change and its own reasoning.

## Testing

67 tests pass, up from 50. New `zap-requests.js` is isolated like `relax-grants.js`, with 17 tests covering the abuse cases: wrong site, wrong account, wrong amount, replay, expiry, lock, and a regression test pinning the no-inline-description fact using two of the real invoices.

The payment race logic was simulated across all 8 paths, including the two that matter most: a wallet saying "insufficient balance" is never rescued into a success (0 lookups — a real no stays no), and the happy path adds 0 extra relay traffic.

Not covered by unit tests: the message-dispatch path and the keepalive, both of which need a real browser. Worth zapping repeatedly — especially to an LSP-backed wallet, which is what reproduced #3.

🍸 Shaken with [Claude Code](https://claude.com/claude-code)