### PR TITLE
feat: auto-zap covers the whole zap, not just the payment

### DIFF
--- a/background.js
+++ b/background.js
@@ -15,7 +15,7 @@
 // survive-restart machinery below applies equally to both.
 
 if (typeof importScripts === 'function') {
-  importScripts('nostr-tools.js', 'crypto.js', 'keystore.js', 'permissions.js', 'signer.js', 'wallet-budgets.js', 'nwc-client.js', 'relax-grants.js', 'replaceable-baseline.js');
+  importScripts('nostr-tools.js', 'crypto.js', 'keystore.js', 'permissions.js', 'signer.js', 'wallet-budgets.js', 'nwc-client.js', 'relax-grants.js', 'replaceable-baseline.js', 'zap-requests.js');
 }
 
 const KS = self.SidecarKeystore;
@@ -25,6 +25,7 @@ const BUDGETS = self.SidecarBudgets;
 const NWC = self.SidecarNWC;
 const RELAX = self.SidecarRelax;
 const BASELINE = self.SidecarBaseline;
+const ZAPREQ = self.SidecarZapRequests;
 
 const DEFAULT_RELAYS = {
   'wss://nos.lol': { read: true, write: true },
@@ -969,9 +970,15 @@ async function handleNostrRpc(method, params, host, sendResponse, originWindowId
     // A shared-identity content sign always confirms, regardless of trust tier —
     // unless it's a coalesced app-data sign, under an active relax window, etc.
     // A destructive overwrite overrides every skip.
+    // A zap request within the auto-zap caps signs without asking, so "auto-approve
+    // zaps" covers the whole zap rather than just its second half. See autoZapMaySign.
+    const zapAutoSign = method === 'signEvent' && signKind === 9734
+      ? await autoZapMaySign(signEvent)
+      : false;
+
     const needApproval = destructive
       ? true
-      : (coalesced || appDataAutoAllow || decryptCoalesced || relaxActive
+      : (coalesced || appDataAutoAllow || decryptCoalesced || relaxActive || zapAutoSign
           ? false
           : ((status === 'ask' && !isRelayAuth) || sharedIdentity));
 
@@ -1079,6 +1086,12 @@ async function handleNostrRpc(method, params, host, sendResponse, originWindowId
     // that already succeeded.
     if (method === 'signEvent' && !isRelayAuth && result && BASELINE.isTracked(result.kind)) {
       try { await BASELINE.record(activePubkey, result, result.created_at || 0); } catch (_) {}
+    }
+
+    // A zap request the user just authorized. Remember it so the payment that follows
+    // can be recognized as that zap (see zap-requests.js). Best-effort, same as above.
+    if (method === 'signEvent' && !isRelayAuth && result && result.kind === 9734) {
+      try { await ZAPREQ.record(host, activePubkey, result); } catch (_) {}
     }
 
     // Pin this host to the account it just successfully used. Only an explicit
@@ -1301,20 +1314,6 @@ function bolt11PaymentHash(invoice) {
   if (!b || b.length !== 32) return '';
   return Array.from(b, (x) => x.toString(16).padStart(2, '0')).join('');
 }
-function bolt11Description(invoice) {
-  const b = bolt11Field(invoice, 13); // 'd'
-  return b ? new TextDecoder().decode(b) : '';
-}
-function isZapInvoice(invoice) {
-  const desc = bolt11Description(invoice);
-  if (!desc || desc[0] !== '{') return false;
-  try {
-    const ev = JSON.parse(desc);
-    return !!ev && ev.kind === 9734;
-  } catch (_) {
-    return false;
-  }
-}
 
 // ---- payment serialization + auto-zap aggregate cap ----
 // Payments run one-at-a-time per account: without this, a burst of concurrent
@@ -1342,6 +1341,95 @@ async function autoZapWindow() {
 async function recordAutoZap(sats) {
   const { spent, resetAt } = await autoZapWindow();
   await sset({ [AUTOZAP_WINDOW_KEY]: { spent: spent + Math.max(0, Math.floor(sats || 0)), resetAt } });
+}
+
+// Auto-zap covers BOTH gates of a zap: signing the kind:9734 request, and paying the
+// invoice the lnurl server returns for it. Raising the cap only ever silenced the
+// second one, which is why a small zap could still stop to ask — the signing prompt is
+// governed by the site's permission tier and the shared-host override, not by any
+// wallet setting.
+//
+// A zap request carries its own `amount` tag, so the very same per-zap and daily caps
+// can be applied at signing time. This check is advisory: the payment path re-checks
+// and is the thing that actually records the spend, so the caps are still enforced
+// there even if several requests get signed before any of them is paid.
+//
+// Like relax mode, this overrides the shared-host confirm — and unlike relax mode it
+// is bounded by an amount, not just a clock. Fails closed on anything unexpected.
+async function autoZapMaySign(ev) {
+  try {
+    if (!ev || ev.kind !== 9734) return false;
+    if (KS.isLocked()) return false;
+    const settings = (await sget('sidecar_settings')).sidecar_settings || {};
+    if (settings.autoZap !== true) return false;
+    const zapMax = Number(settings.autoZapMaxSats) || 0;
+    if (zapMax <= 0) return false;
+    const tag = Array.isArray(ev.tags) ? ev.tags.find((t) => Array.isArray(t) && t[0] === 'amount') : null;
+    const msat = tag ? Number(tag[1]) : 0;
+    // NIP-57 makes `amount` optional, and a request that declares no amount can't be
+    // held to a cap. Ask for those.
+    if (!Number.isFinite(msat) || msat <= 0) return false;
+    const sats = Math.round(msat / 1000);
+    if (sats > zapMax) return false;
+    const dailySet = Number(settings.autoZapDailyMaxSats);
+    const dailyMax = dailySet > 0 ? dailySet : zapMax * AUTOZAP_DAILY_MULTIPLE;
+    if (dailyMax <= 0) return false;
+    const { spent } = await autoZapWindow();
+    return spent + sats <= dailyMax;
+  } catch (_) {
+    return false;
+  }
+}
+
+// The page-invoice card asks this before it appears: is this invoice simply the one
+// for a zap the user already authorized here? Jumble and other Bitcoin Connect clients
+// render a QR rather than calling window.webln, so the card — not the approval prompt —
+// is what stands between picking an amount and paying.
+//
+// Answers true only when an unconsumed zap request signed on THIS host and account,
+// for THIS exact amount, is waiting, and the auto-zap caps allow it. Then there is
+// nothing left to confirm. Every other case returns false and the card appears.
+//
+// Peeks rather than claims: payInvoiceCore does the real, single-use claim, and
+// consuming the record here would make it prompt instead.
+//
+// `host` MUST come from the sender's URL, never from the message body — see the call
+// site in the router.
+async function tryZapAutopay(invoiceRaw, host, originWindowId, tabId) {
+  const no = (why) => {
+    dlog('info', 'zap', 'auto-pay declined', { why, host });
+    return { handled: false, paid: false };
+  };
+  const inv = String(invoiceRaw || '');
+  if (!host || !inv) return no('no host or invoice');
+  if (KS.isLocked()) return no('keystore locked');
+  const settings = (await sget('sidecar_settings')).sidecar_settings || {};
+  if (settings.autoZap !== true) return no('auto-approve zaps is off');
+  const cap = Number(settings.autoZapMaxSats) || 0;
+  if (cap <= 0) return no('per-zap cap is 0');
+  const amt = invoiceSats(inv);
+  if (amt == null) return no('invoice has no amount');
+  if (amt > cap) return no(amt + ' sats exceeds the ' + cap + ' cap');
+  const who = await resolveSiteAccount(host);
+  if (!who) return no('no account resolved for ' + host);
+  if ((await PERMS.getLevel(who, host)) === 'blocked') return no('site is blocked');
+  if (!(await ZAPREQ.peek(host, who, amt))) {
+    return no('no zap request signed here matches ' + amt + ' sats (' + amt * 1000 + ' msat)');
+  }
+  // Show the card in its auto form first. Money moving with nothing on screen is the
+  // wrong trade even when the user opted out of being asked — and it means a failure
+  // has somewhere to be reported instead of vanishing.
+  notifyTabAutopaying(tabId, inv);
+  try {
+    await payInvoiceCore(inv, host, who, undefined, originWindowId);
+    notifyTabPaid(tabId, inv);
+    return { handled: true, paid: true };
+  } catch (e) {
+    // Still handled: the auto card is up and is where this error belongs. Replacing it
+    // with a fresh manual card would throw the reason away.
+    notifyTabPayFailed(tabId, inv, e && e.message);
+    return { handled: true, paid: false };
+  }
 }
 
 // Ask the wallet whether an invoice actually settled. Called ONLY to resolve a
@@ -1473,7 +1561,11 @@ async function payInvoiceLocked(invoiceRaw, host, pubkey, memo, originWindowId) 
     ? (dailyMaxSet > 0 ? dailyMaxSet : zapMax * AUTOZAP_DAILY_MULTIPLE)
     : 0;
   let zapOk = false;
-  if (unlocked && zapMax > 0 && sats <= zapMax && isZapInvoice(invoice)) {
+  // Claim only if the payment actually needs it: the site's budget already covering
+  // this one makes autoOk true either way, and a zap approval is single-use, so
+  // spending one here would be for nothing. The amount is likewise checked first so
+  // an over-cap payment doesn't burn a record it can't use.
+  if (!budgetOk && unlocked && zapMax > 0 && sats <= zapMax && (await ZAPREQ.claim(host, pubkey, sats))) {
     const { spent } = await autoZapWindow();
     zapOk = zapDailyMax > 0 && spent + sats <= zapDailyMax;
   }
@@ -1602,6 +1694,15 @@ async function notifyTabsPaidByHost(host) {
       }
     });
   } catch (_) {}
+}
+
+// Tell a tab an auto-zap is going out, so the page-invoice card can show what's
+// happening instead of money moving with nothing on screen. Sent BEFORE the payment,
+// so the card is already up when the result lands on it.
+function notifyTabAutopaying(tabId, invoice) {
+  if (tabId != null && chrome.tabs) {
+    chrome.tabs.sendMessage(tabId, { type: 'SIDECAR_EVENT', event: 'autopaying', invoice }, () => void chrome.runtime.lastError);
+  }
 }
 
 function notifyTabPaid(tabId, invoice) {
@@ -1748,6 +1849,9 @@ async function lockKeystore(auto = false) {
   // signs makes no sense, and idle auto-lock is exactly the "walked away" case
   // where a lingering auto-sign shouldn't survive.
   RELAX.revokeAll().then(syncRelaxBadge);
+  // Same reasoning for pending zap requests: they authorize a payment to go out with
+  // no prompt, so a locked keystore must not leave any of them spendable.
+  ZAPREQ.clear().catch(() => {});
   // Tell any open panel/popup to drop to the unlock screen immediately — otherwise
   // it keeps showing whatever was open (e.g. the composer) and only discovers the
   // lock on its next action, which then fails with a "locked" error. `auto` marks an
@@ -2268,8 +2372,15 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     (typeof sender.url === 'string' && sender.url.startsWith(EXT_URL_PREFIX)) ||
     (typeof sender.origin === 'string' && sender.origin + '/' === EXT_URL_PREFIX)
   );
+  // SIDECAR_TRY_ZAP_AUTOPAY belongs here for the same reason SIDECAR_PAY_PAGE_INVOICE
+  // does — the page-invoice card lives in the content script — and it is strictly
+  // more restrictive than that one: it pays only when auto-zap is on, the amount is
+  // inside both caps, and an unconsumed zap request signed on THIS host and account
+  // for THIS exact amount is waiting. A content script can't forge that record; only
+  // a signature the user authorized through Sidecar creates one.
   const CONTENT_OK = new Set([
     'SIDECAR_NOSTR_RPC', 'SIDECAR_WEBLN_RPC', 'SIDECAR_PAY_PAGE_INVOICE',
+    'SIDECAR_TRY_ZAP_AUTOPAY',
     'SIDECAR_IS_CONNECTED', 'SIDECAR_GET_SETTINGS', 'SIDECAR_SET_SETTINGS',
   ]);
   if (!fromExtPage && !CONTENT_OK.has(message.type)) {
@@ -2319,6 +2430,18 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   // whether to nudge the user to open/pin Sidecar from the toolbar.
   if (message.type === 'SIDECAR_PANEL_OPEN') {
     waitForPanelPort(300).then((port) => sendResponse({ ok: true, open: !!port }));
+    return true; // async response
+  }
+
+  // Card auto-pay probe. Host comes from the sender's own URL, like the handlers
+  // around it — a content script must not be able to name a different site and spend
+  // against its zap approvals.
+  if (message.type === 'SIDECAR_TRY_ZAP_AUTOPAY') {
+    let h = '';
+    try { h = new URL((sender && sender.url) || '').host; } catch (_) {}
+    tryZapAutopay(message.invoice, h, originWindowId, sender && sender.tab && sender.tab.id)
+      .then((r) => sendResponse({ ok: true, result: r }))
+      .catch((e) => sendResponse({ ok: false, error: e.message }));
     return true; // async response
   }
 

--- a/background.js
+++ b/background.js
@@ -1324,6 +1324,27 @@ function bolt11PaymentHash(invoice) {
 // each under the per-zap cap — the per-zap limit alone bounds nothing in aggregate.
 const PAY_DAY_MS = 24 * 60 * 60 * 1000;
 const AUTOZAP_DAILY_MULTIPLE = 5; // default daily cap = 5× the per-zap cap when unset
+// Hard ceilings on the no-confirmation path. Auto-zap spends with nothing to click,
+// so the limits that bound it shouldn't be whatever was last typed into a text field:
+// a stray zero on that input would otherwise widen the automatic path by 10×. Above
+// these, zaps fall back to a normal approval — which is the right behavior for an
+// amount large enough to want a second look.
+const AUTOZAP_ABS_MAX = 1000; // sats, per zap
+const AUTOZAP_ABS_DAILY_MAX = 10000; // sats, rolling day
+
+// The auto-zap limits in force, clamped. Applied on READ as well as on write, so a
+// value stored before these ceilings existed can't outlive them. Returns zeros when
+// the setting is off, which every caller treats as "ask".
+function autoZapLimits(settings) {
+  if (!settings || settings.autoZap !== true) return { perZap: 0, daily: 0 };
+  const perZap = Math.min(Math.max(0, Number(settings.autoZapMaxSats) || 0), AUTOZAP_ABS_MAX);
+  const set = Number(settings.autoZapDailyMaxSats);
+  const daily = Math.min(
+    set > 0 ? set : perZap * AUTOZAP_DAILY_MULTIPLE,
+    AUTOZAP_ABS_DAILY_MAX
+  );
+  return { perZap, daily };
+}
 const AUTOZAP_WINDOW_KEY = 'sidecar_autozap_window';
 const payLocks = new Map(); // pubkey -> tail of the serialized payment chain
 function withPayLock(pubkey, fn) {
@@ -1361,8 +1382,7 @@ async function autoZapMaySign(ev) {
     if (!ev || ev.kind !== 9734) return false;
     if (KS.isLocked()) return false;
     const settings = (await sget('sidecar_settings')).sidecar_settings || {};
-    if (settings.autoZap !== true) return false;
-    const zapMax = Number(settings.autoZapMaxSats) || 0;
+    const { perZap: zapMax, daily: dailyMax } = autoZapLimits(settings);
     if (zapMax <= 0) return false;
     const tag = Array.isArray(ev.tags) ? ev.tags.find((t) => Array.isArray(t) && t[0] === 'amount') : null;
     const msat = tag ? Number(tag[1]) : 0;
@@ -1371,8 +1391,6 @@ async function autoZapMaySign(ev) {
     if (!Number.isFinite(msat) || msat <= 0) return false;
     const sats = Math.round(msat / 1000);
     if (sats > zapMax) return false;
-    const dailySet = Number(settings.autoZapDailyMaxSats);
-    const dailyMax = dailySet > 0 ? dailySet : zapMax * AUTOZAP_DAILY_MULTIPLE;
     if (dailyMax <= 0) return false;
     const { spent } = await autoZapWindow();
     return spent + sats <= dailyMax;
@@ -1404,9 +1422,8 @@ async function tryZapAutopay(invoiceRaw, host, originWindowId, tabId) {
   if (!host || !inv) return no('no host or invoice');
   if (KS.isLocked()) return no('keystore locked');
   const settings = (await sget('sidecar_settings')).sidecar_settings || {};
-  if (settings.autoZap !== true) return no('auto-approve zaps is off');
-  const cap = Number(settings.autoZapMaxSats) || 0;
-  if (cap <= 0) return no('per-zap cap is 0');
+  const { perZap: cap } = autoZapLimits(settings);
+  if (cap <= 0) return no('auto-approve zaps is off, or the per-zap cap is 0');
   const amt = invoiceSats(inv);
   if (amt == null) return no('invoice has no amount');
   if (amt > cap) return no(amt + ' sats exceeds the ' + cap + ' cap');
@@ -1552,14 +1569,9 @@ async function payInvoiceLocked(invoiceRaw, host, pubkey, memo, originWindowId) 
   const settings = (await sget('sidecar_settings')).sidecar_settings || {};
   const unlocked = !KS.isLocked() && sats != null;
   const budgetOk = unlocked && (await BUDGETS.covers(pubkey, host, sats));
-  const zapMax = settings.autoZap === true ? Number(settings.autoZapMaxSats) || 0 : 0;
-  // Auto-zap is gated by BOTH a per-zap cap and a rolling daily aggregate cap.
-  // The daily cap defaults to a multiple of the per-zap cap when unset, so
-  // existing auto-zap users are bounded without having to reconfigure.
-  const dailyMaxSet = Number(settings.autoZapDailyMaxSats);
-  const zapDailyMax = settings.autoZap === true
-    ? (dailyMaxSet > 0 ? dailyMaxSet : zapMax * AUTOZAP_DAILY_MULTIPLE)
-    : 0;
+  // Auto-zap is gated by BOTH a per-zap cap and a rolling daily aggregate cap, each
+  // held under a hard ceiling (see autoZapLimits).
+  const { perZap: zapMax, daily: zapDailyMax } = autoZapLimits(settings);
   let zapOk = false;
   // Claim only if the payment actually needs it: the site's budget already covering
   // this one makes autoOk true either way, and a zap approval is single-use, so
@@ -2192,6 +2204,15 @@ async function handleControl(message, sendResponse) {
       case 'SIDECAR_SET_SETTINGS': {
         const prev = (await sget('sidecar_settings')).sidecar_settings || {};
         const merged = { ...prev, ...message.settings };
+        // Hold the auto-zap limits under their ceilings here, not just in the panel
+        // that draws the input. This is the value every payment gate then trusts, so
+        // it is validated where it is stored rather than where it is typed.
+        if ('autoZapMaxSats' in merged) {
+          merged.autoZapMaxSats = Math.min(Math.max(1, Number(merged.autoZapMaxSats) || 1), AUTOZAP_ABS_MAX);
+        }
+        if ('autoZapDailyMaxSats' in merged) {
+          merged.autoZapDailyMaxSats = Math.min(Math.max(1, Number(merged.autoZapDailyMaxSats) || 1), AUTOZAP_ABS_DAILY_MAX);
+        }
         await sset({ sidecar_settings: merged });
         // Apply an auto-lock change immediately: drop any alarm armed under the
         // old value, then re-arm from the new one (no-op when Never or locked).

--- a/content.js
+++ b/content.js
@@ -318,6 +318,14 @@
     '.pay:active{transform:translateY(1px);}' +
     '.pay.pending{cursor:default;opacity:.94;}' +
     '.pay.done{cursor:default;background:none;box-shadow:none;{CARD_SUCCESS};}' +
+    // Auto-zap: nothing here is pressable, so it must not read as a button. Strip the
+    // fill, the shadow and the bold weight and let it sit as a status line — the same
+    // treatment .done already uses. The spinner is drawn in the button-text color, so
+    // on a flat card it has to switch to currentColor or it disappears.
+    '.auto .pay{background:none;box-shadow:none;cursor:default;font-weight:600;padding:12px 14px 4px;color:{CARD_TEXT};}' +
+    '.auto .pay:hover{filter:none;}' +
+    '.auto .pay.pending{opacity:1;}' +
+    '.auto .pay.pending .pay-spin{border:2px solid currentColor;border-top-color:transparent;opacity:.55;}' +
     '.pay-bolt{height:16px;width:auto;display:block;}' +
     '.pay.pending .pay-bolt,.pay.done .pay-bolt{display:none;}' +
     '.pay-check{display:none;width:18px;height:18px;}' +
@@ -554,14 +562,17 @@
     }
   }
 
-  function renderCard(invoice) {
+  // `auto` renders the same card for a zap going out under the auto-zap limits: no
+  // decision to make, but the spend is still shown, and a failure has somewhere to
+  // land. It drops straight into the sending state and reuses setPaid/setError.
+  function renderCard(invoice, auto) {
     removeCard();
     shownInvoice = invoice;
     const sats = invoiceSats(invoice);
     const memo = invoiceMemo(invoice);
     const site = location.host.replace(/^www\./, '');
 
-    const eyebrow = sats != null ? "You're paying" : 'Pay with Sidecar';
+    const eyebrow = auto ? 'Auto-zapping' : sats != null ? "You're paying" : 'Pay with Sidecar';
     const amountBlock =
       sats != null
         ? '<div class="amt"><span class="num">' + sats.toLocaleString('en-US') + '</span><span class="unit">sats</span></div>'
@@ -582,7 +593,8 @@
     s.innerHTML =
       '<style>' + cardCss + '</style>' +
       '<div class="ov">' +
-      '<div class="card" role="dialog" aria-label="Pay with Sidecar">' +
+      '<div class="card' + (auto ? ' auto' : '') + '" role="dialog" aria-label="' +
+      (auto ? 'Auto-zap in progress' : 'Pay with Sidecar') + '">' +
       '<div class="brand">' + logoSvg + '</div>' +
       '<div class="eyebrow">' + eyebrow + '</div>' +
       amountBlock +
@@ -614,16 +626,18 @@
     // back or re-tap. The background reports the outcome via 'paid' / 'payfailed'.
     const label = s.querySelector('.pay-label');
     const status = s.querySelector('.pay-status');
-    function setSending() {
+    function setSending(isAuto) {
       sending = true;
       card.classList.add('busy'); // dims + disables Not now / the toggle
       payBtn.classList.remove('done');
       payBtn.classList.add('pending');
       payBtn.disabled = true;
-      label.textContent = 'Sending payment…';
+      label.textContent = isAuto ? 'Zapping…' : 'Sending payment…';
       status.hidden = false;
       status.className = 'pay-status';
-      status.textContent = 'Confirming with your wallet. This can take a few seconds.';
+      status.textContent = isAuto
+        ? 'Inside your auto-zap limits, so Sidecar is paying this without asking.'
+        : 'Confirming with your wallet. This can take a few seconds.';
     }
     function setPaid() {
       payBtn.classList.remove('pending');
@@ -676,13 +690,54 @@
 
     (document.documentElement || document.body).appendChild(cardHost);
     requestAnimationFrame(() => ov.classList.add('in'));
+    // Auto-zap: the payment is already on its way, so open in the sending state. A
+    // failure re-enables Try again / Not now via setError, which is the right
+    // affordance once there's a decision to make again.
+    if (auto) setSending(true);
   }
+
+  // Auto-pay bookkeeping. The MutationObserver re-scans constantly, so a decision
+  // in flight must not spawn a second attempt, and a decline must be remembered or
+  // the card would never get to appear.
+  let autopayPending = '';
+  let autopayDeclined = '';
 
   function scanForInvoice() {
     if (!showCard || !connectedToSite) return removeCard();
     const invoice = findPageInvoice();
     if (!invoice || invoice === dismissedInvoice) return removeCard();
     if (invoice === shownInvoice && cardHost) return; // already showing this one
+    if (invoice === autopayPending) return; // asking the worker; show nothing yet
+    if (invoice !== autopayDeclined) {
+      // Ask first whether this is just the invoice for a zap already authorized on
+      // this page. If it is, the worker pays it and no card is ever needed.
+      autopayPending = invoice;
+      chrome.runtime
+        .sendMessage({ type: 'SIDECAR_TRY_ZAP_AUTOPAY', invoice, host })
+        .then((res) => {
+          autopayPending = '';
+          const r = (res && res.ok && res.result) || null;
+          if (r && r.handled) {
+            // Either way the auto card has already been shown and carries the result.
+            // Mark the invoice spent so the next DOM mutation can't re-probe it — the
+            // approval is single-use, so that second probe would be declined and would
+            // replace the card (and, on failure, throw the error message away).
+            autopayDeclined = invoice;
+            if (r.paid) dismissedInvoice = invoice;
+            return;
+          }
+          autopayDeclined = invoice;
+          scanForInvoice();
+        })
+        .catch(() => {
+          // Worker asleep or updating — fall back to asking the user, never to
+          // paying silently.
+          autopayPending = '';
+          autopayDeclined = invoice;
+          scanForInvoice();
+        });
+      return;
+    }
     renderCard(invoice);
   }
 
@@ -699,6 +754,10 @@
     if (msg.event === 'settings') {
       showCard = msg.showPayButton !== false;
       scanForInvoice();
+    } else if (msg.event === 'autopaying') {
+      // An auto-zap is going out for this invoice — show it, with no action to take.
+      // The 'paid' / 'payfailed' events below then land on this same card.
+      if (msg.invoice) renderCard(msg.invoice, true);
     } else if (msg.event === 'paid') {
       dismissedInvoice = msg.invoice; // don't resurface even if the link lingers
       // Throw the bolt across the page whether or not our own card was up — a zap

--- a/manifest.json
+++ b/manifest.json
@@ -26,6 +26,7 @@
       "nwc-client.js",
       "relax-grants.js",
       "replaceable-baseline.js",
+      "zap-requests.js",
       "jsqr.js",
       "background.js"
     ]

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -319,7 +319,7 @@
 
       <div class="setting">
         <h3>Automatic zaps</h3>
-        <p class="hint">Pay zaps without a prompt, up to a limit per zap and a daily total across all sites. Larger zaps, anything over the daily total, and all other payments still ask.</p>
+        <p class="hint">Zaps within these limits go through with no confirmation at all: Sidecar signs them, pays them, and skips its payment card. Only zaps you start in a client qualify, matched to the request Sidecar signed. Larger zaps, anything over the daily total, and every other payment still ask.</p>
         <label class="toggle-row"><input type="checkbox" id="autozap-toggle" /> <span>Auto-approve zaps</span></label>
         <label class="toggle-row hidden" id="autozap-max-row">
           <span>Max per zap</span>
@@ -331,6 +331,7 @@
           <input type="text" inputmode="numeric" id="autozap-daily-max" class="autozap-max-input" />
           <span>sats</span>
         </label>
+        <p class="hint">Covers zaps you start in a client. For other payments, give a site its own daily budget under <strong>Sites</strong>.</p>
       </div>
 
       <div class="setting">

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -319,7 +319,7 @@
 
       <div class="setting">
         <h3>Automatic zaps</h3>
-        <p class="hint">Zaps within these limits go through with no confirmation at all: Sidecar signs them, pays them, and skips its payment card. Only zaps you start in a client qualify, matched to the request Sidecar signed. Larger zaps, anything over the daily total, and every other payment still ask.</p>
+        <p class="hint">Zaps within these limits go through with no confirmation at all: Sidecar signs them, pays them, and skips its payment card. Only zaps you start in a client qualify, matched to the request Sidecar signed. Larger zaps, anything over the daily total, and every other payment still ask. Capped at 1,000 sats per zap and 10,000 a day.</p>
         <label class="toggle-row"><input type="checkbox" id="autozap-toggle" /> <span>Auto-approve zaps</span></label>
         <label class="toggle-row hidden" id="autozap-max-row">
           <span>Max per zap</span>

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -581,7 +581,6 @@
     if (typeof syncApprovalOverlay === 'function') syncApprovalOverlay();
   }
 
-
   // ---- onboarding ----
   const validateOnboardingPin = attachPinValidation($('ob-pin'), $('ob-pin2'), $('ob-submit'));
   $('onboarding-form').addEventListener('submit', async (e) => {
@@ -6258,7 +6257,6 @@
   const DENOM_ORDER = ['sats', 'btc', 'fiat'];
   let denom = 'sats';
 
-
   // Bitcoin's smallest unit is one sat, so 8 decimals is exact, not a rounding choice.
   const fmtBtc = (sats) => (Math.round(sats) / 1e8).toFixed(8);
 
@@ -7358,7 +7356,13 @@
     call({ type: 'SIDECAR_GET_BUDGETS' })
       .then((budgets) => {
         const hosts = Object.keys(budgets || {}).sort();
-        if (!hosts.length) { list.classList.add('empty'); listState(list, 'No sites have a spending budget.'); return; }
+        // Budgets can only be created from a payment prompt, so an empty list has to
+        // say how — otherwise the feature is invisible to anyone who ever unticked it.
+        if (!hosts.length) {
+          list.classList.add('empty');
+          listState(list, 'No sites have a spending budget. Tick “remember a budget” when you approve a payment.');
+          return;
+        }
         list.classList.remove('empty');
         list.innerHTML = '';
         hosts.forEach((host) => list.append(budgetRow(host, budgets[host])));

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -10,6 +10,11 @@
   // a stored value is missing or invalid.
   const AUTOZAP_DEFAULT_MAX = 100;
   const AUTOZAP_DAILY_MULT = 5; // default daily cap = 5× the per-zap cap
+  // Ceilings on the no-confirmation path — mirrored from background.js, which is
+  // where they are actually enforced. Reflected here only so a clamped entry snaps
+  // back visibly instead of appearing to have been accepted as typed.
+  const AUTOZAP_ABS_MAX = 1000;
+  const AUTOZAP_ABS_DAILY_MAX = 10000;
 
   // ---- messaging ----
   function bg(message) {
@@ -7962,25 +7967,25 @@
     const on = e.target.checked;
     $('autozap-max-row').classList.toggle('hidden', !on);
     $('autozap-daily-row').classList.toggle('hidden', !on);
-    const max = Math.max(1, parseInt($('autozap-max').value, 10) || AUTOZAP_DEFAULT_MAX);
+    const max = Math.min(AUTOZAP_ABS_MAX, Math.max(1, parseInt($('autozap-max').value, 10) || AUTOZAP_DEFAULT_MAX));
     $('autozap-max').value = String(max);
-    const daily = Math.max(max, parseInt($('autozap-daily-max').value, 10) || max * AUTOZAP_DAILY_MULT);
+    const daily = Math.min(AUTOZAP_ABS_DAILY_MAX, Math.max(max, parseInt($('autozap-daily-max').value, 10) || max * AUTOZAP_DAILY_MULT));
     $('autozap-daily-max').value = String(daily);
     await call({ type: 'SIDECAR_SET_SETTINGS', settings: { autoZap: on, autoZapMaxSats: max, autoZapDailyMaxSats: daily } });
   });
 
   $('autozap-max').addEventListener('change', async (e) => {
-    const max = Math.max(1, parseInt(e.target.value, 10) || AUTOZAP_DEFAULT_MAX);
+    const max = Math.min(AUTOZAP_ABS_MAX, Math.max(1, parseInt(e.target.value, 10) || AUTOZAP_DEFAULT_MAX));
     e.target.value = String(max);
     // Keep the daily total at or above the per-zap cap.
-    const daily = Math.max(max, parseInt($('autozap-daily-max').value, 10) || max * AUTOZAP_DAILY_MULT);
+    const daily = Math.min(AUTOZAP_ABS_DAILY_MAX, Math.max(max, parseInt($('autozap-daily-max').value, 10) || max * AUTOZAP_DAILY_MULT));
     $('autozap-daily-max').value = String(daily);
     await call({ type: 'SIDECAR_SET_SETTINGS', settings: { autoZapMaxSats: max, autoZapDailyMaxSats: daily } });
   });
 
   $('autozap-daily-max').addEventListener('change', async (e) => {
-    const perZap = Math.max(1, parseInt($('autozap-max').value, 10) || AUTOZAP_DEFAULT_MAX);
-    const daily = Math.max(perZap, parseInt(e.target.value, 10) || perZap * AUTOZAP_DAILY_MULT);
+    const perZap = Math.min(AUTOZAP_ABS_MAX, Math.max(1, parseInt($('autozap-max').value, 10) || AUTOZAP_DEFAULT_MAX));
+    const daily = Math.min(AUTOZAP_ABS_DAILY_MAX, Math.max(perZap, parseInt(e.target.value, 10) || perZap * AUTOZAP_DAILY_MULT));
     e.target.value = String(daily);
     await call({ type: 'SIDECAR_SET_SETTINGS', settings: { autoZapDailyMaxSats: daily } });
   });

--- a/test/zap-requests.test.js
+++ b/test/zap-requests.test.js
@@ -1,0 +1,259 @@
+'use strict';
+
+// Unit coverage for zap-request correlation (zap-requests.js).
+//
+// This module decides whether a Lightning payment may go out with NO prompt, so its
+// invariants are spending controls, not conveniences:
+//   - a payment only auto-approves against a zap request THIS user signed, for this
+//     site, this account, and this exact amount;
+//   - single-use — one signed request authorizes one payment, never a run of them;
+//   - anything that can't be bound tightly (no amount tag, no invoice amount) is
+//     refused rather than stored loosely: the cost of refusing is a prompt;
+//   - records expire, and a lock clears them outright.
+//
+// The check it replaces looked for a kind:9734 zap request inline in the invoice
+// description. NIP-57 step 6 issues a description HASH invoice, so that field is empty
+// on every spec-compliant zap and the old check never fired at all — "Auto-approve
+// zaps" was dead. It was also weaker in principle: any site could paste a real-looking
+// 9734 into a description it wrote itself, with nothing tying it to the user. The
+// no-inline-description case is pinned below so that regression can't come back.
+//
+// zap-requests.js is isolated (talks only to globalThis.chrome), so we load it in a vm
+// against a small chrome mock — same approach as test/replaceable-baseline.test.js.
+
+const { test, before, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const ROOT = path.join(__dirname, '..');
+
+function makeStorageArea() {
+  const data = {};
+  return {
+    get(keys, cb) {
+      let out = {};
+      if (keys == null) out = { ...data };
+      else if (typeof keys === 'string') { if (keys in data) out[keys] = data[keys]; }
+      else if (Array.isArray(keys)) { for (const k of keys) if (k in data) out[k] = data[k]; }
+      else { for (const k of Object.keys(keys)) out[k] = (k in data) ? data[k] : keys[k]; }
+      cb(out);
+    },
+    set(obj, cb) { Object.assign(data, obj); cb && cb(); },
+    remove(keys, cb) { for (const k of (Array.isArray(keys) ? keys : [keys])) delete data[k]; cb && cb(); },
+    clear(cb) { for (const k of Object.keys(data)) delete data[k]; cb && cb(); },
+  };
+}
+
+let Z;
+const ALICE = 'a'.repeat(64);
+const BOB = 'b'.repeat(64);
+const SITE = 'jumble.social';
+const OTHER = 'evil.example';
+
+// A kind:9734 zap request for `msat` millisats. `amount` is optional per NIP-57, so
+// passing null models the request that carries none.
+function zapRequest(msat, extraTags) {
+  const tags = [['p', 'c'.repeat(64)], ['relays', 'wss://relay.example']];
+  if (msat != null) tags.push(['amount', String(msat)]);
+  return { kind: 9734, content: '', tags: tags.concat(extraTags || []) };
+}
+
+before(() => {
+  globalThis.self = globalThis;
+  globalThis.chrome = { storage: { session: makeStorageArea() }, runtime: {} };
+  vm.runInThisContext(fs.readFileSync(path.join(ROOT, 'zap-requests.js'), 'utf8'), {
+    filename: 'zap-requests.js',
+  });
+  Z = globalThis.SidecarZapRequests;
+  assert.ok(Z, 'SidecarZapRequests loaded');
+});
+
+beforeEach(async () => {
+  await Z.clear();
+});
+
+// ---- the happy path ----
+
+test('a signed zap request lets the matching payment through', async () => {
+  assert.equal(await Z.record(SITE, ALICE, zapRequest(212000)), true);
+  assert.equal(await Z.claim(SITE, ALICE, 212), true);
+});
+
+test('sub-sat rounding still matches (invoice sats -> millisats)', async () => {
+  await Z.record(SITE, ALICE, zapRequest(1000));
+  assert.equal(await Z.claim(SITE, ALICE, 1), true);
+});
+
+test('several queued zaps each pay exactly once', async () => {
+  await Z.record(SITE, ALICE, zapRequest(100000));
+  await Z.record(SITE, ALICE, zapRequest(212000));
+  assert.equal(await Z.claim(SITE, ALICE, 212), true);
+  assert.equal(await Z.claim(SITE, ALICE, 100), true);
+  assert.equal(await Z.claim(SITE, ALICE, 100), false, 'no third payment');
+});
+
+// ---- single use ----
+
+test('one signed request cannot authorize two payments', async () => {
+  await Z.record(SITE, ALICE, zapRequest(212000));
+  assert.equal(await Z.claim(SITE, ALICE, 212), true);
+  assert.equal(await Z.claim(SITE, ALICE, 212), false, 'replay must be refused');
+});
+
+// ---- scoping: the abuse cases ----
+
+test('a different site cannot spend my zap request', async () => {
+  await Z.record(SITE, ALICE, zapRequest(212000));
+  assert.equal(await Z.claim(OTHER, ALICE, 212), false);
+  assert.equal(await Z.claim(SITE, ALICE, 212), true, 'still there for the real site');
+});
+
+test('a different account cannot spend it', async () => {
+  await Z.record(SITE, ALICE, zapRequest(212000));
+  assert.equal(await Z.claim(SITE, BOB, 212), false);
+});
+
+test('the amount must match exactly — no overpaying a small approval', async () => {
+  await Z.record(SITE, ALICE, zapRequest(212000));
+  assert.equal(await Z.claim(SITE, ALICE, 213), false);
+  assert.equal(await Z.claim(SITE, ALICE, 211), false);
+  assert.equal(await Z.claim(SITE, ALICE, 500000), false);
+  assert.equal(await Z.claim(SITE, ALICE, 212), true);
+});
+
+test('a payment with no prior zap request is never auto-approved', async () => {
+  assert.equal(await Z.claim(SITE, ALICE, 212), false);
+});
+
+// ---- refuse what cannot be bound ----
+
+test('a zap request without an amount tag is not stored', async () => {
+  assert.equal(await Z.record(SITE, ALICE, zapRequest(null)), false);
+  assert.deepEqual(await Z.pending(), [], 'a match-anything record is not a safeguard');
+});
+
+test('a non-numeric or non-positive amount is not stored', async () => {
+  for (const bad of ['abc', '0', '-5000', '']) {
+    const ev = { kind: 9734, content: '', tags: [['amount', bad]] };
+    assert.equal(await Z.record(SITE, ALICE, ev), false, 'amount ' + JSON.stringify(bad));
+  }
+  assert.deepEqual(await Z.pending(), []);
+});
+
+test('an amountless invoice never claims a record', async () => {
+  await Z.record(SITE, ALICE, zapRequest(212000));
+  assert.equal(await Z.claim(SITE, ALICE, null), false);
+  assert.equal(await Z.claim(SITE, ALICE, undefined), false);
+  assert.equal(await Z.claim(SITE, ALICE, NaN), false);
+  assert.equal((await Z.pending()).length, 1, 'and does not consume it');
+});
+
+test('only kind 9734 is recorded', async () => {
+  for (const kind of [0, 1, 3, 9735, 10000]) {
+    assert.equal(await Z.record(SITE, ALICE, { kind, tags: [['amount', '212000']] }), false);
+  }
+  assert.deepEqual(await Z.pending(), []);
+});
+
+test('malformed events are refused without throwing', async () => {
+  for (const ev of [null, undefined, {}, { kind: 9734 }, { kind: 9734, tags: 'nope' }]) {
+    assert.equal(await Z.record(SITE, ALICE, ev), false);
+  }
+  assert.equal(await Z.record('', ALICE, zapRequest(1000)), false, 'no host');
+  assert.equal(await Z.record(SITE, '', zapRequest(1000)), false, 'no account');
+  assert.deepEqual(await Z.pending(), []);
+});
+
+// ---- peek: decides whether the page-invoice card can be skipped ----
+
+test('peek matches without consuming, so the payment can still claim', async () => {
+  await Z.record(SITE, ALICE, zapRequest(21000));
+  assert.equal(await Z.peek(SITE, ALICE, 21), true);
+  assert.equal(await Z.peek(SITE, ALICE, 21), true, 'repeatable — peeking is not spending');
+  assert.equal((await Z.pending()).length, 1);
+  assert.equal(await Z.claim(SITE, ALICE, 21), true, 'the record survived to be claimed');
+});
+
+test('peek is scoped exactly like claim', async () => {
+  await Z.record(SITE, ALICE, zapRequest(21000));
+  assert.equal(await Z.peek(OTHER, ALICE, 21), false, 'wrong site');
+  assert.equal(await Z.peek(SITE, BOB, 21), false, 'wrong account');
+  assert.equal(await Z.peek(SITE, ALICE, 22), false, 'wrong amount');
+  assert.equal(await Z.peek(SITE, ALICE, null), false, 'amountless');
+  assert.equal(await Z.peek(SITE, ALICE, 21), true);
+});
+
+test('peek finds nothing when no zap was authorized', async () => {
+  assert.equal(await Z.peek(SITE, ALICE, 21), false);
+});
+
+test('peek refuses an expired record', async () => {
+  await Z.record(SITE, ALICE, zapRequest(21000));
+  const stale = (await Z.pending()).map((z) => ({ ...z, ts: z.ts - Z.TTL_MS - 1000 }));
+  await new Promise((r) => chrome.storage.session.set({ [Z.STORAGE_KEY]: stale }, r));
+  assert.equal(await Z.peek(SITE, ALICE, 21), false);
+});
+
+// ---- expiry and lock ----
+
+test('an expired record is refused', async () => {
+  await Z.record(SITE, ALICE, zapRequest(212000));
+  const stale = (await Z.pending()).map((z) => ({ ...z, ts: z.ts - Z.TTL_MS - 1000 }));
+  await new Promise((r) => chrome.storage.session.set({ [Z.STORAGE_KEY]: stale }, r));
+  assert.equal(await Z.claim(SITE, ALICE, 212), false);
+});
+
+test('recording sweeps expired records', async () => {
+  await new Promise((r) =>
+    chrome.storage.session.set(
+      { [Z.STORAGE_KEY]: [{ host: SITE, pubkey: ALICE, msat: 1, ts: Date.now() - Z.TTL_MS - 1 }] },
+      r
+    )
+  );
+  await Z.record(SITE, ALICE, zapRequest(212000));
+  const left = await Z.pending();
+  assert.equal(left.length, 1);
+  assert.equal(left[0].msat, 212000);
+});
+
+test('lock clears every pending approval', async () => {
+  await Z.record(SITE, ALICE, zapRequest(212000));
+  await Z.record(SITE, BOB, zapRequest(100000));
+  await Z.clear();
+  assert.deepEqual(await Z.pending(), []);
+  assert.equal(await Z.claim(SITE, ALICE, 212), false);
+});
+
+// ---- the regression this module exists for ----
+
+test('a real zap invoice carries NO inline description, which is why the old check never fired', () => {
+  // Tag 13 ('d') is the inline description; tag 23 ('h') is the description hash.
+  // Real NIP-57 zap invoices, as collected from a live client, carry only 'h'.
+  const REAL_ZAP_INVOICES = [
+    'lnbc2120n1p4x232wpp559ajf4ec7s4t7gef74xnsyqert3jt807dr6ydxq23ft3hdskd2rqhp5wau44uqa3az65r80rmn4ymfsqnwrex4yhzfll8aul55e48cgcjmscqzysxqrrssrzjqv3dpepm8kfdxrk3sl6wzqdf49s9c0h9ljtjrek6c08r6aejlwcnur0dwyqqvusqqqqqqqlgqqqq86qqjqsp5g5kgwuuptl7yjc7g9xxzhcs8dnejccuy8fy3z9xywz02uhnqpagq9qxpqysgqneh4h267tam88h5hqnwj6rt2u40ekwcfuevejt60kjdu6lpp0lqq7a9nwjxdmqqz8x9cxlsp75qs4wl6qgn7g3uk7p8z25u33mg8h7gq8fhzmf',
+    'lnbc840n1p4x2jvwpp5fng2eafm4m6zqj33jvquywx5edmq02sca2cfxmtlzxvddxpjlspssp5dcxdutntg573nsuwduvz5edanyh707wzkfjjha79clny7p7zhwlqxq9z0rgqnp4qvyndeaqzman7h898jxm98dzkm0mlrsx36s93smrur7h0azyyuxc5rzjq25carzepgd4vqsyn44jrk85ezrpju92xyrk9apw4cdjh6yrwt5jgqqqqrt49lmtcqqqqqqqqqqq86qq9qrzjqvt4uzpwalva67rw74e4a4qkxgvfh8z7cu68k8ctx3l5sxssr0578apyqr6zgqqqq8hxk2qqae4jsqyugqcqzpuhp5kkfy66cj2050ug3pwuc4vdwnv8wec30dqh6xz822ym2f6uvnqxtq9qyyssqdkpznl3ek82zqvjd90ru27ysx4pqpqn8jjk0uqxa8232ftdlu654djysf5dws2mpyhnejvtva3uuzpxxvg4naerm8c4m7mnxc8xnahsp94d6n7',
+  ];
+  const CHARS = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l';
+  const tagsOf = (inv) => {
+    const words = inv.slice(inv.lastIndexOf('1') + 1).split('').map((c) => CHARS.indexOf(c));
+    const body = words.slice(0, words.length - 6);
+    const end = body.length - 104;
+    const found = [];
+    let i = 7;
+    while (i + 3 <= end) {
+      const tag = body[i];
+      const len = body[i + 1] * 32 + body[i + 2];
+      if (i + 3 + len > end) break;
+      found.push(tag);
+      i += 3 + len;
+    }
+    return found;
+  };
+  for (const inv of REAL_ZAP_INVOICES) {
+    const tags = tagsOf(inv);
+    assert.ok(tags.includes(23), 'zap invoice commits via description hash (tag 23)');
+    assert.ok(!tags.includes(13), 'and carries no inline description (tag 13) to sniff');
+  }
+});

--- a/zap-requests.js
+++ b/zap-requests.js
@@ -1,0 +1,128 @@
+// Sidecar — zap-request correlation for auto-approved zaps (isolated module).
+//
+// "Auto-approve zaps" is a spending gate: under it, a site's payment goes out with no
+// prompt at all. So the test for "is this really a zap?" has to be one an unfriendly
+// site cannot satisfy on its own.
+//
+// The old test asked whether the invoice's description was a kind:9734 zap request.
+// It never once fired. NIP-57 step 6 has the lnurl server issue a description HASH
+// invoice — "the description is this zap request note and this note only" — so the
+// request is committed to, never carried. The description field is empty on every
+// spec-compliant zap, and the check always returned false. The setting did nothing.
+//
+// Matching that hash isn't a fix. It's computed over the exact JSON the client posted
+// to the lnurl callback, and Sidecar hands back a signed event which the client then
+// re-serializes in whatever key order it pleases. Sidecar cannot know those bytes, and
+// a check that silently fails closed forever is worse than no check.
+//
+// So bind to what Sidecar does know: it SIGNED the kind:9734, seconds earlier. A
+// payment qualifies only if it matches a zap request this user authorized through
+// Sidecar — same site, same account, same amount to the millisat, inside a short
+// window, redeemable exactly once. That is strictly stronger than what it replaces:
+// the old inline check could be satisfied by any site that pasted a real-looking 9734
+// into a description it wrote itself, with nothing tying it to the user at all.
+//
+// Records live in chrome.storage.session: a worker restart between signing and paying
+// must not quietly switch auto-zap off, and they never belong on disk.
+//
+// Isolated (like relax-grants.js / replaceable-baseline.js) so it can be unit-tested
+// directly against a chrome mock — see test/zap-requests.test.js.
+
+(function () {
+  'use strict';
+
+  const STORAGE_KEY = 'sidecar_pending_zaps';
+  // Generous enough for a slow lnurl round trip, short enough that a stale approval
+  // can't be spent much later. The zap flow itself is seconds.
+  const TTL_MS = 180000;
+
+  const now = () => Date.now();
+
+  function read() {
+    return new Promise((resolve) =>
+      chrome.storage.session.get(STORAGE_KEY, (got) => {
+        void chrome.runtime.lastError;
+        const list = got && got[STORAGE_KEY];
+        resolve(Array.isArray(list) ? list : []);
+      })
+    );
+  }
+
+  function write(list) {
+    return new Promise((resolve) =>
+      chrome.storage.session.set({ [STORAGE_KEY]: list }, () => {
+        void chrome.runtime.lastError;
+        resolve();
+      })
+    );
+  }
+
+  const fresh = (list, t) => list.filter((z) => z && t - z.ts <= TTL_MS);
+
+  // Remember a zap request we just signed, so the payment that follows can be tied
+  // back to it. Anything we can't bind tightly is skipped rather than stored loosely —
+  // the cost of skipping is a prompt, which is the safe direction.
+  async function record(host, pubkey, ev) {
+    if (!host || !pubkey) return false;
+    if (!ev || ev.kind !== 9734 || !Array.isArray(ev.tags)) return false;
+    const tag = ev.tags.find((t) => Array.isArray(t) && t[0] === 'amount');
+    const msat = tag ? Number(tag[1]) : 0;
+    // NIP-57 makes `amount` optional. A record that would match ANY amount is not a
+    // safeguard, so decline to store one and let the payment prompt normally.
+    if (!Number.isFinite(msat) || msat <= 0) return false;
+    const t = now();
+    const list = fresh(await read(), t);
+    list.push({ host, pubkey, msat, ts: t });
+    await write(list);
+    return true;
+  }
+
+  // Claim the zap request behind this payment, if there is one. Single-use: one signed
+  // request authorizes exactly one payment, so a site cannot replay a single approval
+  // across a run of invoices.
+  async function claim(host, pubkey, sats) {
+    if (!host || !pubkey) return false;
+    if (sats == null || !Number.isFinite(sats)) return false;
+    const t = now();
+    const msat = Math.round(sats * 1000);
+    const list = await read();
+    const i = list.findIndex(
+      (z) =>
+        z &&
+        z.host === host &&
+        z.pubkey === pubkey &&
+        z.msat === msat &&
+        t - z.ts <= TTL_MS
+    );
+    if (i < 0) return false;
+    list.splice(i, 1);
+    await write(fresh(list, t));
+    return true;
+  }
+
+  // Is there a request this payment would match? Same test as claim(), but it does
+  // NOT consume: callers that only need to decide whether to offer/skip a UI must
+  // leave the record intact for the payment itself to claim.
+  async function peek(host, pubkey, sats) {
+    if (!host || !pubkey) return false;
+    if (sats == null || !Number.isFinite(sats)) return false;
+    const t = now();
+    const msat = Math.round(sats * 1000);
+    return (await read()).some(
+      (z) => z && z.host === host && z.pubkey === pubkey && z.msat === msat && t - z.ts <= TTL_MS
+    );
+  }
+
+  // Drop everything — used on lock, so a locked keystore leaves no spendable approvals.
+  async function clear() {
+    await write([]);
+  }
+
+  async function pending() {
+    return fresh(await read(), now());
+  }
+
+  const api = { STORAGE_KEY, TTL_MS, record, claim, peek, clear, pending };
+  if (typeof self !== 'undefined') self.SidecarZapRequests = api;
+  if (typeof globalThis !== 'undefined') globalThis.SidecarZapRequests = api;
+})();


### PR DESCRIPTION
Stacked on #141 — that merges first; this diff is against it, not `main`.

## Why auto-zap never worked

The check asked whether the invoice's description was a `kind:9734` zap request. [NIP-57 step 6](https://github.com/nostr-protocol/nips/blob/master/57.md) has the lnurl server issue a description *hash* invoice — "the description is this zap request note and this note only" — so that field is empty on every spec-compliant zap. Tested false against three real ones. The setting has been dead since it shipped.

Matching the hash instead doesn't work: it's computed over the exact JSON the client posted to the callback, and we hand back a signed event the client re-serializes in its own key order. Unreproducible from here.

What we do have is the signature itself — Sidecar signs the 9734 seconds before the invoice appears. So a payment auto-approves only against a zap request signed through Sidecar for the same site, account, and amount to the millisat. Single use, short window, cleared on lock.

Incidentally stricter than the old check, which any site could satisfy by pasting a plausible 9734 into a description it wrote itself.

## Three gates, not one

```
1. sign the kind:9734  → permission tier + shared-host override
2. the client's own UI → not ours
3. pay the invoice     → the only gate the setting used to cover
```

Raising the cap only ever touched gate 3, which is why small zaps still stopped to ask. Gate 1 now honors the same limits — a zap request declares its own amount, so the caps apply at signing time; the payment path re-checks and stays the thing that records the spend.

Gate 3 turned out not to be the blocker anyway. Jumble never calls `window.webln` — it renders a QR, and our own page-invoice card is what sits between picking an amount and paying. That card now checks first whether the invoice belongs to a zap already authorized on the page, and pays without appearing if so. It peeks rather than claims; `payInvoiceCore` does the real single-use claim, and consuming it early would make it prompt.

## Limits

1,000 sats per zap, 10,000 a day, enforced in `background.js` on both read and write. Previously the panel floor-clamped and nothing else validated, so the bound on automatic spending was whatever was last typed into a text field. Clamping on read means a value stored before the ceilings existed gets brought under them without the user touching anything.

Everything requires `autoZap === true` strictly; absent reads as off. Locked keystore, blocked site, missing amount tag, malformed event, unreachable worker all fall through to asking. Blocked sites throw before the approval gate is computed, and the destructive-overwrite guard keeps precedence over auto-signing.

`SIDECAR_TRY_ZAP_AUTOPAY` is on `CONTENT_OK` next to `SIDECAR_PAY_PAGE_INVOICE` and is strictly narrower. Host from `sender.url`, never the message body.

## The card still shows

Auto-zaps render the card in a flat, buttonless "Zapping…" state, put up before the payment so a failure has somewhere to land. Previously a failed auto-pay was silent.

## Two things to remember later

Records match on `(host, account, amount)`, not on the invoice — a compromised client could substitute a different invoice of the same amount. The manual card never protected against that either (it shows amount and site, never recipient), and the ceilings bound it.

Turning off "Show this automatically" also disables auto-zap, since `scanForInvoice` returns before the probe. Fails safe, but it's non-obvious and undocumented.

## Tests

71, up from 50. `zap-requests.js` is isolated like `relax-grants.js`; 21 tests cover wrong site, wrong account, wrong amount, replay, expiry, lock, non-consuming peek, and a regression test pinning the no-inline-description fact against two real invoices. Ceiling clamping verified across 10 input shapes including a legacy over-limit value.

Confirmed end to end on a live Jumble zap: 21 sats out, preimage recorded, no Sidecar surface at any gate.

🍾 Uncorked with [Claude Code](https://claude.com/claude-code)