### PR TITLE
polish: cut the auto-zap hint from 60 words to 24

### DIFF
--- a/sidepanel.html
+++ b/sidepanel.html
@@ -319,7 +319,7 @@
 
       <div class="setting">
         <h3>Automatic zaps</h3>
-        <p class="hint">Zaps within these limits go through with no confirmation at all: Sidecar signs them, pays them, and skips its payment card. Only zaps you start in a client qualify, matched to the request Sidecar signed. Larger zaps, anything over the daily total, and every other payment still ask. Capped at 1,000 sats per zap and 10,000 a day.</p>
+        <p class="hint">Zaps under these limits go through with nothing to approve. Every other payment still asks. Capped at 1,000 sats a zap, 10,000 a day.</p>
         <label class="toggle-row"><input type="checkbox" id="autozap-toggle" /> <span>Auto-approve zaps</span></label>
         <label class="toggle-row hidden" id="autozap-max-row">
           <span>Max per zap</span>


### PR DESCRIPTION
> Zaps under these limits go through with nothing to approve. Every other payment still asks. Capped at 1,000 sats a zap, 10,000 a day.

Dropped:

- *"Sidecar signs them, pays them, and skips its payment card"* — "nothing to approve" covers all three without naming internal surfaces.
- *"matched to the request Sidecar signed"* — implementation detail; changes no decision made at that toggle.
- *"Larger zaps, anything over the daily total, and…"* — the two inputs directly above already state the limits.

The caps stay: they explain why the input snaps back if you type something bigger. Verified they match what's actually enforced — `AUTOZAP_ABS_MAX = 1000` / `AUTOZAP_ABS_DAILY_MAX = 10000` in `background.js`, mirrored in `sidepanel.js`.

One line, no logic.

🧊 Stirred with [Claude Code](https://claude.com/claude-code)