### PR TITLE
release: 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ Release practice: the latest release's highlights are also summarized in-app, in
 guide's **What's new** section (`help.html#whats-new`, linked from Settings → Updates).
 Update that section alongside this file as part of every release.
 
+## [1.6.0] — 2026-07-26
+
+### Added
+- **Zap animations.** A bolt of lightning strikes across the page whenever a payment goes out — procedurally drawn, never the same twice. It fires for zaps sent from a client's own UI as well as from Sidecar, and can be turned off in Settings.
+- **Tap the balance to change units.** The wallet balance and the pinned balance bar cycle through sats, BTC, and your local currency on tap. Pick the currency in Settings or from the wallet screen; sixteen are supported, defaulting to USD.
+- **24-hour bitcoin price chart.** A round button on the wallet card opens a gradient-filled chart of the last 24 hours against your chosen currency.
+- **A warning before an app erases your data.** Follow lists, mute lists, and profiles are *replaceable* events: a new version wholly replaces the old one, with no merge and no undo, so a buggy or careless client can wipe years of follows in a single signature. Sidecar now compares what it's being asked to sign against what it last signed for you and stops to warn you — in plain language, naming what would be lost — before an event that would erase your follows, your mutes, or fields from your profile. The approval buttons stay disabled until you acknowledge it, a timed relax window can't wave it through, and the check is entirely local, so it costs no network time.
+- **Auto-zap now covers the whole zap.** Previously it never fired at all: it looked for the zap request inside the invoice's description, but NIP-57 issues description-*hash* invoices, so that field is empty on every spec-compliant zap. Sidecar now matches the payment against the zap request it signed for you moments earlier — same site, same account, same amount — and, when the amount is within your limits, signs and pays without a prompt or a payment card. Capped at 1,000 sats per zap and 10,000 per day, enforced whatever you type into the settings.
+- **Refresh your profile from the Profile screen** — the circular arrow now actually re-fetches, for when a change made elsewhere hasn't reached Sidecar yet.
+
+### Fixed
+- **Notes could be signed, reported as posted, and published nowhere.** Two faults compounded: Sidecar published only to the write relays declared in your relay list, so if those lapsed or gated on a web of trust the note had nowhere else to go; and a relay that couldn't be reached was being counted as a successful publish, so no error was ever raised. Posts now go to those relays *and* the ones configured in Settings, and an unreachable relay is reported as the failure it is, naming each relay and why. The same faults affected profile edits, relay-list updates, and follow lists.
+- **Payments could succeed while the page was told they failed** — or left waiting up to three minutes. Approving a payment cancelled the keepalive at the moment the money moved, and a lost confirmation from the wallet was being read as a failed payment. Sidecar now holds itself awake for the whole payment and asks the wallet what actually happened rather than inferring it from silence, so the answer arrives in seconds and is the truth.
+- **The approval popup no longer hides the PIN field, the auto-sign options, or the site asking.** On a long request the PIN scrolled out of view beneath the button demanding it — and because the field takes focus automatically, the popup opened scrolled to the bottom, pushing the site name and the multiple-accounts warning off-screen. Everything you act on now sits below the fold line, and a wrong-PIN message appears against the PIN field instead of down beside the buttons.
+- **Outgoing payment toasts name the amount** instead of a bare "Payment sent".
+- **Repeated actions no longer stack duplicate toasts.**
+- **Firefox Add-ons links point at the real listing.** (#133)
+
+### Changed
+- The help guide documents relax mode and the new data-erasure warning, with screenshots.
+
 ## [1.5.1] — 2026-07-24
 
 ### Added

--- a/help.html
+++ b/help.html
@@ -345,6 +345,17 @@
          linked below. -->
     <section class="guide-section" id="whats-new">
       <h2>What's new</h2>
+      <p class="whatsnew-version">Version 1.6.0</p>
+      <ul class="whatsnew-list">
+        <li><strong>A warning before an app erases your data.</strong> Your follow list, mute list, and profile are stored as events that <em>replace</em> the previous version outright — there's no merge and no undo, so one careless app can wipe years of follows in a single signature. Sidecar now checks what it's being asked to sign against what it last signed for you, and stops to tell you in plain language what would be lost. You have to acknowledge the warning before the approval buttons unlock, and a timed auto-sign window can't wave it through.</li>
+        <li><strong>Zaps strike.</strong> A bolt of lightning crosses the page whenever a payment goes out, drawn fresh every time. Turn it off in Settings if you'd rather not.</li>
+        <li><strong>Tap your balance to change units.</strong> Cycle between sats, BTC, and your local currency — on the wallet card and the pinned balance bar. Sixteen currencies, set in Settings or on the wallet screen.</li>
+        <li><strong>A 24-hour price chart</strong> on the wallet card, in whichever currency you've chosen.</li>
+        <li><strong>Auto-approve zaps actually works now</strong> — it never fired before. Zaps within your limits go through with nothing to approve, capped at 1,000 sats a zap and 10,000 a day.</li>
+        <li><strong>Notes now reach your relays.</strong> A note could be signed, reported as posted, and stored nowhere, with no error shown. Sidecar publishes more widely and tells you plainly when a relay refuses.</li>
+        <li><strong>Payments report the truth.</strong> A payment that succeeded could be reported as failed, or leave the page waiting. Sidecar now asks your wallet what happened instead of guessing from silence.</li>
+        <li><strong>A clearer approval popup.</strong> The PIN field, the auto-sign options, and the name of the site asking all stay in view on a long request.</li>
+      </ul>
       <p class="whatsnew-version">Version 1.5.1</p>
       <ul class="whatsnew-list">
         <li><strong>Relax mode.</strong> Grant a timed auto-sign window — 5, 15, or 30 minutes — so you don't have to approve every action during an active session on a site you trust. A persistent status bar counts down the remaining time; tap End to revoke early.</li>
@@ -356,13 +367,6 @@
         <li><strong>Sidecar is now on Firefox.</strong> The full signer — multi-account, NIP-07, the Lightning wallet, and the approval flow — runs on Firefox 128 and later, at parity with Chrome. On Firefox it lives in the sidebar; install it from Firefox Add-ons.</li>
         <li><strong>Three themes to choose from.</strong> A new picker in Settings offers Speakeasy (the original velvet), Film Noir (matte black with silver accents), and Art Deco (a daylight eggshell-and-bronze look). Your pick sticks, and the on-page "Pay with Sidecar" card follows it too.</li>
         <li><strong>Toasts moved to the bottom</strong> of the panel, so a confirmation no longer sits over the account switcher and toolbar.</li>
-      </ul>
-      <p class="whatsnew-version">Version 1.4.1</p>
-      <ul class="whatsnew-list">
-        <li><strong>Auto-lock, smoothed out.</strong> When the idle timer fires, the panel drops straight to the unlock screen with a "Locked due to inactivity" notice, instead of only surfacing the lock on your next action. Composing counts as activity so it won't lock mid-draft — and unlocking straight from a key reveal or export now flows through in one step.</li>
-        <li><strong>Stronger PIN protection.</strong> The unlock screen's brute-force guard — escalating delays between wrong tries and the final-strike wipe — now covers every PIN prompt, including key reveals and exports.</li>
-        <li><strong>More apps to explore.</strong> Eight new apps in the directory — Flotilla, Tunestr, Wavlake, WaveFunc Radio, Boost Me Bitch, Cordn, Imwald, and ContextVM — now also browsable on the web at sidecar.top/apps.</li>
-        <li><strong>A lighter quoted-note icon</strong> in notifications, easier to see on the dark panel.</li>
       </ul>
       <p>The full history, including earlier releases, is in the
       <a href="https://github.com/dmnyc/sidecar/blob/main/CHANGELOG.md" target="_blank" rel="noreferrer noopener" id="changelog-link">changelog on GitHub</a>.</p>

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Sidecar | A Classy Nostr Signer",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "minimum_chrome_version": "114",
   "description": "A multi-account NIP-07 Nostr signer with a built-in Lightning wallet, in your browser sidebar.",
   "permissions": [


### PR DESCRIPTION
Version bump, changelog, and in-app What's New. No code changes — everything shipping already merged via #137, #139, #144, #145, #146 and the wallet/zap work.

Per the publish checklist this merges **before** anything is packaged: no zip built from content that isn't documented on `main` yet.

## Shipping in 1.6.0

**Features** — the data-erasure warning for follow lists, mute lists and profiles; the lightning-strike zap animation; sats/BTC/fiat balance toggle across sixteen currencies; the 24-hour price chart; auto-zap working for the first time (hard-capped at 1,000/zap, 10,000/day); a real profile refresh.

**Fixes with teeth** — notes could be signed, reported as posted, and stored on no relay; payments could succeed while the page was told they failed; the approval popup hid the PIN field and the name of the site asking.

## Release state

- **AMO** is public on 1.5.1 — Firefox is clear to go.
- **Chrome** still has 1.5.1 in review, so 1.6.0 can't be submitted there yet. Confirmed with Daniel. The GitHub release and AMO upload aren't gated on that; the Nostr announcement is.

## Parity checks run

- `zap-requests.js` is in `manifest.background.scripts`, so the Firefox event page loads it (Chrome gets it via `importScripts`)
- `chrome.storage.session` — Firefox 115+, minimum here is 128
- `chrome.runtime.getPlatformInfo` — supported on both
- no service-worker-only APIs (`skipWaiting`, `clients.claim`) introduced
- no hardcoded extension origins outside comments
- 71 tests pass

**Not yet done: the Firefox smoke test** from `BROWSER_PARITY.md`. Everything this cycle was exercised on Chrome. Since Firefox ships first this time and AMO locks a version string permanently, that test is worth running before upload.

🍾 Uncorked with [Claude Code](https://claude.com/claude-code)