### PR TITLE
fix: close the payment modal Sidecar just paid out from under

### DIFF
--- a/background.js
+++ b/background.js
@@ -1438,8 +1438,8 @@ async function tryZapAutopay(invoiceRaw, host, originWindowId, tabId) {
   // has somewhere to be reported instead of vanishing.
   notifyTabAutopaying(tabId, inv);
   try {
-    await payInvoiceCore(inv, host, who, undefined, originWindowId);
-    notifyTabPaid(tabId, inv);
+    const r = await payInvoiceCore(inv, host, who, undefined, originWindowId);
+    notifyTabPaid(tabId, inv, r && r.preimage);
     return { handled: true, paid: true };
   } catch (e) {
     // Still handled: the auto card is up and is where this error belongs. Replacing it
@@ -1717,9 +1717,16 @@ function notifyTabAutopaying(tabId, invoice) {
   }
 }
 
-function notifyTabPaid(tabId, invoice) {
+// `preimage` is what proves the payment to the page. Bitcoin Connect clients hand it
+// to their onPaid callback, so the content script needs it to close a modal that has
+// no other way of learning the invoice settled — see the bridge in nostr-provider.js.
+function notifyTabPaid(tabId, invoice, preimage) {
   if (tabId != null && chrome.tabs) {
-    chrome.tabs.sendMessage(tabId, { type: 'SIDECAR_EVENT', event: 'paid', invoice }, () => void chrome.runtime.lastError);
+    chrome.tabs.sendMessage(
+      tabId,
+      { type: 'SIDECAR_EVENT', event: 'paid', invoice, preimage: String(preimage || '') },
+      () => void chrome.runtime.lastError
+    );
   }
 }
 
@@ -1817,7 +1824,7 @@ chrome.contextMenus &&
         .then((inv) => payFromPage(inv, host, originWindowId).then((r) => ({ r, inv })))
         .then(({ r, inv }) => {
           notify(r.sats != null ? 'Payment sent — ' + r.sats.toLocaleString('en-US') + ' sats' : 'Payment sent');
-          notifyTabPaid(tab && tab.id, inv);
+          notifyTabPaid(tab && tab.id, inv, r.preimage);
         })
         .catch((e) => notify((e && e.message) || 'Payment failed'));
 
@@ -2473,7 +2480,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     payFromPage(message.invoice, host, originWindowId)
       .then((r) => {
         notify(r.sats != null ? 'Payment sent — ' + r.sats.toLocaleString('en-US') + ' sats' : 'Payment sent');
-        notifyTabPaid(tabId, message.invoice);
+        notifyTabPaid(tabId, message.invoice, r.preimage);
       })
       .catch((e) => {
         const m = (e && e.message) || 'Payment failed';

--- a/content.js
+++ b/content.js
@@ -760,6 +760,17 @@
       if (msg.invoice) renderCard(msg.invoice, true);
     } else if (msg.event === 'paid') {
       dismissedInvoice = msg.invoice; // don't resurface even if the link lingers
+      // Tell the page's payment modal, if it has one, that this invoice settled. We
+      // paid it entirely outside the page — scraped from the DOM, sent over NWC — so
+      // a Bitcoin Connect modal is otherwise left spinning on an invoice that is
+      // already paid. Handed to the MAIN world (nostr-provider.js) because the event
+      // detail has to be built in the page's own realm for its listeners to read it.
+      try {
+        window.postMessage(
+          { ext: 'sidecar', kind: 'settled', invoice: msg.invoice, preimage: msg.preimage || '' },
+          '*'
+        );
+      } catch (_) {}
       // Throw the bolt across the page whether or not our own card was up — a zap
       // sent from the client's own UI has no card, and that's the common case.
       pageLightningStrike();

--- a/nostr-provider.js
+++ b/nostr-provider.js
@@ -49,6 +49,46 @@
     else p.reject(new Error((r && r.error) || 'Sidecar request failed'));
   });
 
+  // ---- Bitcoin Connect settlement bridge ----
+  // A zap paid from Sidecar's card settles with the page none the wiser: the invoice
+  // was read out of the DOM and paid over NWC, so Bitcoin Connect — which only hears
+  // about payments its own connectors make — leaves the modal spinning on an invoice
+  // that is already settled. Its own launchPaymentModal listens for 'bc:onpaid' on
+  // window, and its setPaid() does exactly the two things below, so replaying them
+  // resolves the client's pending promise and closes the modal.
+  //
+  // These are internals, not published API. If they change this quietly stops working
+  // and the modal spins as it does today — the failure mode is the status quo, never
+  // something worse. Nothing here is a capability the page lacks: any script on the
+  // page can dispatch this event itself.
+  window.addEventListener('message', function (event) {
+    if (event.source !== window) return;
+    const d = event.data;
+    if (!d || d.ext !== 'sidecar' || d.kind !== 'settled') return;
+    try {
+      // No modal, no work — this is a no-op on pages that don't use Bitcoin Connect.
+      const el = document.querySelector('bc-payment');
+      if (!el) return;
+      // Only ever claim the invoice the modal is actually showing, and require the
+      // match — an unverifiable modal is left alone rather than told a payment
+      // settled. Accepting a missing `invoice` attribute as "close enough" would let
+      // a modal for one invoice be resolved by a payment for another, and a false
+      // "paid" is the one direction a payment UI must not fail in. If a future
+      // Bitcoin Connect stops putting the bolt11 here, this stops firing and the
+      // modal spins as it does today.
+      const shown = (el.getAttribute('invoice') || '').toLowerCase();
+      if (!shown || shown !== String(d.invoice || '').toLowerCase()) return;
+      el.setAttribute('paid', 'paid'); // drives Bitcoin Connect's own success state
+      el.dispatchEvent(
+        new CustomEvent('bc:onpaid', {
+          bubbles: true,
+          composed: true,
+          detail: { preimage: String(d.preimage || '') },
+        })
+      );
+    } catch (_) {}
+  });
+
   // ---- window.nostr (NIP-07) ----
   const nostr = {
     getPublicKey: () => call('nostr', 'getPublicKey'),

--- a/test/MANUAL-bitcoin-connect-bridge.md
+++ b/test/MANUAL-bitcoin-connect-bridge.md
@@ -1,0 +1,67 @@
+# Manual verification — Bitcoin Connect settlement bridge
+
+The bridge in `nostr-provider.js` closes a payment modal that Sidecar paid from
+outside the page. It works by replaying what Bitcoin Connect's own `setPaid()`
+does, and **that is an internal detail of the library, not published API**. If
+Alby renames the event or restructures the element, the bridge silently stops
+firing and the modal goes back to spinning — the same place it is without the
+bridge, so nothing breaks, but nothing helps either. Re-check this after a
+Bitcoin Connect version bump on any client you care about.
+
+## What the bridge depends on
+
+From `@getalby/bitcoin-connect@3.12.3`, `launchPaymentModal` deminified:
+
+```js
+window.addEventListener("bc:onpaid", (e) => { paid = true; onPaid?.(e.detail); });
+...
+return { setPaid: (detail) => {
+  payment.setAttribute("paid", "paid");
+  payment.dispatchEvent(new CustomEvent("bc:onpaid", {bubbles:true, composed:true, detail}));
+}};
+```
+
+Three things must stay true:
+1. The listener is on `window`, for the event name `bc:onpaid`.
+2. The invoice element is `<bc-payment>` with the bolt11 in an `invoice` attribute.
+3. `onPaid` receives the event `detail`, and reads `preimage` off it.
+
+**Point 2 is load-bearing twice over.** The bridge requires an exact match between
+the `invoice` attribute and the invoice Sidecar paid — a modal it cannot verify is
+left alone rather than told a payment settled, since a false "paid" is the one
+direction a payment UI must not fail in. So if the bolt11 ever moves off that
+attribute, the bridge stops firing entirely rather than resolving the wrong modal.
+
+**Unverified assumption — check this first.** `document.querySelector('bc-payment')`
+does not reach inside a shadow root. If Bitcoin Connect renders the modal within one,
+the bridge silently does nothing and the console check below is what will tell you.
+
+## Reproduce end to end
+
+1. Connect a wallet in Sidecar (NWC) and sign into a Bitcoin Connect client —
+   jumble.social is the reference case. Do **not** connect a wallet inside the
+   client's own Bitcoin Connect modal; the bridge is only for the path where the
+   client has no provider and falls back to showing a QR.
+2. Zap a note. The client puts up the Bitcoin Connect modal with a QR.
+3. Sidecar's "Pay with Sidecar" card appears over it. Pay.
+
+**Expected:** the card flashes Paid, and the Bitcoin Connect modal underneath
+closes on its own instead of spinning on an invoice that already settled.
+
+**Without the bridge:** the card says Paid, the lightning strike fires, and the
+modal is still sitting there showing the QR.
+
+## Checking the mechanism without a wallet
+
+The dependencies above can be checked directly, no payment needed. With a
+Bitcoin Connect modal open on any page, run in the page console:
+
+```js
+const el = document.querySelector('bc-payment');
+el.setAttribute('paid', 'paid');
+el.dispatchEvent(new CustomEvent('bc:onpaid',
+  { bubbles: true, composed: true, detail: { preimage: 'deadbeef' } }));
+```
+
+If the modal resolves, the bridge's assumptions still hold. If it doesn't,
+compare the current bundle against the three points above.


### PR DESCRIPTION
Closes #143. Confirmed working three times in a row on jumble.social.

## The problem

A zap paid from Sidecar's card settles with the page none the wiser. The invoice was read out of the DOM and paid over NWC, so Bitcoin Connect — which only hears about payments its own connectors make — leaves the modal spinning on an invoice that already settled.

## The bridge

Replays what Bitcoin Connect's own `setPaid()` does: sets `paid=paid` on `<bc-payment>` and dispatches `bc:onpaid` with the preimage, which resolves the client's pending promise and closes the modal. The preimage now travels with the `paid` event for that purpose.

Dispatched from `nostr-provider.js` in the **MAIN world**, not the content script — a `CustomEvent` detail built in the isolated world can't be read by the page's own listeners.

**Scoped to out-of-band payments only.** It rides the `paid` event, which the card, auto-zap and context-menu paths send — never `paidflash`, the WebLN path, where the page already learns from its own resolved promise.

## Requires an exact invoice match

A modal it cannot verify is left alone rather than told a payment settled. Accepting a missing `invoice` attribute as close enough would let one invoice's modal be resolved by another's payment, and a false "paid" is the one direction a payment UI must not fail in.

Verified across six cases: a matching invoice fires (case-insensitively); a different invoice, a missing `invoice` attribute, no `bc-payment` element, and an empty invoice in the message all leave the modal alone.

## Depending on library internals

`bc:onpaid` and the `<bc-payment>` element are internals, not published API. If they change this stops firing and the modal spins as it does today — **the failure mode is the status quo, never something worse.** Nothing here is a capability the page lacks either: any script on the page can dispatch that event itself.

`test/MANUAL-bitcoin-connect-bridge.md` records the three assumptions with the deminified `launchPaymentModal` source they rest on, plus a console check that verifies them without needing a payment. Worth re-running after a Bitcoin Connect version bump. `test/` is stripped from the package, so the doc doesn't ship.

One assumption is called out as unverified in that doc: `document.querySelector('bc-payment')` doesn't reach inside a shadow root. It evidently isn't one on jumble.social, but another client could differ, and the failure would be silent.

🍸 Stirred with [Claude Code](https://claude.com/claude-code)
