### PR TITLE
fix: notes were signed, reported as posted, and published nowhere

### DIFF
--- a/sidepanel.js
+++ b/sidepanel.js
@@ -1160,14 +1160,22 @@
 
   async function publishToRelays(relays, signed) {
     if (!relays.length) throw new Error('No relays configured (add some in Settings)');
-    const results = await Promise.allSettled(getPool().publish(relays, signed));
+    // Dedupe the way the pool will. A plain Set over the raw strings keeps
+    // 'wss://nos.lol' and 'wss://nos.lol/' as two entries, but SimplePool normalizes
+    // before connecting and rejects the second with 'duplicate url' — which then
+    // counts as a failed relay and muddies the error detail. Both spellings occur in
+    // the wild: NIP-65 tags and relay hints disagree about the trailing slash.
+    const targets = [...new Set(relays.map((u) => {
+      try { return NT.utils.normalizeURL(u); } catch (_) { return u; }
+    }))];
+    const results = await Promise.allSettled(getPool().publish(targets, signed));
     const ok = results.filter((r) => !publishFailed(r)).length;
     if (!ok) {
       const detail = results
         .map((r, i) => {
           const why =
             r.status === 'rejected' ? r.reason?.message || r.reason || 'rejected' : r.value;
-          return `${relays[i]}: ${why}`;
+          return `${targets[i]}: ${why}`;
         })
         .join(' | ');
       throw new Error(`Could not publish to any relay — ${detail}`);

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -1133,20 +1133,43 @@
     return parsed;
   }
 
-  // Where to publish the active account's events: its NIP-65 write relays if it
-  // has them, else the relays configured in Settings.
+  // Where to publish the active account's events: its NIP-65 write relays UNION the
+  // relays configured in Settings.
+  //
+  // It used to be one or the other — NIP-65 if present, else Settings. That put every
+  // post at the mercy of the declared write set: if those relays lapse, gate on a
+  // web-of-trust, or simply stop resolving, the note goes nowhere even though a
+  // perfectly good relay is configured a few lines away. Publishing to both means a
+  // note still lands, and still lands where the account claims to write.
+  // publishNip65() already targets a union for the same reason.
   async function postRelays() {
     const n = await getNip65(state.activePubkey);
-    if (n && n.write.length) return n.write;
-    return relayUrls(true);
+    const configured = await relayUrls(true);
+    return [...new Set([...(n ? n.write : []), ...configured])];
   }
+
+  // A relay that could not be reached is NOT a successful publish. SimplePool.publish()
+  // resolves with the string "connection failure: …" instead of rejecting in that case
+  // (see nostr-tools.js — vendored and pinned, so this string is stable; re-check it if
+  // that file is ever upgraded). Counting settled promises therefore counted dead
+  // relays as wins: with enough of them every post reported success while landing
+  // nowhere, which is exactly how notes went out with a valid id and reached no one.
+  const publishFailed = (r) =>
+    r.status === 'rejected' ||
+    (typeof r.value === 'string' && r.value.startsWith('connection failure:'));
 
   async function publishToRelays(relays, signed) {
     if (!relays.length) throw new Error('No relays configured (add some in Settings)');
     const results = await Promise.allSettled(getPool().publish(relays, signed));
-    const ok = results.filter((r) => r.status === 'fulfilled').length;
+    const ok = results.filter((r) => !publishFailed(r)).length;
     if (!ok) {
-      const detail = results.map((r, i) => `${relays[i]}: ${r.reason?.message || r.reason || 'rejected'}`).join(' | ');
+      const detail = results
+        .map((r, i) => {
+          const why =
+            r.status === 'rejected' ? r.reason?.message || r.reason || 'rejected' : r.value;
+          return `${relays[i]}: ${why}`;
+        })
+        .join(' | ');
       throw new Error(`Could not publish to any relay — ${detail}`);
     }
     return ok;


### PR DESCRIPTION
Notes composed in Sidecar were being signed, given a valid event id, reported as posted — and stored on no relay at all.

Two faults, either of which alone would have hidden the other.

## Every post rode on the NIP-65 write set alone

`postRelays()` was either/or: the account's declared write relays if it has any, else the relays from Settings. So if those write relays lapse, gate on a web of trust, or simply stop resolving, the note goes nowhere — while a perfectly good relay sits configured a few lines away, unused.

It now publishes to the **union**. A note lands, and still lands where the account claims to write. `publishNip65()` already targeted a union for exactly this reason; posts just never did.

## The failure was invisible

`SimplePool.publish()` **resolves with the string `"connection failure: …"`** instead of rejecting when a relay can't be reached (`nostr-tools.js:3896`). Counting settled promises therefore counted dead relays as successes — enough of them and `ok > 0`, nothing throws, and the composer reports success.

```
relay accepted            → resolves ""                      → success ✓
relay rejected (OK false) → rejects                          → failure ✓
cannot connect            → resolves "connection failure: …" → success ✗
```

Now classified properly, verified against all six shapes `publish()` can produce: accepted, accepted-with-reason, `OK false`, `auth-required`, connection failure, duplicate url. A failed publish also names each relay and its reason rather than a bare `rejected`.

## Scope

Both faults applied to everything that goes through `publishSigned` — posts, profile writes, NIP-65 updates, follow lists. A follow list silently failing to publish is the case the destructive-event guard exists to protect.

## Verification

A note posted after the fix is live on `relay.azzamo.net`, `nos.lol`, and `nostr.land` — queried by event id, independent of the client.

**`nos.lol` is the proof the union is doing the work:** it's a Settings relay and is absent from this account's NIP-65 write list. It could only have got there via the union.

Diagnosis notes, since two plausible theories were wrong along the way:
- Not a regression. `postRelays`, `publishToRelays`, `getNip65`, `getPool` and `relayUrls` are byte-identical to v1.5.0; `nostr-tools.js` is unchanged too. A 1.5.0 install worked only because its NIP-65 lookup came back empty and it fell through to the Settings relays.
- Not NIP-42 auth. `nostr.land` sends an AUTH challenge but demonstrably stores this account's notes without one.
- The `nostr.wine` relays are not dead. They refuse a Node client that sends no `Origin` header; a browser is unaffected.

🥂 Toasted with [Claude Code](https://claude.com/claude-code)