### PR TITLE
fix: the approval footer — PIN, relax chips and errors all reachable

### DIFF
--- a/prompt.html
+++ b/prompt.html
@@ -66,14 +66,22 @@
       backdrop-filter: blur(14px);
       -webkit-backdrop-filter: blur(14px);
     }
-    /* The unlock field sits in the footer (see the markup). A hairline separates it
-       from the scrolling body above, and its own margin keeps it off the buttons. */
-    .prompt-footer #unlock {
-      margin-bottom: 12px;
-      padding-top: 12px;
-      border-top: 1px solid var(--border);
-    }
+    /* Everything the user ACTS on lives in the footer — PIN, the budget toggle, the
+       relax chips, the buttons. The body above holds what they're deciding about and
+       is the only part that scrolls. Anything interactive left in the body can be
+       scrolled out of reach with nothing to suggest it's there, which is how the
+       relax chips went missing once the PIN stopped scrolling.
+       The hairline sits on the footer itself so it lands correctly whichever of these
+       is visible — they're conditional, and #relax-row and #remember never co-occur
+       (signing vs payment). */
+    .prompt-footer { border-top: 1px solid var(--border); padding-top: 12px; }
+    .prompt-footer #unlock { margin-bottom: 12px; }
     .prompt-footer #unlock input[type=password] { margin-bottom: 0; }
+    .prompt-footer #relax-row,
+    .prompt-footer #remember { margin-bottom: 12px; }
+    /* The relax heading is a Playfair display line sized for the body; in the footer
+       it only needs to label three chips. */
+    .prompt-footer .relax-label { font-size: 13px; margin-bottom: 7px; }
     .brand { display: flex; align-items: center; justify-content: center; margin-bottom: 18px; }
     .brand img { height: 26px; width: auto; display: block; filter: drop-shadow(0 2px 8px rgba(0, 0, 0, 0.4)); }
     .host {
@@ -308,22 +316,7 @@
     <button class="switch-toggle hidden" id="switch-toggle">Sign in with a different account</button>
     <div class="switch-menu hidden" id="switch-menu"></div>
 
-    <div id="remember" class="remember hidden">
-      <label class="check"><input type="checkbox" id="remember-budget" /> Allow this site to spend up to</label>
-      <div class="budget-row">
-        <input type="number" id="budget-amount" min="1" placeholder="sats" />
-        <span class="budget-unit">sats / day without asking</span>
-      </div>
-    </div>
 
-    <div id="relax-row" class="relax-row hidden">
-      <div class="relax-label">Auto-sign for the next</div>
-      <div class="relax-chips">
-        <button type="button" class="relax-chip" data-mins="5">5 min</button>
-        <button type="button" class="relax-chip" data-mins="15">15 min</button>
-        <button type="button" class="relax-chip" data-mins="30">30 min</button>
-      </div>
-    </div>
   </div>
 
   <div class="prompt-footer">
@@ -334,6 +327,21 @@
     <div id="unlock" class="hidden">
       <label for="pin">Enter your PIN to unlock</label>
       <input type="password" id="pin" autocomplete="off" maxlength="32" autofocus />
+    </div>
+    <div id="remember" class="remember hidden">
+    <label class="check"><input type="checkbox" id="remember-budget" /> Allow this site to spend up to</label>
+    <div class="budget-row">
+      <input type="number" id="budget-amount" min="1" placeholder="sats" />
+      <span class="budget-unit">sats / day without asking</span>
+    </div>
+    </div>
+    <div id="relax-row" class="relax-row hidden">
+    <div class="relax-label">Auto-sign for the next</div>
+    <div class="relax-chips">
+      <button type="button" class="relax-chip" data-mins="5">5 min</button>
+      <button type="button" class="relax-chip" data-mins="15">15 min</button>
+      <button type="button" class="relax-chip" data-mins="30">30 min</button>
+    </div>
     </div>
     <div class="error" id="error"></div>
     <div class="actions">

--- a/prompt.html
+++ b/prompt.html
@@ -78,7 +78,16 @@
     .prompt-footer #unlock { margin-bottom: 12px; }
     .prompt-footer #unlock input[type=password] { margin-bottom: 0; }
     .prompt-footer #relax-row,
-    .prompt-footer #remember { margin-bottom: 12px; }
+    .prompt-footer #remember { margin-bottom: 10px; }
+    /* The chips are the last thing in the relax row; its own margin spaces them from
+       the buttons, so don't pay twice. */
+    .prompt-footer .relax-chips { margin-bottom: 0; }
+    /* .error reserves 18px + 8px so the body layout can't jump when a message
+       appears. In the footer that reservation is permanent dead space above the
+       buttons on every prompt — and the footer is the last thing on screen, so
+       nothing below it can be pushed around. Collapse it until it has something
+       to say. */
+    .prompt-footer .error:empty { display: none; }
     /* The relax heading is a Playfair display line sized for the body; in the footer
        it only needs to label three chips. */
     .prompt-footer .relax-label { font-size: 13px; margin-bottom: 7px; }

--- a/prompt.html
+++ b/prompt.html
@@ -66,6 +66,14 @@
       backdrop-filter: blur(14px);
       -webkit-backdrop-filter: blur(14px);
     }
