### PR TITLE
feat: quick-start a Lightning wallet with Rizful

### DIFF
--- a/WALLET_BACKENDS.md
+++ b/WALLET_BACKENDS.md
@@ -1,7 +1,8 @@
 # Wallet backends — what Sidecar uses, and what it ruled out
 
 Sidecar's Lightning wallet talks **NWC (NIP-47)** to a wallet you already control.
-Sidecar never holds funds and never runs a node.
+Sidecar never holds funds and never runs a node. For users who don't have a wallet
+yet, the Rizful quick start (below) obtains an NWC connection without a paste.
 
 This file records the alternatives that were evaluated and rejected, and why. It
 exists so the question doesn't get re-opened from scratch every few months — and so
@@ -108,10 +109,77 @@ Held for now because the specification is an
 and wallet-side support is limited. Cheap to add alongside NWC if it gains traction;
 expensive to have shipped early if it doesn't.
 
-### Making NWC connection easier
+## Bitcoin Connect — nothing to add, on either side
 
-The problem worth solving is not that NWC is bad — it's that a user with no Lightning
-wallet at all has a hard first five minutes. An app-initiated connection handshake
-(Sidecar generates a keypair, the user approves in their wallet, the connection string
-returns without copy-paste) would be a large onboarding win for a fraction of the cost
-of embedding a wallet, and costs neither an API key nor Firefox support.
+[`@getalby/bitcoin-connect`](https://www.npmjs.com/package/@getalby/bitcoin-connect)
+is a connect-a-wallet UI for web apps, not a wallet backend. It comes up anyway, so
+both directions are recorded here.
+
+**As something pages use to reach Sidecar: already works, nothing to do.** Bitcoin
+Connect registers its extension connector as `extension.generic`, labeled "Browser
+Extensions" — generic, not Alby-specific — and it picks up any `window.webln`, which
+Sidecar provides. Sidecar also already carries a settlement bridge for it
+(`nostr-provider.js`, the "Bitcoin Connect settlement bridge" block): a zap paid from
+Sidecar's own card would otherwise leave the page's modal spinning on an invoice that
+had already settled.
+
+One thing worth knowing for support: users on a Bitcoin Connect page click **"Browser
+Extensions"**, not "Sidecar." That is Bitcoin Connect's copy, not something this side
+can change.
+
+**As a connect option inside Sidecar: no case for it.** Its connector list is Alby
+Hub, Browser Extensions, NWC, Coinos, LNbits, LNbits NWC Plugin, Cashu.me. Against
+that:
+
+- The connectors largely duplicate what exists. "NWC" is paste-a-connection-string.
+  Alby Hub, Coinos and LNbits are provider flows that all terminate in an NWC string —
+  which is exactly what the Rizful quick start below does, at no dependency cost.
+- "Browser Extensions" is incoherent here. It means consuming another extension's
+  `window.webln`. Sidecar *is* a WebLN provider, and the side panel has no page
+  `window.webln` to consume in any case.
+- 263 KB for the UMD bundle — about 14% on top of the entire shipped package — plus
+  five transitive dependencies including `@getalby/sdk` and `@lightninglabs/lnc-web`.
+  Sidecar's NWC client is ~150 hand-rolled lines with zero dependencies; this would
+  import an SDK to redo it.
+- It is a Lit web-component UI with its own theming, and would match none of the five
+  themes.
+- `VENDOR.md` promises byte-exact provenance with CI-pinned hashes so that "no trust
+  in this repo is required." A 263 KB third-party UI bundle with five dependencies is
+  a large surface to stand behind in a signer, for a connect dialog.
+
+**The one case that would justify it** is breadth of connectors without writing each
+flow — particularly LND-direct over LNC, which Bitcoin Connect supports and Sidecar
+would otherwise never build. That is a question about who the users are, not about
+architecture.
+
+## What shipped instead: the Rizful quick start
+
+The problem was never that NWC is bad — it's that a user with **no** Lightning wallet
+has a hard first five minutes. That is now solved without a backend change at all.
+
+Rizful publishes a token exchange (the same one Jumble uses): the user creates an
+account, gets a one-time code, and Sidecar trades it for a standard NWC connection
+string, which then goes through the same `SIDECAR_SET_NWC` path as a hand-pasted one
+and is validated by the same `getInfo` round-trip first.
+
+Why this beats every embedded-wallet option evaluated above:
+
+- **No API key, no WASM, no offscreen document**, so it works identically on Firefox —
+  which is where Breez Spark failed outright.
+- **No new dependency.** One `fetch` and a text field.
+- **It completes the loop.** The exchange returns a lightning address (or one rides in
+  the NWC string's `lud16`), which the Profile screen's existing `maybeSuggestLud16`
+  prompt offers to publish. That is what makes a brand-new wallet reachable by zaps,
+  and it was already built — the gap was only ever *acquiring the string*.
+- **The pattern generalizes.** A second provider is a few dozen lines against the same
+  UI, so this is not a single-vendor lock-in.
+
+The trade-off is stated in the UI rather than hidden: Rizful is custodial, run by
+[Megalith](https://megalithic.me/), and the modal says they hold the funds and that a
+self-custodial wallet can replace it later. Sidecar still holds nothing.
+
+A fully app-initiated handshake — Sidecar generates a keypair, the user approves in
+their wallet, no copy-paste at all — remains the ideal, and is what Damus appears to
+have with Coinos. It needs provider-side support that isn't in Coinos's public API
+([open feature request](https://github.com/coinos/coinos-server/issues/74)), so the
+code exchange is the best available today.

--- a/WALLET_BACKENDS.md
+++ b/WALLET_BACKENDS.md
@@ -1,0 +1,117 @@
+# Wallet backends — what Sidecar uses, and what it ruled out
+
+Sidecar's Lightning wallet talks **NWC (NIP-47)** to a wallet you already control.
+Sidecar never holds funds and never runs a node.
+
+This file records the alternatives that were evaluated and rejected, and why. It
+exists so the question doesn't get re-opened from scratch every few months — and so
+that anyone proposing a change knows which walls are already mapped.
+
+## The constraint that decides most of it
+
+**A Lightning address is a hosted service.** Receiving `you@example.com` requires
+something awake at a domain, serving `/.well-known/lnurlp/you` and answering a
+callback with a fresh invoice whenever a stranger decides to pay you
+([LUD-16](https://github.com/lnurl/luds/blob/luds/16.md)).
+
+A browser extension is not reachable at a domain and is not running when the browser
+is closed. It therefore cannot be its own Lightning address, no matter which SDK is
+embedded in it.
+
+That matters more on Nostr than elsewhere, because
+[NIP-57](https://github.com/nostr-protocol/nips/blob/master/57.md) zaps resolve
+through the `lud16` field on your profile. **No `lud16`, no zap button** — not a
+failed zap, but no button at all, in every major client.
+
+Which produces the trade-off table:
+
+| Backend | Needs an API key | Provides a Lightning address |
+|---|---|---|
+| **NWC (current)** | no | yes — inherited from your wallet |
+| Breez SDK Spark | **yes** | yes, via Breez infrastructure |
+| Cashu / NIP-60 | no | **no, and cannot** |
+
+You can have "no API key" or "a built-in Lightning address," but not both, unless you
+run the server yourself. An API key is largely what you pay for someone else running
+that infrastructure.
+
+## Evaluated and rejected
+
+### Breez SDK Spark — rejected on size, keys, and Firefox
+
+[`@breeztech/breez-sdk-spark`](https://www.npmjs.com/package/@breeztech/breez-sdk-spark)
+is a genuinely capable embedded wallet, and the architecture is well understood: the
+SDK has to live in an **offscreen document** that owns the WASM and IndexedDB, with
+the service worker relaying RPC to the side panel. It is not viable here for four
+reasons, in order of severity:
+
+1. **Firefox has no `chrome.offscreen` API.** Sidecar ships Chrome and Firefox from
+   one codebase (see `BROWSER_PARITY.md`). A Chrome-only wallet backend is a fork of
+   the product, not a feature of it.
+2. **11 MB of WASM.** Sidecar's entire signed package is under 2 MB. This is roughly a
+   6.5× increase for one optional feature.
+3. **A required API key.** The key is a Breez *partner* credential — it cannot spend
+   or read balances, so a leak is a quota/ToS problem rather than a theft one. But
+   this repo is public and the extension runs entirely on the user's machine, so the
+   key would have to be injected at package time and would still be extractable from
+   any install. That is a commercial dependency that can be revoked, on a feature
+   users' money depends on.
+4. **It requires `'wasm-unsafe-eval'` in the extension CSP**, on a signer whose
+   listing says everything runs locally with no remote code. Still true, but it
+   invites a review conversation on every submission.
+
+### Cashu / NIP-60 — rejected because it cannot receive zaps
+
+[NIP-60](https://github.com/nostr-protocol/nips/blob/master/60.md) (Cashu wallets with
+state on relays) is an excellent fit on paper: no API key, no WASM, no server, and its
+stated purpose is that "new users immediately are able to receive funds without
+creating accounts with other services." Wallet state follows the user across apps.
+
+It was rejected because **a NIP-60 wallet has no `lud16`, so it cannot receive
+ordinary zaps** — see the constraint above. Inbound payments would work only via
+[NIP-61](https://github.com/nostr-protocol/nips/blob/master/61.md) nutzaps, which are
+supported by a small minority of clients. For a wallet that lives inside a Nostr
+signer, being unable to participate in the main way money moves on Nostr is
+disqualifying.
+
+Two secondary findings, recorded because they are easy to miss:
+
+- **`nsec` becomes a bearer instrument for the wallet.** NIP-60 keeps the wallet's
+  spending key separate from the Nostr key, but stores it encrypted *to* the Nostr
+  key so wallet state can follow the user. Anyone holding the `nsec` can therefore
+  decrypt it and spend. This is inherent to the design, not a flaw in it — but it
+  sits badly with a signer whose purpose is protecting that key.
+- **`@cashu/cashu-ts` ships no browser bundle** (no `browser`, `unpkg` or `main`
+  field; four dependencies; ~1.5 MB unpacked). Vendoring it would require a local
+  build rather than a byte-exact copy of a published artifact, which is a weaker
+  provenance guarantee than every other bundle in `VENDOR.md`.
+
+## Still open
+
+### CLINK — worth watching, too early to adopt
+
+[CLINK](https://clinkme.dev/) (Common Lightning Interface for Nostr Keys, by ShockNet)
+defines Nostr-native Lightning offers (`noffer`) and debits (`ndebit`), with
+NIP-05 → offer discovery. It is the most interesting alternative found, because it
+addresses discovery and connection over Nostr rather than over HTTPS, and
+[`@shocknet/clink-sdk`](https://www.npmjs.com/package/@shocknet/clink-sdk) is 85 KB
+with dependencies Sidecar already vendors (`nostr-tools`, `@scure/base`,
+`@noble/hashes`).
+
+It does **not** remove the always-on requirement — something still has to answer a
+`noffer` request with a fresh invoice — so it is an alternative to *NWC*, not a way
+for the extension to become its own wallet. Its appeal is onboarding: connecting by
+Nostr identity rather than by pasting a connection string.
+
+Held for now because the specification is an
+[open PR](https://github.com/nostr-protocol/nips/pull/1529) rather than a merged NIP,
+and wallet-side support is limited. Cheap to add alongside NWC if it gains traction;
+expensive to have shipped early if it doesn't.
+
+### Making NWC connection easier
+
+The problem worth solving is not that NWC is bad — it's that a user with no Lightning
+wallet at all has a hard first five minutes. An app-initiated connection handshake
+(Sidecar generates a keypair, the user approves in their wallet, the connection string
+returns without copy-paste) would be a large onboarding win for a fraction of the cost
+of embedding a wallet, and costs neither an API key nor Firefox support.

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -45,7 +45,8 @@ git archive "${TAG}" | tar -x -C "${STAGE}"
 rm -rf "${STAGE}/.claude" "${STAGE}/.github" "${STAGE}/scripts" "${STAGE}/assets" "${STAGE}/test"
 rm -f "${STAGE}/.gitignore" "${STAGE}/README.md" "${STAGE}/CHANGELOG.md" \
       "${STAGE}/FEATURES.md" "${STAGE}/PRIVACY.md" "${STAGE}/BROWSER_PARITY.md" \
-      "${STAGE}/FIREFOX_PORT.md" "${STAGE}/VENDOR.md" "${STAGE}/package.json"
+      "${STAGE}/FIREFOX_PORT.md" "${STAGE}/VENDOR.md" "${STAGE}/WALLET_BACKENDS.md" \
+      "${STAGE}/package.json"
 
 # version.js is gitignored and not in the archive — regenerate it, stamped to the tag.
 cat > "${STAGE}/version.js" <<EOF

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -7162,6 +7162,18 @@
       const cancel = h('button', { className: 'ghost', textContent: 'Cancel' });
       cancel.addEventListener('click', closeModal);
 
+      // Who actually runs the wallet belongs next to the custodial warning, not
+      // buried: the user is being asked to trust an operator with funds, so name the
+      // operator and make it verifiable.
+      const runBy = h('p', { className: 'hint compact' });
+      runBy.append(document.createTextNode('Rizful is run by '));
+      const megalith = h('a', { href: '#', className: 'explore-link inline', textContent: 'Megalith' });
+      megalith.addEventListener('click', (e) => {
+        e.preventDefault();
+        chrome.tabs.create({ url: 'https://megalithic.me/' });
+      });
+      runBy.append(megalith, document.createTextNode('.'));
+
       modal.append(
         h('h3', { textContent: 'Start with a Rizful wallet' }),
         h('p', {
@@ -7171,6 +7183,7 @@
             + 'It is the quickest way to start receiving zaps, and you can connect a self-custodial '
             + 'wallet later instead.',
         }),
+        runBy,
         step(1, 'Create a Rizful account (skip if you have one)', 'Sign up', RIZFUL_SIGNUP_URL),
         step(2, 'Get your one-time code', 'Get code', RIZFUL_GET_CODE_URL),
         step(3, 'Paste it here'),

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -7119,20 +7119,6 @@
       });
       const go = h('button', { className: 'primary', textContent: 'Connect wallet' });
 
-      const step = (n, label, btnText, url) => {
-        const row = h('div', { className: 'rizful-step' });
-        row.append(h('span', { className: 'rizful-step-n', textContent: String(n) }));
-        const body = h('div', { className: 'rizful-step-body' });
-        body.append(h('div', { className: 'rizful-step-label', textContent: label }));
-        if (btnText) {
-          const b = h('button', { className: 'secondary rizful-step-btn', textContent: btnText });
-          b.addEventListener('click', () => chrome.tabs.create({ url }));
-          body.append(b);
-        }
-        row.append(body);
-        return row;
-      };
-
       go.addEventListener('click', async () => {
         const value = code.value.trim();
         if (!value) return (err.textContent = 'Paste the code from Rizful.');
@@ -7162,34 +7148,46 @@
       const cancel = h('button', { className: 'ghost', textContent: 'Cancel' });
       cancel.addEventListener('click', closeModal);
 
-      // Who actually runs the wallet belongs next to the custodial warning, not
-      // buried: the user is being asked to trust an operator with funds, so name the
-      // operator and make it verifiable.
-      const runBy = h('p', { className: 'hint compact' });
-      runBy.append(document.createTextNode('Rizful is run by '));
+      // One action, one field, one footnote — in that order.
+      //
+      // The first pass was a numbered three-step list with its own button inside each
+      // step, above a paragraph of custodial disclosure. It read as a form to fill in
+      // rather than two things to do, and the disclosure gated the actions behind five
+      // lines of small print. Both steps 1 and 2 happen on Rizful's site anyway, so
+      // they collapse into one button; step 3 was just restating the input's own
+      // placeholder.
+      const getCode = h('button', { className: 'secondary rizful-get', textContent: 'Get a code from Rizful' });
+      getCode.addEventListener('click', () => chrome.tabs.create({ url: RIZFUL_GET_CODE_URL }));
+
+      const signup = h('button', { className: 'rizful-signup', textContent: 'New to Rizful? Create an account' });
+      signup.addEventListener('click', () => chrome.tabs.create({ url: RIZFUL_SIGNUP_URL }));
+
+      // Custody still gets said plainly, but as a closing note rather than a wall the
+      // user has to read past. "Hosted" is in the line above, which is the word that
+      // actually carries the warning.
+      const note = h('p', { className: 'rizful-note' });
+      note.append(document.createTextNode('Run by '));
       const megalith = h('a', { href: '#', className: 'explore-link inline', textContent: 'Megalith' });
       megalith.addEventListener('click', (e) => {
         e.preventDefault();
         chrome.tabs.create({ url: 'https://megalithic.me/' });
       });
-      runBy.append(megalith, document.createTextNode('.'));
+      note.append(
+        megalith,
+        document.createTextNode('. They hold the funds, not Sidecar — you can switch to a self-custodial wallet later.')
+      );
+
+      const actions = h('div', { className: 'actions setup-actions' }, [cancel, go]);
 
       modal.append(
-        h('h3', { textContent: 'Start with a Rizful wallet' }),
-        h('p', {
-          className: 'hint',
-          textContent:
-            'Rizful is a hosted Lightning wallet — they hold the funds, not you and not Sidecar. '
-            + 'It is the quickest way to start receiving zaps, and you can connect a self-custodial '
-            + 'wallet later instead.',
-        }),
-        runBy,
-        step(1, 'Create a Rizful account (skip if you have one)', 'Sign up', RIZFUL_SIGNUP_URL),
-        step(2, 'Get your one-time code', 'Get code', RIZFUL_GET_CODE_URL),
-        step(3, 'Paste it here'),
+        h('h3', { textContent: 'Start with Rizful' }),
+        h('p', { className: 'rizful-lede', textContent: 'A hosted Lightning wallet, ready in about a minute.' }),
+        getCode,
+        signup,
         code,
         err,
-        h('div', { className: 'actions' }, [cancel, go])
+        actions,
+        note
       );
       setTimeout(() => code.focus(), 50);
     });

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -7196,20 +7196,6 @@
   function renderWalletConnect(view) {
     view.append(h('h2', { textContent: 'Wallet' }));
 
-    // Quick start goes FIRST: this screen only renders when no wallet is connected,
-    // so "I don't have one" is the common case, not the edge case.
-    const quick = h('div', { className: 'wallet-quickstart' });
-    quick.append(h('div', { className: 'wallet-quickstart-title', textContent: 'New to Lightning?' }));
-    quick.append(h('p', {
-      className: 'hint compact',
-      textContent: 'Set up a hosted wallet with Rizful in about a minute, and start receiving zaps.',
-    }));
-    const quickBtn = h('button', { className: 'primary', textContent: 'Quick start with Rizful' });
-    quickBtn.addEventListener('click', rizfulQuickStartModal);
-    quick.append(quickBtn);
-    view.append(quick);
-    view.append(h('div', { className: 'wallet-or', textContent: 'or' }));
-
     view.append(
       h('p', {
         className: 'hint',
@@ -7228,7 +7214,7 @@
       document.createTextNode("— it doesn't support external apps like Sidecar."),
       document.createElement('br')
     );
-    const primalLink = h('a', { href: '#', className: 'explore-link', textContent: 'Need a wallet? See suggestions →' });
+    const primalLink = h('a', { href: '#', className: 'explore-link', textContent: 'More Lightning wallet options →' });
     primalLink.addEventListener('click', (e) => {
       e.preventDefault();
       openExtensionPage('wallets.html');
@@ -7288,11 +7274,31 @@
     restoreBlock.append(restore, restoreNote);
     view.append(restoreBlock);
 
-    // Help users who don't have an NWC-capable wallet yet.
+    // Quick start comes AFTER connect and restore, not before. Someone who already
+    // has a wallet — which is most people opening this screen deliberately — should
+    // reach their own path first and not have to scroll past an onboarding pitch. It
+    // sits last because it reads onward into the suggestions link below it.
+    // The divider goes OUTSIDE the card — .wallet-quickstart has its own border and
+    // background, and a rule inside it reads as a stray line rather than a separator.
+    view.append(h('div', { className: 'wallet-or quickstart-or', textContent: 'or' }));
+    const quick = h('div', { className: 'wallet-quickstart' });
+    quick.append(h('div', { className: 'wallet-quickstart-title', textContent: 'New to Lightning?' }));
+    quick.append(h('p', {
+      className: 'hint compact',
+      textContent: 'Set up a hosted wallet with Rizful in about a minute, and start receiving zaps.',
+    }));
+    const quickBtn = h('button', { className: 'secondary', textContent: 'Quick start with Rizful' });
+    quickBtn.addEventListener('click', rizfulQuickStartModal);
+    quick.append(quickBtn);
+    view.append(quick);
+
+    // Reads as the continuation of the quick-start block above rather than a
+    // consolation prize, so it's framed as more options rather than "you must not
+    // have one".
     const find = h('a', {
       className: 'explore-link wallet-find-link',
       href: '#',
-      textContent: 'Need a wallet? See suggestions →',
+      textContent: 'More Lightning wallet options →',
     });
     find.addEventListener('click', (e) => {
       e.preventDefault();

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -7063,8 +7063,142 @@
     renderWalletConnected(view);
   }
 
+  // ---- Rizful quick start ----------------------------------------------------
+  //
+  // The hard part of connecting a wallet isn't pasting the string — it's that a user
+  // with no Lightning wallet has to go find one first. Rizful publishes a token
+  // exchange for exactly this: the user signs up, copies a short one-time code, and
+  // we trade it for a standard NWC connection string. Same flow Jumble uses.
+  //
+  // Nothing about Sidecar's architecture changes: what comes back is an ordinary
+  // `nostr+walletconnect://` URI that goes through the same SIDECAR_SET_NWC path as a
+  // hand-pasted one. This is purely a friendlier way to obtain it.
+  //
+  // Rizful is CUSTODIAL — they hold the funds. That's stated plainly in the UI rather
+  // than buried, because Sidecar's whole position is that it never holds your money,
+  // and offering a one-tap wallet shouldn't quietly blur that.
+  const RIZFUL_ORIGIN = 'https://rizful.com';
+  const RIZFUL_SIGNUP_URL = RIZFUL_ORIGIN + '/create-account';
+  const RIZFUL_GET_CODE_URL = RIZFUL_ORIGIN + '/nostr_onboarding_auth_token/get_token';
+  const RIZFUL_EXCHANGE_URL = RIZFUL_ORIGIN + '/nostr_onboarding_auth_token/post_for_secrets';
+
+  // Trade a one-time code for an NWC string. Returns { nwcUri, lightningAddress }.
+  //
+  // The response is treated as untrusted: a `nwc_uri` that isn't actually an NWC URI
+  // is rejected rather than handed to SIDECAR_SET_NWC, so a compromised or confused
+  // endpoint can't get an arbitrary string stored as the user's wallet.
+  async function rizfulExchangeCode(code, pubkey) {
+    const res = await fetch(RIZFUL_EXCHANGE_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'omit', // never attach cookies to a token exchange
+      body: JSON.stringify({ secret_code: String(code).trim(), nostr_public_key: pubkey }),
+      signal: AbortSignal.timeout(20000),
+    });
+    if (!res.ok) {
+      let detail = '';
+      try { detail = (await res.text()).slice(0, 200); } catch (_) {}
+      throw new Error(detail || 'Rizful rejected that code (' + res.status + ').');
+    }
+    let data;
+    try { data = await res.json(); } catch (_) { throw new Error('Rizful sent a response Sidecar could not read.'); }
+    const nwcUri = data && typeof data.nwc_uri === 'string' ? data.nwc_uri.trim() : '';
+    if (!nwcUri.startsWith('nostr+walletconnect://')) {
+      throw new Error('Rizful did not return a wallet connection.');
+    }
+    const addr = data && typeof data.lightning_address === 'string' ? data.lightning_address.trim() : '';
+    return { nwcUri, lightningAddress: addr && addr.includes('@') ? addr : parseNwcLud16(nwcUri) };
+  }
+
+  function rizfulQuickStartModal() {
+    openModal((modal) => {
+      const err = h('div', { className: 'error' });
+      const code = h('input', {
+        type: 'text', className: 'rizful-code', spellcheck: false, autocomplete: 'off',
+        placeholder: 'Paste your one-time code',
+      });
+      const go = h('button', { className: 'primary', textContent: 'Connect wallet' });
+
+      const step = (n, label, btnText, url) => {
+        const row = h('div', { className: 'rizful-step' });
+        row.append(h('span', { className: 'rizful-step-n', textContent: String(n) }));
+        const body = h('div', { className: 'rizful-step-body' });
+        body.append(h('div', { className: 'rizful-step-label', textContent: label }));
+        if (btnText) {
+          const b = h('button', { className: 'secondary rizful-step-btn', textContent: btnText });
+          b.addEventListener('click', () => chrome.tabs.create({ url }));
+          body.append(b);
+        }
+        row.append(body);
+        return row;
+      };
+
+      go.addEventListener('click', async () => {
+        const value = code.value.trim();
+        if (!value) return (err.textContent = 'Paste the code from Rizful.');
+        err.textContent = '';
+        go.disabled = true;
+        go.textContent = 'Connecting…';
+        try {
+          const { nwcUri, lightningAddress } = await rizfulExchangeCode(value, state.activePubkey);
+          // Prove it works before storing it — same check the paste path makes.
+          const client = window.SidecarNWC.makeClient(nwcUri);
+          await client.getInfo();
+          client.close();
+          await call({ type: 'SIDECAR_SET_NWC', connection: nwcUri });
+          closeModal();
+          toast(lightningAddress ? 'Wallet connected — ' + lightningAddress : 'Wallet connected', 'success');
+          // The Profile screen's existing lud16 prompt picks it up from here and
+          // offers to publish the address, which is what makes zaps reachable.
+          renderWallet();
+        } catch (e) {
+          err.textContent = (e && e.message) || 'Could not connect that wallet.';
+          go.disabled = false;
+          go.textContent = 'Connect wallet';
+        }
+      });
+      code.addEventListener('keydown', (e) => { if (e.key === 'Enter') { e.preventDefault(); go.click(); } });
+
+      const cancel = h('button', { className: 'ghost', textContent: 'Cancel' });
+      cancel.addEventListener('click', closeModal);
+
+      modal.append(
+        h('h3', { textContent: 'Start with a Rizful wallet' }),
+        h('p', {
+          className: 'hint',
+          textContent:
+            'Rizful is a hosted Lightning wallet — they hold the funds, not you and not Sidecar. '
+            + 'It is the quickest way to start receiving zaps, and you can connect a self-custodial '
+            + 'wallet later instead.',
+        }),
+        step(1, 'Create a Rizful account (skip if you have one)', 'Sign up', RIZFUL_SIGNUP_URL),
+        step(2, 'Get your one-time code', 'Get code', RIZFUL_GET_CODE_URL),
+        step(3, 'Paste it here'),
+        code,
+        err,
+        h('div', { className: 'actions' }, [cancel, go])
+      );
+      setTimeout(() => code.focus(), 50);
+    });
+  }
+
   function renderWalletConnect(view) {
     view.append(h('h2', { textContent: 'Wallet' }));
+
+    // Quick start goes FIRST: this screen only renders when no wallet is connected,
+    // so "I don't have one" is the common case, not the edge case.
+    const quick = h('div', { className: 'wallet-quickstart' });
+    quick.append(h('div', { className: 'wallet-quickstart-title', textContent: 'New to Lightning?' }));
+    quick.append(h('p', {
+      className: 'hint compact',
+      textContent: 'Set up a hosted wallet with Rizful in about a minute, and start receiving zaps.',
+    }));
+    const quickBtn = h('button', { className: 'primary', textContent: 'Quick start with Rizful' });
+    quickBtn.addEventListener('click', rizfulQuickStartModal);
+    quick.append(quickBtn);
+    view.append(quick);
+    view.append(h('div', { className: 'wallet-or', textContent: 'or' }));
+
     view.append(
       h('p', {
         className: 'hint',

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -7148,19 +7148,27 @@
       const cancel = h('button', { className: 'ghost', textContent: 'Cancel' });
       cancel.addEventListener('click', closeModal);
 
-      // One action, one field, one footnote — in that order.
+      // Two buttons, in order, then the field.
       //
-      // The first pass was a numbered three-step list with its own button inside each
-      // step, above a paragraph of custodial disclosure. It read as a form to fill in
-      // rather than two things to do, and the disclosure gated the actions behind five
-      // lines of small print. Both steps 1 and 2 happen on Rizful's site anyway, so
-      // they collapse into one button; step 3 was just restating the input's own
-      // placeholder.
-      const getCode = h('button', { className: 'secondary rizful-get', textContent: 'Get a code from Rizful' });
-      getCode.addEventListener('click', () => chrome.tabs.create({ url: RIZFUL_GET_CODE_URL }));
-
-      const signup = h('button', { className: 'rizful-signup', textContent: 'New to Rizful? Create an account' });
+      // These were briefly one button ("Get a code from Rizful") with signup as a
+      // quiet link underneath. That was wrong: a user without an account clicks the
+      // big button, gets redirected to Rizful's signup, finishes it, and is then
+      // nowhere near a code — so they have to come back and click the same button
+      // again to actually get one. One control silently doing two different things on
+      // two clicks is exactly the confusion that caused.
+      //
+      // Signup is a real button now, sized like the other, so the two trips to Rizful
+      // are visible up front. Anyone who already has an account just skips the first.
+      // Still no step numbers — top-to-bottom order carries the sequence.
+      const signup = h('button', {
+        className: 'secondary rizful-get', textContent: 'Create a Rizful account',
+      });
       signup.addEventListener('click', () => chrome.tabs.create({ url: RIZFUL_SIGNUP_URL }));
+
+      const getCode = h('button', {
+        className: 'secondary rizful-get', textContent: 'Get your one-time code',
+      });
+      getCode.addEventListener('click', () => chrome.tabs.create({ url: RIZFUL_GET_CODE_URL }));
 
       // Custody still gets said plainly, but as a closing note rather than a wall the
       // user has to read past. "Hosted" is in the line above, which is the word that
@@ -7182,8 +7190,8 @@
       modal.append(
         h('h3', { textContent: 'Start with Rizful' }),
         h('p', { className: 'rizful-lede', textContent: 'A hosted Lightning wallet, ready in about a minute.' }),
-        getCode,
         signup,
+        getCode,
         code,
         err,
         actions,

--- a/styles.css
+++ b/styles.css
@@ -1658,14 +1658,14 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
   font-family: var(--font-ui); font-size: 13.5px; line-height: 1.5;
   color: var(--text-2); margin: 0 0 14px;
 }
+/* The two trips to Rizful, same size so neither looks like the only one. Signup is
+   skippable if you already have an account; order carries that, so neither needs a
+   step number or an explanatory line. */
 .rizful-get { display: block; width: 100%; padding: 10px 14px; font-size: 14px; }
-/* A quiet text link, not a second button competing with the one above it. */
-.rizful-signup {
-  display: block; width: 100%; margin: -2px 0 4px;
-  background: none; border: none; cursor: pointer; padding: 6px;
-  font-family: var(--font-ui); font-size: 12.5px; color: var(--muted);
-}
-.rizful-signup:hover { color: var(--lav); }
+.rizful-get + .rizful-get { margin-top: 7px; }
+/* A little air before the field — the two buttons are one group, the paste is the
+   next thing. */
+.rizful-get + .rizful-code { margin-top: 14px; }
 .rizful-code {
   width: 100%; margin-top: 4px; padding: 11px 12px; border-radius: 10px;
   font-family: var(--font-ui); font-size: 14px; letter-spacing: 0.04em;

--- a/styles.css
+++ b/styles.css
@@ -908,6 +908,10 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
 .explore-link-wrap { display: flex; flex-direction: column; gap: 8px; margin-top: 24px; padding: 0 4px; }
 .explore-link { font-size: 13px; color: var(--muted); text-decoration: none; text-align: center; display: block; }
 .explore-link:hover { color: var(--lav); }
+/* For a link sitting inside a sentence rather than on its own line — the base rule
+   is display:block and centered, which breaks the sentence in half. Same treatment
+   .wallet-notice .explore-link already gets, as a reusable modifier. */
+.explore-link.inline { display: inline; color: inherit; text-align: inherit; text-decoration: underline; }
 .explore-link.share-link { display: flex; align-items: center; justify-content: center; gap: 6px; }
 .share-link svg { width: 14px; height: 14px; }
 #share-sidecar-btn { display: inline-flex; align-items: center; justify-content: center; gap: 7px; }

--- a/styles.css
+++ b/styles.css
@@ -1636,14 +1636,19 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
 /* Quick start — the first thing on a screen that only appears when there's no
    wallet, so it gets card weight rather than sitting as one more link. */
 .wallet-quickstart {
-  margin: 4px 0 14px; padding: 14px; border-radius: 12px;
+  margin: 0 0 10px; padding: 14px; border-radius: 12px;
   border: 1px solid var(--border-strong);
   background: linear-gradient(160deg, var(--velvet-1), var(--velvet-2));
   box-shadow: var(--sheen);
 }
 .wallet-quickstart-title { font-weight: 600; font-size: 14px; color: var(--text); margin-bottom: 2px; }
 .wallet-quickstart .hint { margin: 0 0 11px; }
-.wallet-quickstart .primary { display: block; width: 100%; }
+/* Secondary, not primary: "Connect wallet" above owns the primary weight on this
+   screen, and two filled buttons would compete for the same decision. */
+.wallet-quickstart .secondary { display: block; width: 100%; }
+/* Separates the restore block from the quick-start card. Matches the spacing the
+   restore block gets from its own container. */
+.quickstart-or { margin-top: 20px; }
 
 /* Rizful quick-start modal. Deliberately few elements and larger type than the
    first attempt, which stacked three numbered steps each carrying its own button

--- a/styles.css
+++ b/styles.css
@@ -1629,6 +1629,40 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
 }
 .wallet-or::before, .wallet-or::after { content: ''; flex: 1; height: 1px; background: var(--border); }
 
+/* Quick start — the first thing on a screen that only appears when there's no
+   wallet, so it gets card weight rather than sitting as one more link. */
+.wallet-quickstart {
+  margin: 4px 0 14px; padding: 14px; border-radius: 12px;
+  border: 1px solid var(--border-strong);
+  background: linear-gradient(160deg, var(--velvet-1), var(--velvet-2));
+  box-shadow: var(--sheen);
+}
+.wallet-quickstart-title { font-weight: 600; font-size: 14px; color: var(--text); margin-bottom: 2px; }
+.wallet-quickstart .hint { margin: 0 0 11px; }
+.wallet-quickstart .primary { display: block; width: 100%; }
+
+/* Numbered steps in the Rizful modal. */
+.rizful-step { display: flex; align-items: flex-start; gap: 10px; margin: 11px 0; }
+.rizful-step-n {
+  flex-shrink: 0; width: 20px; height: 20px; border-radius: 50%; margin-top: 1px;
+  display: flex; align-items: center; justify-content: center;
+  font-family: var(--font-ui); font-size: 11px; font-weight: 700;
+  background: var(--accent-fill, var(--gold)); color: var(--btn-primary-text, #1a0e08);
+}
+.rizful-step-body { min-width: 0; flex: 1; }
+.rizful-step-label { font-size: 13px; color: var(--text-2); }
+.rizful-step-btn { margin-top: 6px; padding: 5px 11px; font-size: 12.5px; }
+.rizful-code {
+  width: 100%; margin-top: 2px; padding: 9px 11px; border-radius: 9px;
+  font-size: 13px; letter-spacing: 0.04em;
+  color: var(--text); border: 1px solid var(--border);
+  background: var(--input-bg, linear-gradient(180deg, rgba(8, 2, 20, 0.6), rgba(20, 4, 40, 0.6)));
+}
+.rizful-code:focus {
+  outline: none; border-color: var(--border-strong);
+  box-shadow: 0 0 0 3px var(--focus-ring, rgba(203, 161, 78, 0.16));
+}
+
 /* wallet backup card: label + status on top, full-width buttons below */
 .wallet-backup-card {
   background: linear-gradient(180deg, var(--velvet-1), var(--velvet-2));

--- a/styles.css
+++ b/styles.css
@@ -1645,26 +1645,39 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
 .wallet-quickstart .hint { margin: 0 0 11px; }
 .wallet-quickstart .primary { display: block; width: 100%; }
 
-/* Numbered steps in the Rizful modal. */
-.rizful-step { display: flex; align-items: flex-start; gap: 10px; margin: 11px 0; }
-.rizful-step-n {
-  flex-shrink: 0; width: 20px; height: 20px; border-radius: 50%; margin-top: 1px;
-  display: flex; align-items: center; justify-content: center;
-  font-family: var(--font-ui); font-size: 11px; font-weight: 700;
-  background: var(--accent-fill, var(--gold)); color: var(--btn-primary-text, #1a0e08);
+/* Rizful quick-start modal. Deliberately few elements and larger type than the
+   first attempt, which stacked three numbered steps each carrying its own button
+   above a five-line disclosure — a lot of small text to read before anything could
+   be done. One action, one field, one closing note. */
+.rizful-lede {
+  font-family: var(--font-ui); font-size: 13.5px; line-height: 1.5;
+  color: var(--text-2); margin: 0 0 14px;
 }
-.rizful-step-body { min-width: 0; flex: 1; }
-.rizful-step-label { font-size: 13px; color: var(--text-2); }
-.rizful-step-btn { margin-top: 6px; padding: 5px 11px; font-size: 12.5px; }
+.rizful-get { display: block; width: 100%; padding: 10px 14px; font-size: 14px; }
+/* A quiet text link, not a second button competing with the one above it. */
+.rizful-signup {
+  display: block; width: 100%; margin: -2px 0 4px;
+  background: none; border: none; cursor: pointer; padding: 6px;
+  font-family: var(--font-ui); font-size: 12.5px; color: var(--muted);
+}
+.rizful-signup:hover { color: var(--lav); }
 .rizful-code {
-  width: 100%; margin-top: 2px; padding: 9px 11px; border-radius: 9px;
-  font-size: 13px; letter-spacing: 0.04em;
+  width: 100%; margin-top: 4px; padding: 11px 12px; border-radius: 10px;
+  font-family: var(--font-ui); font-size: 14px; letter-spacing: 0.04em;
   color: var(--text); border: 1px solid var(--border);
   background: var(--input-bg, linear-gradient(180deg, rgba(8, 2, 20, 0.6), rgba(20, 4, 40, 0.6)));
 }
+.rizful-code::placeholder { color: var(--faint); letter-spacing: normal; }
 .rizful-code:focus {
   outline: none; border-color: var(--border-strong);
   box-shadow: 0 0 0 3px var(--focus-ring, rgba(203, 161, 78, 0.16));
+}
+/* Sits below the buttons, above the modal's bottom edge — visible without standing
+   between the user and the first action. */
+.rizful-note {
+  font-family: var(--font-ui); font-size: 11.5px; line-height: 1.5;
+  color: var(--faint); margin: 12px 0 0; padding-top: 12px;
+  border-top: 1px solid var(--border);
 }
 
 /* wallet backup card: label + status on top, full-width buttons below */

--- a/test/rizful-exchange.test.js
+++ b/test/rizful-exchange.test.js
@@ -1,0 +1,166 @@
+'use strict';
+
+// Unit coverage for rizfulExchangeCode() in sidepanel.js.
+//
+// This function trades a one-time code for a wallet connection string that Sidecar
+// then STORES AND SPENDS FROM. The response comes from a third party over the
+// network, so it's untrusted input on a path that ends in the user's money — these
+// tests are mostly about what it refuses, not what it accepts.
+//
+// The specific hazard: if a `nwc_uri` that isn't an NWC URI reached
+// SIDECAR_SET_NWC, a confused or compromised endpoint could get an arbitrary string
+// stored as the user's wallet.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const ROOT = path.join(__dirname, '..');
+const source = fs.readFileSync(path.join(ROOT, 'sidepanel.js'), 'utf8');
+
+function lift(pattern, label) {
+  const m = source.match(pattern);
+  if (!m) throw new Error('Could not find ' + label + ' in sidepanel.js');
+  return m[0];
+}
+
+// Build a context with a stubbed fetch. `respond` returns { ok, status, json, text }.
+function harness(respond) {
+  const calls = [];
+  const ctx = {
+    console,
+    // A vm context inherits no globals. parseNwcLud16 uses URLSearchParams, and
+    // without it here its try/catch swallows a ReferenceError and returns null —
+    // which looks exactly like "this URI has no lud16".
+    URLSearchParams,
+    AbortSignal: { timeout: (ms) => ({ __timeout: ms }) },
+    fetch: async (url, opts) => {
+      calls.push({ url, opts });
+      const r = respond(url, opts);
+      return {
+        ok: r.ok !== false,
+        status: r.status || 200,
+        json: async () => { if (r.throwsOnJson) throw new Error('bad json'); return r.json; },
+        text: async () => r.text || '',
+      };
+    },
+  };
+  vm.createContext(ctx);
+  vm.runInContext(
+    lift(/const RIZFUL_ORIGIN = [\s\S]*?const RIZFUL_EXCHANGE_URL = [^\n]+/, 'Rizful URLs') + '\n' +
+    lift(/function parseNwcLud16\(connection\)\s*\{[\s\S]*?\n  \}/, 'parseNwcLud16') + '\n' +
+    lift(/async function rizfulExchangeCode\(code, pubkey\)\s*\{[\s\S]*?\n  \}/, 'rizfulExchangeCode') + '\n' +
+    'globalThis.rizfulExchangeCode = rizfulExchangeCode;' +
+    'globalThis.RIZFUL_EXCHANGE_URL = RIZFUL_EXCHANGE_URL;',
+    ctx
+  );
+  return { ctx, calls };
+}
+
+const NWC = 'nostr+walletconnect://abc123?relay=wss%3A%2F%2Frelay.example&secret=deadbeef';
+const NWC_WITH_ADDR = NWC + '&lud16=alice%40rizful.com';
+const PUBKEY = '82341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2';
+
+test('a good exchange returns the connection string', async () => {
+  const { ctx } = harness(() => ({ json: { nwc_uri: NWC } }));
+  const out = await ctx.rizfulExchangeCode('CODE-1', PUBKEY);
+  assert.equal(out.nwcUri, NWC);
+});
+
+test('it posts the code and pubkey as JSON, without cookies', async () => {
+  const { ctx, calls } = harness(() => ({ json: { nwc_uri: NWC } }));
+  await ctx.rizfulExchangeCode('  CODE-1  ', PUBKEY);
+  const { url, opts } = calls[0];
+  assert.equal(url, ctx.RIZFUL_EXCHANGE_URL);
+  assert.equal(opts.method, 'POST');
+  assert.equal(opts.credentials, 'omit', 'a token exchange must not carry cookies');
+  assert.equal(opts.headers['Content-Type'], 'application/json');
+  const body = JSON.parse(opts.body);
+  assert.equal(body.secret_code, 'CODE-1', 'the code should be trimmed');
+  assert.equal(body.nostr_public_key, PUBKEY);
+});
+
+test('the request is bounded by a timeout', async () => {
+  const { ctx, calls } = harness(() => ({ json: { nwc_uri: NWC } }));
+  await ctx.rizfulExchangeCode('CODE-1', PUBKEY);
+  assert.ok(calls[0].opts.signal, 'no abort signal — a hung endpoint would hang the modal');
+});
+
+// The central guard.
+test('a response that is not an NWC URI is REFUSED', async () => {
+  for (const bad of [
+    'https://evil.example/drain',
+    'javascript:alert(1)',
+    'nostr+walletconnectX://abc',
+    'lnbc1...',
+    '',
+    '   ',
+  ]) {
+    const { ctx } = harness(() => ({ json: { nwc_uri: bad } }));
+    await assert.rejects(
+      () => ctx.rizfulExchangeCode('CODE-1', PUBKEY),
+      /did not return a wallet connection/,
+      JSON.stringify(bad) + ' must be refused'
+    );
+  }
+});
+
+test('a non-string or missing nwc_uri is refused rather than coerced', async () => {
+  for (const bad of [undefined, null, 42, {}, ['nostr+walletconnect://x']]) {
+    const { ctx } = harness(() => ({ json: { nwc_uri: bad } }));
+    await assert.rejects(() => ctx.rizfulExchangeCode('CODE-1', PUBKEY), /did not return a wallet connection/);
+  }
+});
+
+test('an HTTP error surfaces the server text, truncated', async () => {
+  const { ctx } = harness(() => ({ ok: false, status: 400, text: 'That code has expired.' }));
+  await assert.rejects(() => ctx.rizfulExchangeCode('CODE-1', PUBKEY), /That code has expired/);
+
+  const long = harness(() => ({ ok: false, status: 500, text: 'x'.repeat(5000) }));
+  const err = await long.ctx.rizfulExchangeCode('C', PUBKEY).then(() => null, (e) => e);
+  assert.ok(err.message.length <= 220, 'a huge error body should not be pasted whole into the UI');
+});
+
+test('an HTTP error with no body still names the status', async () => {
+  const { ctx } = harness(() => ({ ok: false, status: 502, text: '' }));
+  await assert.rejects(() => ctx.rizfulExchangeCode('CODE-1', PUBKEY), /502/);
+});
+
+test('unparseable JSON fails with a clear message rather than a raw SyntaxError', async () => {
+  const { ctx } = harness(() => ({ throwsOnJson: true }));
+  await assert.rejects(() => ctx.rizfulExchangeCode('CODE-1', PUBKEY), /could not read/);
+});
+
+test('the lightning address is taken from the response when present', async () => {
+  const { ctx } = harness(() => ({ json: { nwc_uri: NWC, lightning_address: 'alice@rizful.com' } }));
+  const out = await ctx.rizfulExchangeCode('CODE-1', PUBKEY);
+  assert.equal(out.lightningAddress, 'alice@rizful.com');
+});
+
+// This is what makes the profile's lud16 prompt fire, which is what makes the new
+// wallet actually reachable by zaps — so it must not depend on the optional field.
+test('the address falls back to the lud16 inside the NWC string', async () => {
+  const { ctx } = harness(() => ({ json: { nwc_uri: NWC_WITH_ADDR } }));
+  const out = await ctx.rizfulExchangeCode('CODE-1', PUBKEY);
+  assert.equal(out.lightningAddress, 'alice@rizful.com');
+});
+
+test('a junk lightning_address is ignored rather than shown', async () => {
+  const { ctx } = harness(() => ({ json: { nwc_uri: NWC, lightning_address: 'not-an-address' } }));
+  const out = await ctx.rizfulExchangeCode('CODE-1', PUBKEY);
+  assert.equal(out.lightningAddress, null, 'no @ means it is not an address; fall through');
+});
+
+test('no address anywhere is not an error — the wallet still connects', async () => {
+  const { ctx } = harness(() => ({ json: { nwc_uri: NWC } }));
+  const out = await ctx.rizfulExchangeCode('CODE-1', PUBKEY);
+  assert.equal(out.nwcUri, NWC);
+  assert.equal(out.lightningAddress, null);
+});
+
+test('the exchange endpoint is on rizful.com over https', async () => {
+  const { ctx } = harness(() => ({ json: { nwc_uri: NWC } }));
+  assert.match(ctx.RIZFUL_EXCHANGE_URL, /^https:\/\/rizful\.com\//);
+});


### PR DESCRIPTION
The wallet screen's hardest moment isn't pasting a connection string — it's that a user with **no** Lightning wallet has to go find one first. Rizful publishes a token exchange for exactly this, and it's the flow Jumble uses: sign up, get a one-time code, trade it for a standard NWC string.

**Nothing about the architecture changes.** What comes back is an ordinary `nostr+walletconnect://` URI going through the same `SIDECAR_SET_NWC` path as a hand-pasted one, validated by the same `getInfo` round-trip first. No SDK, no WASM, no API key, and it works identically on Firefox. (Context for why that matters: `WALLET_BACKENDS.md` records Breez Spark and Cashu/NIP-60 both being ruled out, partly on those grounds.)

**It completes itself.** The exchange returns a lightning address — or one rides in the NWC string's `lud16` — which the Profile screen's existing `maybeSuggestLud16` prompt picks up and offers to publish. That last step is what makes a brand-new wallet reachable by zaps, and Sidecar already had it built.

**Custody is stated plainly.** *"Run by Megalith. They hold the funds, not Sidecar — you can switch to a self-custodial wallet later."* Sidecar's position is that it never holds funds, and a one-tap wallet button shouldn't blur that by omission. The operator is named and linked because the user is being asked to trust someone with money.

**The response is treated as untrusted input on a path that ends in the user's money.** A `nwc_uri` that isn't an NWC URI is refused rather than stored, so a confused or compromised endpoint can't get an arbitrary string saved as the user's wallet. Cookies are never attached, the request is bounded at 20s, and error bodies are truncated before display. 15 tests cover the refusals and error paths, not just the happy case.

**Placement:** connect → restore → quick start → more options. Someone who opens the Wallet tab deliberately usually already has a wallet, so they reach their own path first; the quick-start card and the retitled "More Lightning wallet options →" link are the same thought, so they sit adjacent.

Three rounds of UI revision off real screenshots are in the history — the notable one is `0856ed1`, where a single "Get a code" button silently did two different things on two clicks. Signup is now its own button so both trips to Rizful are visible up front.

**Not verified:** the live endpoint round-trip beyond Daniel's own successful run, and what Rizful's code page does on a return visit when you're already signed in.

92/92 tests pass.

🥃 Poured with [Claude Code](https://claude.com/claude-code)