+    /* The unlock field sits in the footer (see the markup). A hairline separates it
+       from the scrolling body above, and its own margin keeps it off the buttons. */
+    .prompt-footer #unlock {
+      margin-bottom: 12px;
+      padding-top: 12px;
+      border-top: 1px solid var(--border);
+    }
+    .prompt-footer #unlock input[type=password] { margin-bottom: 0; }
     .brand { display: flex; align-items: center; justify-content: center; margin-bottom: 18px; }
     .brand img { height: 26px; width: auto; display: block; filter: drop-shadow(0 2px 8px rgba(0, 0, 0, 0.4)); }
     .host {
@@ -300,11 +308,6 @@
     <button class="switch-toggle hidden" id="switch-toggle">Sign in with a different account</button>
     <div class="switch-menu hidden" id="switch-menu"></div>
 
-    <div id="unlock" class="hidden">
-      <label for="pin">Enter your PIN to unlock</label>
-      <input type="password" id="pin" autocomplete="off" maxlength="32" autofocus />
-    </div>
-
     <div id="remember" class="remember hidden">
       <label class="check"><input type="checkbox" id="remember-budget" /> Allow this site to spend up to</label>
       <div class="budget-row">
@@ -324,6 +327,14 @@
   </div>
 
   <div class="prompt-footer">
+    <!-- The PIN lives in the FOOTER, not the scrolling body. It is the action the
+         button beside it demands, so it must not be able to scroll out of view — and
+         .prompt-scroll fades its own bottom edge, which was leaving the field
+         half-transparent before it even left the viewport. -->
+    <div id="unlock" class="hidden">
+      <label for="pin">Enter your PIN to unlock</label>
+      <input type="password" id="pin" autocomplete="off" maxlength="32" autofocus />
+    </div>
     <div class="error" id="error"></div>
     <div class="actions">
       <button class="primary" id="allow">Allow once</button>

--- a/prompt.html
+++ b/prompt.html
@@ -77,6 +77,7 @@
     .prompt-footer { border-top: 1px solid var(--border); padding-top: 12px; }
     .prompt-footer #unlock { margin-bottom: 12px; }
     .prompt-footer #unlock input[type=password] { margin-bottom: 0; }
+    .prompt-footer #pin-error { margin: 7px 0 0; }
     .prompt-footer #relax-row,
     .prompt-footer #remember { margin-bottom: 10px; }
     /* The chips are the last thing in the relax row; its own margin spaces them from
@@ -336,6 +337,11 @@
     <div id="unlock" class="hidden">
       <label for="pin">Enter your PIN to unlock</label>
       <input type="password" id="pin" autocomplete="off" maxlength="32" autofocus />
+      <!-- PIN failures belong against the PIN, not two controls further down next to
+           the buttons — this is where "N attempts left before all data is erased"
+           lands. #error below stays for everything else (the budget message, which is
+           already adjacent to the budget row). -->
+      <div class="error" id="pin-error"></div>
     </div>
     <div id="remember" class="remember hidden">
     <label class="check"><input type="checkbox" id="remember-budget" /> Allow this site to spend up to</label>

--- a/prompt.html
+++ b/prompt.html
@@ -61,7 +61,8 @@
     }
     .prompt-footer {
       flex-shrink: 0;
-      padding: 10px 22px 18px;
+      padding: 12px 22px 18px;
+      border-top: 1px solid var(--border);
       background: rgba(12, 3, 26, 0.55);
       backdrop-filter: blur(14px);
       -webkit-backdrop-filter: blur(14px);
@@ -74,7 +75,6 @@
        The hairline sits on the footer itself so it lands correctly whichever of these
        is visible — they're conditional, and #relax-row and #remember never co-occur
        (signing vs payment). */
-    .prompt-footer { border-top: 1px solid var(--border); padding-top: 12px; }
     .prompt-footer #unlock { margin-bottom: 12px; }
     .prompt-footer #unlock input[type=password] { margin-bottom: 0; }
     .prompt-footer #pin-error { margin: 7px 0 0; }

--- a/prompt.js
+++ b/prompt.js
@@ -19,6 +19,7 @@
     unlock: $('unlock'),
     pin: $('pin'),
     error: $('error'),
+    pinError: $('pin-error'),
     allow: $('allow'),
     trust: $('trust'),
     reject: $('reject'),
@@ -579,18 +580,19 @@
 
   async function decide(action, opts) {
     els.error.textContent = '';
+    els.pinError.textContent = '';
     // Unlock first if needed (Allow once / Trust / Relax / Pay only).
     if (data.needUnlock && (action === 'once' || action === 'trust' || action === 'relax')) {
       const pin = els.pin.value;
       if (!pin) {
-        els.error.textContent = 'Enter your PIN.';
+        els.pinError.textContent = 'Enter your PIN.';
         return;
       }
       // SIDECAR_UNLOCK contract (see background.js): branch on result.status, not ok.
       const unlocked = await send({ type: 'SIDECAR_UNLOCK', pin });
       const st = unlocked && unlocked.ok && unlocked.result;
       if (!st || st.status !== 'ok') {
-        els.error.textContent =
+        els.pinError.textContent =
           st && st.status === 'throttled' ? 'Too many attempts. Try again in ' + Math.ceil(st.waitMs / 1000) + 's.'
           : st && st.status === 'bad' ? 'Incorrect PIN — ' + st.remaining + ' attempt' + (st.remaining === 1 ? '' : 's') + ' left before all data is erased.'
           : st && st.status === 'wiped' ? 'Too many attempts — all data on this device was erased.'

--- a/prompt.js
+++ b/prompt.js
@@ -574,8 +574,8 @@
   function setLocked(locked) {
     if (els.allow) els.allow.disabled = locked;
     if (els.trust) els.trust.disabled = locked;
-    const footer = els.allow && els.allow.parentNode;
-    if (footer) footer.classList.toggle('approval-locked', locked);
+    const actions = els.allow && els.allow.parentNode; // .actions, not .prompt-footer
+    if (actions) actions.classList.toggle('approval-locked', locked);
   }
 
   async function decide(action, opts) {

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -407,6 +407,10 @@
       <div id="approval-unlock" class="hidden stack">
         <label for="approval-pin">Enter your PIN to unlock</label>
         <input type="password" id="approval-pin" autocomplete="off" maxlength="32" />
+        <!-- PIN failures belong against the PIN, not below the budget/relax rows —
+             this is where "N attempts left before all data is erased" lands.
+             #approval-error stays for everything else. -->
+        <div class="error" id="approval-pin-error"></div>
       </div>
 
       <div id="approval-remember" class="remember hidden">

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -8526,6 +8526,7 @@
     renderApprovalPreview(data);
 
     $('approval-error').textContent = '';
+    $('approval-pin-error').textContent = '';
     // Lock Allow/Trust behind the warning's "I understand" when this event destroys
     // data. Applied here, after renderApprovalPreview built the warning, so a re-render
     // (queue advance, unlock) re-locks rather than leaving a previous acknowledgement
@@ -8615,19 +8616,21 @@
     if (!pendingApproval) return;
     const { id, data } = pendingApproval;
     const err = $('approval-error');
+    const pinErr = $('approval-pin-error');
     err.textContent = '';
+    pinErr.textContent = '';
     // Unlock first if needed (Allow once / Trust / Relax only).
     if (data.needUnlock && (action === 'once' || action === 'trust' || action === 'relax')) {
       const pin = $('approval-pin').value;
       if (!pin) {
-        err.textContent = 'Enter your PIN.';
+        pinErr.textContent = 'Enter your PIN.';
         return;
       }
       // SIDECAR_UNLOCK contract (see background.js): branch on result.status, not ok.
       const resp = await bg({ type: 'SIDECAR_UNLOCK', pin });
       const st = resp && resp.ok && resp.result;
       if (!st || st.status !== 'ok') {
-        err.textContent =
+        pinErr.textContent =
           st && st.status === 'throttled' ? 'Too many attempts. Try again in ' + Math.ceil(st.waitMs / 1000) + 's.'
           : st && st.status === 'bad' ? 'Incorrect PIN — ' + st.remaining + ' attempt' + (st.remaining === 1 ? '' : 's') + ' left before all data is erased.'
           : st && st.status === 'wiped' ? 'Too many attempts — all data on this device was erased.'

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -8428,8 +8428,8 @@
     const trust = $('approval-trust');
     if (allow) allow.disabled = locked;
     if (trust) trust.disabled = locked;
-    const footer = allow && allow.parentNode;
-    if (footer) footer.classList.toggle('approval-locked', locked);
+    const actions = allow && allow.parentNode; // .approval-actions, not the card
+    if (actions) actions.classList.toggle('approval-locked', locked);
   }
 
   function renderApprovalAccountCapsule(data) {


### PR DESCRIPTION
Started as "the PIN scrolls away in the standalone popup" and turned into a pass over the whole approval footer, because the first fix broke something else and the underlying rule only became clear after that.

**The rule: the footer holds what you act on, the body holds what you're deciding about.** Anything interactive left in the scrolling body can end up out of reach with nothing to suggest it exists.

## What was wrong

`#unlock` sat in `.prompt-scroll` while Allow/Reject were pinned in `.prompt-footer` — whose own comment already listed the unlock field among the things it exists to keep visible. On a tall prompt the PIN scrolled away while the button demanding it stayed put. `.prompt-scroll` also masks its bottom 30px, so the field went translucent before it even left the viewport.

Worse, and only visible in the before/after renders: `#pin` carries `autofocus`, and focusing an element inside a scroll container scrolls it into view. On a tall prompt that dragged the body to the bottom, taking the **site name, the ask, and the shared-account heads-up card** off-screen — the very things that card exists to make you check.

## The commits, in the order the problem revealed itself

1. **PIN into the footer.** Fixed the reported symptom and the autofocus side effect.
2. **`#remember` and `#relax-row` too.** Pinning the PIN orphaned what sat below it — the relax chips became unreachable with nothing scrolling to reveal them. Worse than before. They never co-occur (relax for signing, budget for payments), so the footer doesn't stack them. The hairline moved to `.prompt-footer` itself since any of the three can be first visible.
3. **36px of dead space reclaimed.** 26 of it invisible: `.error` reserves `min-height: 18px` + 8px so an arriving message can't jog the layout — worth it in the body, permanent waste in a footer that has nothing below it. Collapses when empty now.
4. **PIN failures moved beside the PIN.** That slot carries "Incorrect PIN — N attempts left before all data is erased" and "all data on this device was erased", and they were rendering two controls away from the field. Three of the four writers are PIN errors; the fourth is the budget message, already correctly adjacent to the budget row — so the PIN got its own slot rather than moving the shared one. **Applied to the side panel too**, which had the same structure and the same messages.
5. **Review tidy.** Two `.prompt-footer` rules had accumulated, the second silently overriding the first's padding. And `setLocked()` called `els.allow.parentNode` "footer" — that's `.actions`, merely imprecise before and actively wrong once a real `.prompt-footer` existed.

## Checked while reviewing

- `.error:empty { display: none }` already exists in `styles.css`, so the panel's new slot adds no dead space
- `.error.unlock-danger` belongs to the lock screen, not this view — unaffected
- relax chips are hidden on destructive events (`!data.destructive`), so no gating gap opened by moving them next to the buttons
- `.approval-locked` targets buttons by id, so it works wherever the class lands
- nothing traverses these nodes by DOM position; all access is by id

## Testing

Rendered on both branches at the real popup size with a shared-host signing request, and again with a populated error to confirm the `:empty` collapse doesn't swallow real messages. Verified live through several rounds.

Worth exercising the payment prompt as well — it's the branch that shows `#remember` instead of the relax chips, and a deliberate wrong PIN on both surfaces, since the error routing changed in each.

🍷 Decanted with [Claude Code](https://claude.com/claude-code)