### PR TITLE
feat: comment on any webpage (NIP-22 kind 1111)

### DIFF
--- a/sidepanel.html
+++ b/sidepanel.html
@@ -63,6 +63,12 @@
         <button id="search-btn" class="icon-btn" title="Find a profile or note" aria-expanded="false" aria-controls="search-bar">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="10" cy="10" r="9"></circle><line x1="21" y1="21" x2="16.35" y2="16.35"></line></svg>
         </button>
+        <!-- Comment on the current page (NIP-22 kind 1111). Feather's edit-3, to
+             match the other topbar glyphs. Grouped with the bell and search: those
+             three act on content, while help/settings/lock are app chrome. -->
+        <button id="comment-btn" class="icon-btn" title="Comment on this page">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"></path><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4 12.5-12.5z"></path></svg>
+        </button>
         <button id="help-btn" class="icon-btn" title="Help &amp; guides">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><circle cx="12" cy="12" r="4"></circle><line x1="4.93" y1="4.93" x2="9.17" y2="9.17"></line><line x1="14.83" y1="14.83" x2="19.07" y2="19.07"></line><line x1="14.83" y1="9.17" x2="19.07" y2="4.93"></line><line x1="9.17" y1="14.83" x2="4.93" y2="19.07"></line></svg>
         </button>

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -63,11 +63,14 @@
         <button id="search-btn" class="icon-btn" title="Find a profile or note" aria-expanded="false" aria-controls="search-bar">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="10" cy="10" r="9"></circle><line x1="21" y1="21" x2="16.35" y2="16.35"></line></svg>
         </button>
-        <!-- Comment on the current page (NIP-22 kind 1111). Feather's edit-3, to
-             match the other topbar glyphs. Grouped with the bell and search: those
-             three act on content, while help/settings/lock are app chrome. -->
+        <!-- Comment on the current page (NIP-22 kind 1111). Feather's message-square
+             with three dots inside: a pencil reads as "edit", and the composer FAB
+             already owns the quill. Grouped with the bell and search — those three act
+             on content, while help/settings/lock are app chrome.
+             Dots sit at y=10 with 3 units' clearance from every wall, which renders as
+             ~3.2px dots at the topbar's 19px icon size: still legible, not mud. -->
         <button id="comment-btn" class="icon-btn" title="Comment on this page">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"></path><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4 12.5-12.5z"></path></svg>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path><circle cx="8" cy="10" r="1"></circle><circle cx="12" cy="10" r="1"></circle><circle cx="16" cy="10" r="1"></circle></svg>
         </button>
         <button id="help-btn" class="icon-btn" title="Help &amp; guides">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><circle cx="12" cy="12" r="4"></circle><line x1="4.93" y1="4.93" x2="9.17" y2="9.17"></line><line x1="14.83" y1="14.83" x2="19.07" y2="19.07"></line><line x1="14.83" y1="9.17" x2="19.07" y2="4.93"></line><line x1="9.17" y1="14.83" x2="4.93" y2="19.07"></line></svg>

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -297,8 +297,8 @@
 
       <div class="setting">
         <h3>Client tag</h3>
-        <p class="hint">Add a “client” tag to notes you post, attributing them to Sidecar. Turn off to post without it.</p>
-        <label class="toggle-row"><input type="checkbox" id="clienttag-toggle" /> <span>Tag notes as posted with Sidecar</span></label>
+        <p class="hint">Add a “client” tag to notes and page comments you post, attributing them to Sidecar. Turn off to post without it.</p>
+        <label class="toggle-row"><input type="checkbox" id="clienttag-toggle" /> <span>Tag posts as made with Sidecar</span></label>
       </div>
 
       <div class="setting">

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -1668,6 +1668,28 @@
     } catch (_) { return raw; }
   }
 
+  // `p` tags for every profile mentioned in the text, deduped and in order.
+  //
+  // This is what makes a mention reach the person mentioned: notification discovery
+  // is `{'#p': [pubkey]}` (see the bell's own filter), so a mention with no p tag
+  // renders for every reader and is invisible to its target. Shared by notes and
+  // comments — it was inline in the note composer, and duplicating it is how the two
+  // drifted apart in the first place.
+  function mentionPTags(content) {
+    const out = [];
+    const seen = new Set();
+    const re = /nostr:(npub1[0-9a-z]+|nprofile1[0-9a-z]+)/g;
+    let m;
+    while ((m = re.exec(String(content || ''))) !== null) {
+      try {
+        const d = NT.nip19.decode(m[1]);
+        const pk = d.type === 'npub' ? d.data : d.data.pubkey;
+        if (pk && !seen.has(pk)) { seen.add(pk); out.push(['p', pk]); }
+      } catch (_) { /* malformed mention — skip it, don't fail the post */ }
+    }
+    return out;
+  }
+
   // `includeClientTag` comes from the same Settings toggle that governs notes, so
   // the switch means what it says rather than covering only kind 1. Verified that
   // Jumble renders it: ReplyNote and NotePage both mount <ClientTag> with no kind
@@ -1676,6 +1698,8 @@
     // Root and parent are identical: this is a top-level comment on the page, not a
     // reply to another comment.
     const tags = [['I', url], ['K', 'web'], ['i', url], ['k', 'web']];
+    // Then who's involved, so a mention actually notifies the person mentioned.
+    tags.push(...mentionPTags(content));
     // Appended rather than prepended (notes put it first): these four scope tags are
     // what was verified byte-for-byte against a real Jumble comment, so keeping them
     // as the leading shape means a future diff against one stays clean. The client
@@ -1833,6 +1857,9 @@
       const glyph = r === '+' ? '❤️' : r === '-' ? '👎' : r.length <= 4 && r ? r : '❤️';
       return { glyph, text: 'reacted to your note' };
     }
+    // A NIP-22 comment that p-tags you. Worth its own wording: "mentioned you" sends
+    // the reader looking for a note, and this is a comment on a page.
+    if (ev.kind === WEB_COMMENT_KIND) return { glyph: '@', text: 'mentioned you in a comment' };
     // kind 1
     const hasQ = ev.tags.some((t) => t[0] === 'q' && t[1]); // NIP-18 quote repost
     // Ornamental quote mark (U+275D) — a text glyph like the '@' below, so it
@@ -1869,8 +1896,10 @@
   // target (card just isn't clickable then).
   function notifLink(ev, client, acctPubkey) {
     try {
-      // kind 1 (reply/mention) → the note itself.
-      if (ev.kind === 1) {
+      // kind 1 (reply/mention) → the note itself. Same for a kind 1111 comment: it
+      // carries I/i scope tags rather than `e`, so every branch below would miss it
+      // and the row would render with no link at all.
+      if (ev.kind === 1 || ev.kind === WEB_COMMENT_KIND) {
         return client.url(NT.nip19.neventEncode({ id: ev.id, author: ev.pubkey, relays: [] }));
       }
 
@@ -2091,7 +2120,10 @@
       // own notes — matched by id so they're caught even without a `p` tag.
       const ownIdList = [...ownIds];
       function buildFilters(sinceTs, limit) {
-        const base = { kinds: [1, 6, 7, 9735], '#p': [a.pubkey], since: sinceTs };
+        // 1111 is a NIP-22 comment (e.g. on a web page). Included so a mention inside
+        // one reaches you: Sidecar writes p tags on comments now, and not querying
+        // them would leave it a client that can send a mention but never receive one.
+        const base = { kinds: [1, 6, 7, 1111, 9735], '#p': [a.pubkey], since: sinceTs };
         const list = [limit ? Object.assign({ limit }, base) : base];
         if (ownIdList.length) {
           const repost = { kinds: [6], '#e': ownIdList, since: sinceTs };
@@ -2202,7 +2234,7 @@
       // Action row
       item.appendChild(h('div', { className: 'notif-action', textContent: text }));
 
-      if (ev.kind === 1 && ev.content) {
+      if ((ev.kind === 1 || ev.kind === WEB_COMMENT_KIND) && ev.content) {
         const cleaned = cleanSnippet(ev.content);
         if (cleaned) {
           const snippet = cleaned.length > 140 ? cleaned.slice(0, 140) + '…' : cleaned;
@@ -2327,7 +2359,7 @@
         const need = new Set();
         events.forEach((e) => {
           need.add(zapSender(e)); // the zapper for zaps, the author otherwise
-          if (e.kind === 1 && e.content) {
+          if ((e.kind === 1 || e.kind === WEB_COMMENT_KIND) && e.content) {
             const re = /nostr:(npub1[0-9a-z]+|nprofile1[0-9a-z]+)/g;
             let mm;
             while ((mm = re.exec(e.content)) !== null) {
@@ -5034,17 +5066,9 @@
 
     async function doPublish() {
       const content = draft.text.trim();
-      const pTags = [];
-      const seenPks = new Set();
-      const mentionRe = /nostr:(npub1[0-9a-z]+|nprofile1[0-9a-z]+)/g;
-      let mm;
-      while ((mm = mentionRe.exec(content)) !== null) {
-        try {
-          const d = NT.nip19.decode(mm[1]);
-          const pk = d.type === 'npub' ? d.data : d.data.pubkey;
-          if (pk && !seenPks.has(pk)) { seenPks.add(pk); pTags.push(['p', pk]); }
-        } catch (_) {}
-      }
+      // Shared with the page-comment path — see mentionPTags. Was inline here, which
+      // is how comments ended up shipping without it.
+      const pTags = mentionPTags(content);
       // The "client" tag (attributes the note to Sidecar) is opt-out via Settings.
       const settings = await call({ type: 'SIDECAR_GET_SETTINGS' });
       const tags = settings && settings.showClientTag === false ? [...pTags] : [CLIENT_TAG.slice(), ...pTags];

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -804,6 +804,101 @@
     if (a) showNotifModal(a);
   });
 
+  // Comment on the page in the active tab. Opened from the topbar pencil.
+  function webCommentModal() {
+    openModal((modal) => {
+      const err = h('div', { className: 'error' });
+      const urlLine = h('div', { className: 'webcomment-url', textContent: 'Reading the current tab…' });
+      const body = h('textarea', {
+        className: 'compose-text webcomment-text',
+        placeholder: 'Write a comment about this page…',
+      });
+      const post = h('button', { className: 'primary', textContent: 'Post comment' });
+      post.disabled = true;
+      const cancel = h('button', { className: 'ghost', textContent: 'Cancel' });
+      cancel.addEventListener('click', closeModal);
+
+      let target = null; // the normalized URL, once known
+
+      // Shown after a successful post: the two Jumble views, since that's where a
+      // kind:1111 on a web target is actually readable.
+      const done = h('div', { className: 'webcomment-done hidden' });
+
+      const link = (label, href) => {
+        const a = h('a', { className: 'explore-link', href: '#', textContent: label });
+        a.addEventListener('click', (e) => { e.preventDefault(); chrome.tabs.create({ url: href }); });
+        return a;
+      };
+
+      post.addEventListener('click', async () => {
+        const text = body.value.trim();
+        if (!target) return (err.textContent = 'No page to comment on.');
+        if (!text) return (err.textContent = 'Write something first.');
+        err.textContent = '';
+        post.disabled = true;
+        post.textContent = 'Posting…';
+        try {
+          const signed = await call({ type: 'SIDECAR_OWNER_SIGN', event: buildWebComment(target, text) });
+          await publishSigned(signed);
+          // nevent rather than note: the relay hint is what lets Jumble find it.
+          let nevent = '';
+          try {
+            nevent = NT.nip19.neventEncode({ id: signed.id, author: signed.pubkey, relays: [] });
+          } catch (_) {}
+          body.disabled = true;
+          post.classList.add('hidden');
+          done.classList.remove('hidden');
+          done.append(
+            h('div', { className: 'webcomment-done-title', textContent: 'Comment posted' }),
+            nevent ? link('View your comment →', jumbleNoteUrl(nevent)) : document.createTextNode(''),
+            link('See all comments on this page →', jumbleThreadUrl(target))
+          );
+          cancel.textContent = 'Close';
+          toast('Comment posted', 'success');
+        } catch (e) {
+          err.textContent = (e && e.message) || 'Could not post that comment.';
+          post.disabled = false;
+          post.textContent = 'Post comment';
+        }
+      });
+
+      modal.append(
+        h('h3', { textContent: 'Comment on this page' }),
+        h('p', {
+          className: 'hint compact',
+          textContent: 'A public Nostr comment attached to this page’s address. Anyone can see it, '
+            + 'including the address itself.',
+        }),
+        urlLine,
+        body,
+        err,
+        done,
+        h('div', { className: 'actions setup-actions' }, [cancel, post])
+      );
+
+      // Resolve the tab AFTER the modal is up, so the URL is never read
+      // speculatively — and show exactly what will be published.
+      activeTabUrl().then((raw) => {
+        if (!raw) {
+          urlLine.textContent = 'Could not read the current tab.';
+          urlLine.classList.add('bad');
+          return;
+        }
+        const { url, error } = normalizeWebUrl(raw);
+        if (error) {
+          urlLine.textContent = error;
+          urlLine.classList.add('bad');
+          return;
+        }
+        target = url;
+        urlLine.textContent = url;
+        urlLine.classList.remove('bad');
+        post.disabled = false;
+        body.focus();
+      });
+    });
+  }
+
   // ---- search: paste an identifier, open it in your client ----
   // Deliberately has no index behind it. A NIP-19 string already *contains* what
   // it points at — the npub is the pubkey, the nevent is the event id — so this
@@ -1032,6 +1127,8 @@
       if (searchResults.length) clearSearchResults(); else closeSearch();
     }
   });
+
+  $('comment-btn').addEventListener('click', webCommentModal);
 
   // ---- help & guides (opens as a full page in the main browser window) ----
   $('help-btn').addEventListener('click', () => {
@@ -1417,6 +1514,90 @@
   // Publish an already-signed event to the account's write relays (NIP-65 → configured).
   async function publishSigned(signed) {
     return publishToRelays(await postRelays(), signed);
+  }
+
+  // ---- web comments (NIP-22 kind 1111 over a NIP-73 "web" target) -------------
+  //
+  // Comment on any page you're looking at. The event is a kind:1111 whose scope is
+  // the page URL, which is how Jumble's external-content view finds it.
+  //
+  // Tag shape is taken from a REAL Jumble comment, fetched and decoded rather than
+  // inferred from the spec — uppercase is the root scope, lowercase the parent, and
+  // for a top-level comment they're the same:
+  //
+  //   ["I", url] ["K", "web"] ["i", url] ["k", "web"]
+  //
+  // The identifier is the URL itself, so normalization decides whether two people
+  // commenting on the same page land in the same thread. Getting it wrong doesn't
+  // error — it silently splits the conversation.
+  const WEB_COMMENT_KIND = 1111;
+
+  // Params that identify where a visitor came FROM, never which page they're on.
+  // Left in, every share link spawns its own thread.
+  const TRACKING_PARAMS = [
+    'utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content', 'utm_id',
+    'fbclid', 'gclid', 'gbraid', 'wbraid', 'msclkid', 'twclid', 'igshid', 'mc_cid',
+    'mc_eid', 'ref_src', 'ref_url', 's_kwcid', 'yclid', '_ga', 'ttclid',
+  ];
+
+  // Reduce a page URL to the identifier the comment is tagged with.
+  // Returns { url } or { error } — never throws, and never guesses on refusal.
+  //
+  // Deliberately NOT nostr-tools' utils.normalizeURL: that one is built for relay
+  // URLs and rewrites https:// to wss://, which would tag every comment with an
+  // address that threads with nothing.
+  function normalizeWebUrl(raw) {
+    let u;
+    try { u = new URL(String(raw || '').trim()); } catch (_) { return { error: 'That is not a URL Sidecar can comment on.' }; }
+    // Only real web pages. chrome://, about:, moz-extension:// and friends aren't
+    // public documents, and file:// would publish a path from this machine to a
+    // relay — which is a privacy leak, not a comment.
+    if (u.protocol !== 'https:' && u.protocol !== 'http:') {
+      return { error: 'Only http and https pages can be commented on.' };
+    }
+    if (!u.hostname || u.hostname === 'localhost' || /^(\d{1,3}\.){3}\d{1,3}$/.test(u.hostname)) {
+      return { error: 'That page is local, so nobody else could open the comment.' };
+    }
+    u.hash = ''; // NIP-73 requires no fragment: #section is the same document
+    for (const p of TRACKING_PARAMS) u.searchParams.delete(p);
+    // The query itself stays — for plenty of sites it IS the page identity
+    // (youtube.com/watch?v=…), so stripping it would merge unrelated pages.
+    u.searchParams.sort(); // ?b=1&a=2 and ?a=2&b=1 are the same page
+    let out = u.toString();
+    // A bare origin normalizes to a trailing slash; a path shouldn't gain one.
+    if (u.pathname !== '/' && out.endsWith('/')) out = out.slice(0, -1);
+    return { url: out };
+  }
+
+  function buildWebComment(url, content) {
+    return {
+      kind: WEB_COMMENT_KIND,
+      created_at: Math.floor(Date.now() / 1000),
+      // Root and parent are identical: this is a top-level comment on the page,
+      // not a reply to another comment.
+      tags: [['I', url], ['K', 'web'], ['i', url], ['k', 'web']],
+      content: content,
+    };
+  }
+
+  // Jumble is where these are actually readable — most clients don't render
+  // kind:1111 over a web target at all, which is why both links point there.
+  const jumbleThreadUrl = (url) =>
+    'https://jumble.social/external-content?id=' + encodeURIComponent(url);
+  const jumbleNoteUrl = (nevent) => 'https://jumble.social/notes/' + nevent;
+
+  // The URL of the page the user is looking at. Read only when the comment panel
+  // is opened — never speculatively — because it's about to be published.
+  function activeTabUrl() {
+    return new Promise((resolve) => {
+      if (!(chrome.tabs && chrome.tabs.query)) return resolve(null);
+      try {
+        chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+          if (chrome.runtime.lastError) return resolve(null);
+          resolve((tabs && tabs[0] && tabs[0].url) || null);
+        });
+      } catch (_) { resolve(null); }
+    });
   }
 
   // Build and publish a NIP-65 (kind:10002) relay list from the editor's model:

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -919,7 +919,11 @@
           done.classList.remove('hidden');
           done.append(
             h('div', { className: 'webcomment-done-title', textContent: 'Comment posted' }),
-            nevent ? link('View your comment \u2192', jumbleNoteUrl(nevent)) : document.createTextNode(''),
+            // Jumble is named because it's currently the only client that renders a
+            // kind:1111 over a web target \u2014 "view your comment" without saying where
+            // suggests it's visible wherever you normally read Nostr, and it isn't.
+            // Drop the name once other clients catch up.
+            nevent ? link('View your comment on Jumble \u2192', jumbleNoteUrl(nevent)) : document.createTextNode(''),
             link('See all comments on this page \u2192', jumbleThreadUrl(target))
           );
           cancel.textContent = 'Close';

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -844,25 +844,37 @@
       let target = null;   // the normalized URL this comments on
       let ogMeta;          // undefined = not fetched, null = no preview available
 
-      // The page being commented on, as the card the composer would draw for it.
-      // The raw URL only appears as a caption underneath: it IS what gets published,
-      // so it can't be hidden, but it shouldn't be the headline either.
-      function renderPreview() {
-        previewPane.innerHTML = '';
-        if (!target) {
-          previewPane.append(h('p', { className: 'hint', textContent: 'No page to comment on.' }));
-          return;
-        }
+      // The page being commented on. This sits ABOVE the tabs, not inside Preview,
+      // because it's CONTEXT rather than content — the same reason "Commenting as"
+      // is up there. A kind:1111 is defined by its target, so writing a comment
+      // without being able to see what you're commenting on is the wrong shape; the
+      // first version hid it behind the Preview tab and the Write pane was a blank
+      // box with no subject.
+      const targetBlock = h('div', { className: 'webcomment-target' });
+
+      function renderTarget() {
+        targetBlock.innerHTML = '';
+        if (!target) return;
         if (ogMeta === undefined) {
-          previewPane.append(h('div', { className: 'link-card loading' }));
+          targetBlock.append(h('div', { className: 'link-card loading' }));
         } else if (ogMeta) {
           const card = h('a', { className: 'link-card' });
           renderLinkCard(card, target, ogMeta);
-          previewPane.append(card);
+          targetBlock.append(card);
         }
-        previewPane.append(h('div', { className: 'webcomment-url', textContent: target }));
+        // The URL is what actually gets published, so it stays visible even when a
+        // card renders — as a caption, not the headline.
+        targetBlock.append(h('div', { className: 'webcomment-url', textContent: target }));
+      }
+
+      // Preview now shows only the comment itself, since the target is permanent
+      // above.
+      function renderPreview() {
+        previewPane.innerHTML = '';
         const text = body.value.trim();
-        if (text) previewPane.append(h('div', { className: 'webcomment-preview-text', textContent: text }));
+        previewPane.append(text
+          ? h('div', { className: 'webcomment-preview-text', textContent: text })
+          : h('p', { className: 'hint', textContent: 'Nothing written yet.' }));
       }
 
       function showTab(which) {
@@ -922,6 +934,7 @@
       modal.append(
         h('h3', { textContent: 'Comment on this page' }),
         author,
+        targetBlock, // above the tabs: the subject, not one of the two views
         tabBar,
         body,
         previewPane,
@@ -930,8 +943,8 @@
         h('div', { className: 'actions' }, [post, cancel])
       );
 
-      // Resolve the tab only after the modal is up \u2014 never speculatively, since
-      // this URL is about to be published.
+      // Resolve the tab only after the modal is up \u2014 never speculatively, since this
+      // URL is about to be published.
       activeTabUrl().then((raw) => {
         const { url, error } = normalizeWebUrl(unwrapJumbleTarget(raw));
         if (error) {
@@ -942,13 +955,14 @@
         }
         target = url;
         post.disabled = false;
+        renderTarget(); // shows the URL and a loading card immediately
         body.focus();
-        // Fetch the card in the background; the Write tab is usable immediately and
-        // Preview fills in when it lands.
+        // The card fills in when the fetch lands; the Write pane is usable throughout
+        // and already shows the URL, so nothing waits on the network.
         call({ type: 'SIDECAR_FETCH_OG', url: target })
           .then((meta) => { ogMeta = meta || null; })
           .catch(() => { ogMeta = null; })
-          .then(() => { if (!previewPane.classList.contains('hidden')) renderPreview(); });
+          .then(renderTarget);
       });
     });
   }

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -830,8 +830,10 @@
       const tabPreview = h('button', { className: 'compose-tab', textContent: 'Preview' });
       const tabBar = h('div', { className: 'compose-tabs' }, [tabWrite, tabPreview]);
 
-      const body = h('textarea', {
-        className: 'compose-text webcomment-text',
+      // The note composer's editor, reused verbatim, so a comment can tag people
+      // the same way a note can. Mentions land as nostr: pills that
+      // buildWebComment turns into the p tags a client needs to notify them.
+      const commentEditor = createMentionEditor({
         placeholder: 'Write a comment about this page\u2026',
       });
       const previewPane = h('div', { className: 'compose-preview hidden' });
@@ -871,7 +873,7 @@
       // above.
       function renderPreview() {
         previewPane.innerHTML = '';
-        const text = body.value.trim();
+        const text = commentEditor.getText().trim();
         previewPane.append(text
           ? h('div', { className: 'webcomment-preview-text', textContent: text })
           : h('p', { className: 'hint', textContent: 'Nothing written yet.' }));
@@ -881,9 +883,9 @@
         const preview = which === 'preview';
         tabWrite.classList.toggle('active', !preview);
         tabPreview.classList.toggle('active', preview);
-        body.classList.toggle('hidden', preview);
+        commentEditor.wrap.classList.toggle('hidden', preview);
         previewPane.classList.toggle('hidden', !preview);
-        if (preview) renderPreview();
+        if (preview) { commentEditor.close(); renderPreview(); }
       }
       tabWrite.addEventListener('click', () => showTab('write'));
       tabPreview.addEventListener('click', () => showTab('preview'));
@@ -898,7 +900,7 @@
       };
 
       post.addEventListener('click', async () => {
-        const text = body.value.trim();
+        const text = commentEditor.getText().trim();
         if (!target) return (err.textContent = 'No page to comment on.');
         if (!text) return (err.textContent = 'Write something first.');
         err.textContent = '';
@@ -917,9 +919,9 @@
           try {
             nevent = NT.nip19.neventEncode({ id: signed.id, author: signed.pubkey, relays: [] });
           } catch (_) {}
-          body.disabled = true;
+          commentEditor.editor.contentEditable = 'false';
           tabBar.classList.add('hidden');
-          body.classList.add('hidden');
+          commentEditor.wrap.classList.add('hidden');
           previewPane.classList.add('hidden');
           post.classList.add('hidden');
           done.classList.remove('hidden');
@@ -946,7 +948,7 @@
         author,
         targetBlock, // above the tabs: the subject, not one of the two views
         tabBar,
-        body,
+        commentEditor.wrap,
         previewPane,
         err,
         done,
@@ -960,13 +962,13 @@
         if (error) {
           err.textContent = error;
           tabBar.classList.add('hidden');
-          body.classList.add('hidden');
+          commentEditor.wrap.classList.add('hidden');
           return;
         }
         target = url;
         post.disabled = false;
         renderTarget(); // shows the URL and a loading card immediately
-        body.focus();
+        commentEditor.focus();
         // The card fills in when the fetch lands; the Write pane is usable throughout
         // and already shows the URL, so nothing waits on the network.
         call({ type: 'SIDECAR_FETCH_OG', url: target })
@@ -5018,6 +5020,228 @@
     if (last < text.length) appendText(text.slice(last));
   }
 
+  // A rich text box with @mention autocomplete and pills, shared by the note
+  // composer and the page-comment modal. Owns its own dropdown state so two can
+  // coexist; the caller supplies `onChange` for whatever it does with the text
+  // (draft autosave, enabling a Post button, repainting a preview).
+  //
+  // Returns { wrap, editor, getText, setText, focus, close }. Append `wrap` —
+  // not `editor` — since the dropdown positions itself against the wrapper.
+  function createMentionEditor(opts) {
+    const onChange = (opts && opts.onChange) || (() => {});
+    const editor = h('div', { className: 'compose-text compose-editor is-empty', contentEditable: 'true' });
+    editor.dataset.placeholder = (opts && opts.placeholder) || '';
+    const wrap = h('div', { className: 'compose-editor-wrap' });
+    wrap.append(editor);
+
+    let acDropdown = null, acResults = [], acIndex = 0;
+    let acSeq = 0, acSuggestTimer = null; // guard stale async + debounce global search
+
+    function syncEmptyClass() {
+      const isEmpty = !editor.textContent.trim() && !editor.querySelector('[data-bech32]');
+      editor.classList.toggle('is-empty', isEmpty);
+      if (isEmpty) editor.innerHTML = '';
+    }
+
+    // Report the text upward, keeping the placeholder state in sync first.
+    function emit() {
+      const text = serializeEditor(editor);
+      syncEmptyClass();
+      onChange(text);
+    }
+
+    function getCaretContext() {
+      const sel = window.getSelection();
+      if (!sel.rangeCount) return null;
+      const range = sel.getRangeAt(0);
+      if (!range.collapsed) return null;
+      const node = range.startContainer;
+      if (node.nodeType !== Node.TEXT_NODE || !editor.contains(node)) return null;
+      const before = node.textContent.slice(0, range.startOffset);
+      const match = before.match(/@([^\s@]*)$/);
+      if (!match) return null;
+      return { node, query: match[1] };
+    }
+
+    function closeAcDropdown() {
+      if (acDropdown) { acDropdown.remove(); acDropdown = null; }
+      acResults = []; acIndex = 0;
+    }
+
+    function updateAcActiveItem() {
+      if (!acDropdown) return;
+      acDropdown.querySelectorAll('.ac-item').forEach((el, i) => el.classList.toggle('active', i === acIndex));
+    }
+
+    function selectAcItem(contact, query) {
+      const sel = window.getSelection();
+      if (!sel.rangeCount) return;
+      const range = sel.getRangeAt(0);
+      const node = range.startContainer;
+      if (node.nodeType !== Node.TEXT_NODE) return;
+      const offset = range.startOffset;
+      // Text before the '@'. Trim any trailing whitespace and re-add exactly one
+      // space, so the mention is always preceded by a single space (or nothing
+      // at line start). Trimming the whole run both collapses a stray double
+      // space and sidesteps the old single-code-unit check, which mis-read an
+      // emoji's surrogate half (e.g. 🤝) as a non-space char and inserted an
+      // extra space.
+      const beforeAt = node.textContent.slice(0, Math.max(0, offset - (query.length + 1)));
+      const trimmed = beforeAt.replace(/\s+$/, '');
+      const atStart = trimmed.length;
+      const needsLeadingSpace = trimmed.length > 0;
+      range.setStart(node, atStart);
+      range.setEnd(node, offset);
+      range.deleteContents();
+      const pill = document.createElement('span');
+      pill.className = 'mention-pill';
+      pill.contentEditable = 'false';
+      pill.dataset.bech32 = 'nostr:' + NT.nip19.npubEncode(contact.pubkey);
+      pill.textContent = '@' + contact.name;
+      if (needsLeadingSpace) range.insertNode(document.createTextNode(' '));
+      range.collapse(false);
+      range.insertNode(pill);
+      // NBSP after pill: never collapsed by the browser, normalized to space by serializer.
+      const trailingSpace = document.createTextNode(' ');
+      range.setStartAfter(pill);
+      range.insertNode(trailingSpace);
+      range.setStartAfter(trailingSpace);
+      range.collapse(true);
+      sel.removeAllRanges();
+      sel.addRange(range);
+      closeAcDropdown();
+      emit();
+    }
+
+    // Anchor the dropdown just under the caret line rather than the bottom of
+    // the (tall) editor box. Falls back to the CSS default if no caret rect.
+    function positionAcDropdown() {
+      if (!acDropdown) return;
+      try {
+        const sel = window.getSelection();
+        if (!sel.rangeCount) return;
+        const r = sel.getRangeAt(0).getBoundingClientRect();
+        if (!r || (!r.top && !r.bottom)) return;
+        const wrapRect = wrap.getBoundingClientRect();
+        acDropdown.style.top = Math.round(r.bottom - wrapRect.top + 4) + 'px';
+      } catch (_) {}
+    }
+
+    // `loading` shows a "Searching Nostr…" footer while the global lookup runs,
+    // and keeps the dropdown open even when there are no local matches yet.
+    function renderAcResults(items, ctx, loading) {
+      acResults = items;
+      if (!acResults.length && !loading) { closeAcDropdown(); return; }
+      acIndex = Math.max(0, Math.min(acIndex, Math.max(0, acResults.length - 1)));
+      if (!acDropdown) {
+        acDropdown = h('div', { className: 'ac-dropdown' });
+        wrap.append(acDropdown);
+      }
+      positionAcDropdown();
+      acDropdown.innerHTML = '';
+      acResults.forEach((c, i) => {
+        const item = h('div', { className: 'ac-item' + (i === acIndex ? ' active' : '') });
+        const av = h('span', { className: 'ac-item-av' });
+        applyAvatar(av, c.picture ? { picture: c.picture } : {});
+        item.append(av, h('span', { className: 'ac-item-name', textContent: '@' + c.name }));
+        item.addEventListener('mousedown', (e) => {
+          e.preventDefault();
+          const fresh = getCaretContext();
+          selectAcItem(c, fresh ? fresh.query : ctx.query);
+        });
+        acDropdown.append(item);
+      });
+      if (loading) {
+        acDropdown.append(h('div', { className: 'ac-loading' }, [
+          h('span', { className: 'ac-spinner' }),
+          h('span', { textContent: acResults.length ? 'Searching more…' : 'Searching Nostr…' }),
+        ]));
+      }
+    }
+
+    // Two async sources feed the dropdown: your follow list (instant from
+    // cache, else a slow first relay load) and a global Nostr search. NEVER
+    // block the UI on the follow list — the first load hits relays and can take
+    // many seconds. Paint immediately (with a spinner), then repaint as each
+    // source resolves. `paint()` renders the deduped union + loading state.
+    async function updateAcDropdown() {
+      const ctx = getCaretContext();
+      if (!ctx || ctx.query.length === 0) { closeAcDropdown(); return; }
+      const seq = ++acSeq;
+      const q = ctx.query.toLowerCase();
+      const willSearchGlobal = ctx.query.length >= 2 && naAvailable();
+
+      const matchFollows = (list) => list.filter((c) => c.name && c.name.toLowerCase().includes(q));
+      let followMatches = [];
+      let globals = [];
+      let globalPending = willSearchGlobal;
+      const paint = () => {
+        if (seq !== acSeq) return;
+        const seen = new Set(followMatches.map((c) => c.pubkey));
+        const merged = followMatches.slice();
+        for (const g of globals) { if (!seen.has(g.pubkey)) { seen.add(g.pubkey); merged.push(g); } }
+        renderAcResults(merged.slice(0, 8), ctx, globalPending);
+      };
+
+      // Follows: use the cache synchronously if present; otherwise load in the
+      // background and repaint when ready (no await here).
+      const cached = (followListCache && followListPubkey === state.activePubkey) ? followListCache : null;
+      if (cached) followMatches = matchFollows(cached);
+      paint(); // instant feedback: local matches (maybe none) + spinner if searching
+      if (!cached) {
+        getFollowList().then((list) => { if (seq === acSeq) { followMatches = matchFollows(list); paint(); } });
+      }
+
+      // Global search across all of Nostr so you can tag people you don't
+      // follow. Debounced; best-effort — a failure/rate-limit just clears the
+      // spinner and leaves the follow matches.
+      if (willSearchGlobal) {
+        if (acSuggestTimer) clearTimeout(acSuggestTimer);
+        acSuggestTimer = setTimeout(async () => {
+          const res = await naSuggest(ctx.query);
+          if (seq !== acSeq) return; // query changed since
+          globals = res;
+          globalPending = false;
+          paint();
+        }, 250);
+      }
+    }
+
+    editor.addEventListener('input', () => {
+      emit();
+      updateAcDropdown();
+      noteActivity(); // composing counts as activity — keep auto-lock at bay
+    });
+
+    editor.addEventListener('keydown', (e) => {
+      if (!acDropdown) return;
+      if (e.key === 'ArrowDown') { e.preventDefault(); acIndex = Math.min(acIndex + 1, acResults.length - 1); updateAcActiveItem(); }
+      else if (e.key === 'ArrowUp') { e.preventDefault(); acIndex = Math.max(acIndex - 1, 0); updateAcActiveItem(); }
+      else if (e.key === 'Enter' || e.key === 'Tab') {
+        if (acResults[acIndex]) { e.preventDefault(); const ctx = getCaretContext(); selectAcItem(acResults[acIndex], ctx ? ctx.query : ''); }
+      } else if (e.key === 'Escape') { e.preventDefault(); closeAcDropdown(); }
+    });
+
+    editor.addEventListener('blur', () => setTimeout(closeAcDropdown, 150));
+
+    return {
+      wrap,
+      editor,
+      getText: () => serializeEditor(editor),
+      // Re-read the editor after the caller mutated its DOM directly (e.g.
+      // appending an uploaded media URL) so the text, placeholder and any
+      // onChange-driven state agree with what's on screen.
+      sync: emit,
+      setText(text) {
+        editor.innerHTML = '';
+        if (text) hydrateEditorFromText(editor, text);
+        syncEmptyClass();
+      },
+      focus: () => editor.focus(),
+      close: closeAcDropdown,
+    };
+  }
+
   // ---- composer draft autosave (per account, in chrome.storage.local) ----
   function loadComposeDraft(pubkey) {
     return new Promise((res) => {
@@ -5094,202 +5318,15 @@
       const tabPreview = h('button', { className: 'compose-tab', textContent: 'Preview' });
       const tabBar = h('div', { className: 'compose-tabs' }, [tabWrite, tabPreview]);
 
-      const editor = h('div', { className: 'compose-text compose-editor is-empty', contentEditable: 'true' });
-      editor.dataset.placeholder = "What’s on your mind?";
-      if (draft.text) { hydrateEditorFromText(editor, draft.text); editor.classList.remove('is-empty'); }
-
-      const editorWrap = h('div', { className: 'compose-editor-wrap' });
-      editorWrap.append(editor);
-
-      // ---- @mention autocomplete ----
-      let acDropdown = null, acResults = [], acIndex = 0;
-      let acSeq = 0, acSuggestTimer = null; // guard stale async + debounce global search
-
-      function getCaretContext() {
-        const sel = window.getSelection();
-        if (!sel.rangeCount) return null;
-        const range = sel.getRangeAt(0);
-        if (!range.collapsed) return null;
-        const node = range.startContainer;
-        if (node.nodeType !== Node.TEXT_NODE || !editor.contains(node)) return null;
-        const before = node.textContent.slice(0, range.startOffset);
-        const match = before.match(/@([^\s@]*)$/);
-        if (!match) return null;
-        return { node, query: match[1] };
-      }
-
-      function closeAcDropdown() {
-        if (acDropdown) { acDropdown.remove(); acDropdown = null; }
-        acResults = []; acIndex = 0;
-      }
-
-      function updateAcActiveItem() {
-        if (!acDropdown) return;
-        acDropdown.querySelectorAll('.ac-item').forEach((el, i) => el.classList.toggle('active', i === acIndex));
-      }
-
-      function selectAcItem(contact, query) {
-        const sel = window.getSelection();
-        if (!sel.rangeCount) return;
-        const range = sel.getRangeAt(0);
-        const node = range.startContainer;
-        if (node.nodeType !== Node.TEXT_NODE) return;
-        const offset = range.startOffset;
-        // Text before the '@'. Trim any trailing whitespace and re-add exactly one
-        // space, so the mention is always preceded by a single space (or nothing
-        // at line start). Trimming the whole run both collapses a stray double
-        // space and sidesteps the old single-code-unit check, which mis-read an
-        // emoji's surrogate half (e.g. 🤝) as a non-space char and inserted an
-        // extra space.
-        const beforeAt = node.textContent.slice(0, Math.max(0, offset - (query.length + 1)));
-        const trimmed = beforeAt.replace(/\s+$/, '');
-        const atStart = trimmed.length;
-        const needsLeadingSpace = trimmed.length > 0;
-        range.setStart(node, atStart);
-        range.setEnd(node, offset);
-        range.deleteContents();
-        const pill = document.createElement('span');
-        pill.className = 'mention-pill';
-        pill.contentEditable = 'false';
-        pill.dataset.bech32 = 'nostr:' + NT.nip19.npubEncode(contact.pubkey);
-        pill.textContent = '@' + contact.name;
-        if (needsLeadingSpace) range.insertNode(document.createTextNode(' '));
-        range.collapse(false);
-        range.insertNode(pill);
-        // NBSP after pill: never collapsed by the browser, normalized to space by serializer.
-        const trailingSpace = document.createTextNode(' ');
-        range.setStartAfter(pill);
-        range.insertNode(trailingSpace);
-        range.setStartAfter(trailingSpace);
-        range.collapse(true);
-        sel.removeAllRanges();
-        sel.addRange(range);
-        closeAcDropdown();
-        draft.text = serializeEditor(editor);
-        syncEmptyClass();
-        updatePostState();
-        scheduleSave();
-      }
-
-      // Anchor the dropdown just under the caret line rather than the bottom of
-      // the (tall) editor box. Falls back to the CSS default if no caret rect.
-      function positionAcDropdown() {
-        if (!acDropdown) return;
-        try {
-          const sel = window.getSelection();
-          if (!sel.rangeCount) return;
-          const r = sel.getRangeAt(0).getBoundingClientRect();
-          if (!r || (!r.top && !r.bottom)) return;
-          const wrap = editorWrap.getBoundingClientRect();
-          acDropdown.style.top = Math.round(r.bottom - wrap.top + 4) + 'px';
-        } catch (_) {}
-      }
-
-      // `loading` shows a "Searching Nostr…" footer while the global lookup runs,
-      // and keeps the dropdown open even when there are no local matches yet.
-      function renderAcResults(items, ctx, loading) {
-        acResults = items;
-        if (!acResults.length && !loading) { closeAcDropdown(); return; }
-        acIndex = Math.max(0, Math.min(acIndex, Math.max(0, acResults.length - 1)));
-        if (!acDropdown) {
-          acDropdown = h('div', { className: 'ac-dropdown' });
-          editorWrap.append(acDropdown);
-        }
-        positionAcDropdown();
-        acDropdown.innerHTML = '';
-        acResults.forEach((c, i) => {
-          const item = h('div', { className: 'ac-item' + (i === acIndex ? ' active' : '') });
-          const av = h('span', { className: 'ac-item-av' });
-          applyAvatar(av, c.picture ? { picture: c.picture } : {});
-          item.append(av, h('span', { className: 'ac-item-name', textContent: '@' + c.name }));
-          item.addEventListener('mousedown', (e) => {
-            e.preventDefault();
-            const fresh = getCaretContext();
-            selectAcItem(c, fresh ? fresh.query : ctx.query);
-          });
-          acDropdown.append(item);
-        });
-        if (loading) {
-          acDropdown.append(h('div', { className: 'ac-loading' }, [
-            h('span', { className: 'ac-spinner' }),
-            h('span', { textContent: acResults.length ? 'Searching more…' : 'Searching Nostr…' }),
-          ]));
-        }
-      }
-
-      // Two async sources feed the dropdown: your follow list (instant from
-      // cache, else a slow first relay load) and a global Nostr search. NEVER
-      // block the UI on the follow list — the first load hits relays and can take
-      // many seconds. Paint immediately (with a spinner), then repaint as each
-      // source resolves. `paint()` renders the deduped union + loading state.
-      async function updateAcDropdown() {
-        const ctx = getCaretContext();
-        if (!ctx || ctx.query.length === 0) { closeAcDropdown(); return; }
-        const seq = ++acSeq;
-        const q = ctx.query.toLowerCase();
-        const willSearchGlobal = ctx.query.length >= 2 && naAvailable();
-
-        const matchFollows = (list) => list.filter((c) => c.name && c.name.toLowerCase().includes(q));
-        let followMatches = [];
-        let globals = [];
-        let globalPending = willSearchGlobal;
-        const paint = () => {
-          if (seq !== acSeq) return;
-          const seen = new Set(followMatches.map((c) => c.pubkey));
-          const merged = followMatches.slice();
-          for (const g of globals) { if (!seen.has(g.pubkey)) { seen.add(g.pubkey); merged.push(g); } }
-          renderAcResults(merged.slice(0, 8), ctx, globalPending);
-        };
-
-        // Follows: use the cache synchronously if present; otherwise load in the
-        // background and repaint when ready (no await here).
-        const cached = (followListCache && followListPubkey === state.activePubkey) ? followListCache : null;
-        if (cached) followMatches = matchFollows(cached);
-        paint(); // instant feedback: local matches (maybe none) + spinner if searching
-        if (!cached) {
-          getFollowList().then((list) => { if (seq === acSeq) { followMatches = matchFollows(list); paint(); } });
-        }
-
-        // Global search across all of Nostr so you can tag people you don't
-        // follow. Debounced; best-effort — a failure/rate-limit just clears the
-        // spinner and leaves the follow matches.
-        if (willSearchGlobal) {
-          if (acSuggestTimer) clearTimeout(acSuggestTimer);
-          acSuggestTimer = setTimeout(async () => {
-            const res = await naSuggest(ctx.query);
-            if (seq !== acSeq) return; // query changed since
-            globals = res;
-            globalPending = false;
-            paint();
-          }, 250);
-        }
-      }
-
-      function syncEmptyClass() {
-        const isEmpty = !editor.textContent.trim() && !editor.querySelector('[data-bech32]');
-        editor.classList.toggle('is-empty', isEmpty);
-        if (isEmpty) editor.innerHTML = '';
-      }
-
-      editor.addEventListener('input', () => {
-        draft.text = serializeEditor(editor);
-        syncEmptyClass();
-        updatePostState();
-        updateAcDropdown();
-        scheduleSave();
-        noteActivity(); // composing counts as activity — keep auto-lock at bay
+      // Rich text box with @mention autocomplete, shared with the page-comment
+      // modal. Edits flow back through onChange into the draft + Post button.
+      const mentionEditor = createMentionEditor({
+        placeholder: "What’s on your mind?",
+        onChange: (text) => { draft.text = text; updatePostState(); scheduleSave(); },
       });
-
-      editor.addEventListener('keydown', (e) => {
-        if (!acDropdown) return;
-        if (e.key === 'ArrowDown') { e.preventDefault(); acIndex = Math.min(acIndex + 1, acResults.length - 1); updateAcActiveItem(); }
-        else if (e.key === 'ArrowUp') { e.preventDefault(); acIndex = Math.max(acIndex - 1, 0); updateAcActiveItem(); }
-        else if (e.key === 'Enter' || e.key === 'Tab') {
-          if (acResults[acIndex]) { e.preventDefault(); const ctx = getCaretContext(); selectAcItem(acResults[acIndex], ctx ? ctx.query : ''); }
-        } else if (e.key === 'Escape') { e.preventDefault(); closeAcDropdown(); }
-      });
-
-      editor.addEventListener('blur', () => setTimeout(closeAcDropdown, 150));
+      mentionEditor.setText(draft.text);
+      const editor = mentionEditor.editor;
+      const editorWrap = mentionEditor.wrap;
 
       const previewPane = h('div', { className: 'compose-preview hidden' });
       function renderPreview() {
@@ -5311,7 +5348,7 @@
         thumbs.classList.toggle('hidden', p);
         addBtn.classList.toggle('hidden', p);
         previewPane.classList.toggle('hidden', !p);
-        if (p) { closeAcDropdown(); renderPreview(); }
+        if (p) { mentionEditor.close(); renderPreview(); }
       }
       tabWrite.addEventListener('click', () => setMode(false));
       tabPreview.addEventListener('click', () => setMode(true));
@@ -5340,11 +5377,8 @@
               }
             }
             draft.media.splice(i, 1);
-            draft.text = serializeEditor(editor);
-            syncEmptyClass();
+            mentionEditor.sync();
             renderThumbs();
-            updatePostState();
-            scheduleSave();
           });
           cell.append(rm);
           thumbs.append(cell);
@@ -5383,11 +5417,8 @@
           const url = await uploadMedia(file, pubkey);
           draft.media.push({ url, isVideo: file.type.startsWith('video/') });
           appendMediaUrl(url);
-          draft.text = serializeEditor(editor);
-          syncEmptyClass();
+          mentionEditor.sync();
           renderThumbs();
-          updatePostState();
-          scheduleSave();
         } catch (e) {
           err.textContent = e.message;
           toast(e.message, 'error');
@@ -5419,11 +5450,8 @@
             draft.media.push({ url, isVideo: false });
             appendMediaUrl(url);
           }
-          draft.text = serializeEditor(editor);
-          syncEmptyClass();
+          mentionEditor.sync();
           renderThumbs();
-          updatePostState();
-          scheduleSave();
         } catch (e) {
           err.textContent = e.message;
           toast(e.message, 'error');

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -905,7 +905,13 @@
         post.disabled = true;
         post.textContent = 'Posting\u2026';
         try {
-          const signed = await call({ type: 'SIDECAR_OWNER_SIGN', event: buildWebComment(target, text) });
+          // Same opt-out the note composer honours (Settings → "Show client tag").
+          const settings = await call({ type: 'SIDECAR_GET_SETTINGS' });
+          const withClient = !(settings && settings.showClientTag === false);
+          const signed = await call({
+            type: 'SIDECAR_OWNER_SIGN',
+            event: buildWebComment(target, text, withClient),
+          });
           await publishSigned(signed);
           let nevent = '';
           try {
@@ -1662,13 +1668,23 @@
     } catch (_) { return raw; }
   }
 
-  function buildWebComment(url, content) {
+  // `includeClientTag` comes from the same Settings toggle that governs notes, so
+  // the switch means what it says rather than covering only kind 1. Verified that
+  // Jumble renders it: ReplyNote and NotePage both mount <ClientTag> with no kind
+  // gate, so this shows as "via Sidecar" beside the name in a thread.
+  function buildWebComment(url, content, includeClientTag) {
+    // Root and parent are identical: this is a top-level comment on the page, not a
+    // reply to another comment.
+    const tags = [['I', url], ['K', 'web'], ['i', url], ['k', 'web']];
+    // Appended rather than prepended (notes put it first): these four scope tags are
+    // what was verified byte-for-byte against a real Jumble comment, so keeping them
+    // as the leading shape means a future diff against one stays clean. The client
+    // tag is metadata and position carries no meaning — readers use find().
+    if (includeClientTag) tags.push(CLIENT_TAG.slice());
     return {
       kind: WEB_COMMENT_KIND,
       created_at: Math.floor(Date.now() / 1000),
-      // Root and parent are identical: this is a top-level comment on the page,
-      // not a reply to another comment.
-      tags: [['I', url], ['K', 'web'], ['i', url], ['k', 'web']],
+      tags,
       content: content,
     };
   }

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -805,25 +805,80 @@
   });
 
   // Comment on the page in the active tab. Opened from the topbar pencil.
+  //
+  // Deliberately built to the New-note convention rather than its own shape: same
+  // "Posting as" header, same Write/Preview tabs, same link card, same button
+  // order. A second composer that looked different would read as a different app.
   function webCommentModal() {
     openModal((modal) => {
       const err = h('div', { className: 'error' });
-      const urlLine = h('div', { className: 'webcomment-url', textContent: 'Reading the current tab…' });
+
+      // Who this posts as. Same block the note composer uses — a public comment
+      // signed by an account you might not have realized was active is exactly the
+      // mistake this prevents.
+      const active = state.accounts.find((a) => a.pubkey === state.activePubkey);
+      const author = h('div', { className: 'compose-author' });
+      author.append(avatarEl(active || {}, 'compose-author-av'));
+      author.append(
+        h('div', { className: 'compose-author-info' }, [
+          h('span', { className: 'compose-author-eyebrow', textContent: 'Commenting as' }),
+          h('span', { className: 'compose-author-name', textContent: active ? displayName(active) : '\u2014' }),
+        ])
+      );
+
+      const tabWrite = h('button', { className: 'compose-tab active', textContent: 'Write' });
+      const tabPreview = h('button', { className: 'compose-tab', textContent: 'Preview' });
+      const tabBar = h('div', { className: 'compose-tabs' }, [tabWrite, tabPreview]);
+
       const body = h('textarea', {
         className: 'compose-text webcomment-text',
-        placeholder: 'Write a comment about this page…',
+        placeholder: 'Write a comment about this page\u2026',
       });
+      const previewPane = h('div', { className: 'compose-preview hidden' });
+
       const post = h('button', { className: 'primary', textContent: 'Post comment' });
       post.disabled = true;
       const cancel = h('button', { className: 'ghost', textContent: 'Cancel' });
       cancel.addEventListener('click', closeModal);
 
-      let target = null; // the normalized URL, once known
+      let target = null;   // the normalized URL this comments on
+      let ogMeta;          // undefined = not fetched, null = no preview available
 
-      // Shown after a successful post: the two Jumble views, since that's where a
-      // kind:1111 on a web target is actually readable.
+      // The page being commented on, as the card the composer would draw for it.
+      // The raw URL only appears as a caption underneath: it IS what gets published,
+      // so it can't be hidden, but it shouldn't be the headline either.
+      function renderPreview() {
+        previewPane.innerHTML = '';
+        if (!target) {
+          previewPane.append(h('p', { className: 'hint', textContent: 'No page to comment on.' }));
+          return;
+        }
+        if (ogMeta === undefined) {
+          previewPane.append(h('div', { className: 'link-card loading' }));
+        } else if (ogMeta) {
+          const card = h('a', { className: 'link-card' });
+          renderLinkCard(card, target, ogMeta);
+          previewPane.append(card);
+        }
+        previewPane.append(h('div', { className: 'webcomment-url', textContent: target }));
+        const text = body.value.trim();
+        if (text) previewPane.append(h('div', { className: 'webcomment-preview-text', textContent: text }));
+      }
+
+      function showTab(which) {
+        const preview = which === 'preview';
+        tabWrite.classList.toggle('active', !preview);
+        tabPreview.classList.toggle('active', preview);
+        body.classList.toggle('hidden', preview);
+        previewPane.classList.toggle('hidden', !preview);
+        if (preview) renderPreview();
+      }
+      tabWrite.addEventListener('click', () => showTab('write'));
+      tabPreview.addEventListener('click', () => showTab('preview'));
+
+      // Shown after posting: both links point at Jumble, since almost nothing else
+      // renders a kind:1111 over a web target.
       const done = h('div', { className: 'webcomment-done hidden' });
-
       const link = (label, href) => {
         const a = h('a', { className: 'explore-link', href: '#', textContent: label });
         a.addEventListener('click', (e) => { e.preventDefault(); chrome.tabs.create({ url: href }); });
@@ -836,22 +891,24 @@
         if (!text) return (err.textContent = 'Write something first.');
         err.textContent = '';
         post.disabled = true;
-        post.textContent = 'Posting…';
+        post.textContent = 'Posting\u2026';
         try {
           const signed = await call({ type: 'SIDECAR_OWNER_SIGN', event: buildWebComment(target, text) });
           await publishSigned(signed);
-          // nevent rather than note: the relay hint is what lets Jumble find it.
           let nevent = '';
           try {
             nevent = NT.nip19.neventEncode({ id: signed.id, author: signed.pubkey, relays: [] });
           } catch (_) {}
           body.disabled = true;
+          tabBar.classList.add('hidden');
+          body.classList.add('hidden');
+          previewPane.classList.add('hidden');
           post.classList.add('hidden');
           done.classList.remove('hidden');
           done.append(
             h('div', { className: 'webcomment-done-title', textContent: 'Comment posted' }),
-            nevent ? link('View your comment →', jumbleNoteUrl(nevent)) : document.createTextNode(''),
-            link('See all comments on this page →', jumbleThreadUrl(target))
+            nevent ? link('View your comment \u2192', jumbleNoteUrl(nevent)) : document.createTextNode(''),
+            link('See all comments on this page \u2192', jumbleThreadUrl(target))
           );
           cancel.textContent = 'Close';
           toast('Comment posted', 'success');
@@ -864,37 +921,34 @@
 
       modal.append(
         h('h3', { textContent: 'Comment on this page' }),
-        h('p', {
-          className: 'hint compact',
-          textContent: 'A public Nostr comment attached to this page’s address. Anyone can see it, '
-            + 'including the address itself.',
-        }),
-        urlLine,
+        author,
+        tabBar,
         body,
+        previewPane,
         err,
         done,
-        h('div', { className: 'actions setup-actions' }, [cancel, post])
+        h('div', { className: 'actions' }, [post, cancel])
       );
 
-      // Resolve the tab AFTER the modal is up, so the URL is never read
-      // speculatively — and show exactly what will be published.
+      // Resolve the tab only after the modal is up \u2014 never speculatively, since
+      // this URL is about to be published.
       activeTabUrl().then((raw) => {
-        if (!raw) {
-          urlLine.textContent = 'Could not read the current tab.';
-          urlLine.classList.add('bad');
-          return;
-        }
-        const { url, error } = normalizeWebUrl(raw);
+        const { url, error } = normalizeWebUrl(unwrapJumbleTarget(raw));
         if (error) {
-          urlLine.textContent = error;
-          urlLine.classList.add('bad');
+          err.textContent = error;
+          tabBar.classList.add('hidden');
+          body.classList.add('hidden');
           return;
         }
         target = url;
-        urlLine.textContent = url;
-        urlLine.classList.remove('bad');
         post.disabled = false;
         body.focus();
+        // Fetch the card in the background; the Write tab is usable immediately and
+        // Preview fills in when it lands.
+        call({ type: 'SIDECAR_FETCH_OG', url: target })
+          .then((meta) => { ogMeta = meta || null; })
+          .catch(() => { ogMeta = null; })
+          .then(() => { if (!previewPane.classList.contains('hidden')) renderPreview(); });
       });
     });
   }
@@ -1567,6 +1621,27 @@
     // A bare origin normalizes to a trailing slash; a path shouldn't gain one.
     if (u.pathname !== '/' && out.endsWith('/')) out = out.slice(0, -1);
     return { url: out };
+  }
+
+  // If the tab is already a Jumble external-content view, comment on the ARTICLE it
+  // is showing rather than on the Jumble URL.
+  //
+  // Without this, reading a thread on Jumble and then commenting from Sidecar starts
+  // a second thread addressed to `jumble.social/external-content?id=…` — which is a
+  // different identifier, so it never joins the conversation the user is looking at.
+  // Silent and confusing; caught because a screenshot happened to be taken on that
+  // exact page.
+  function unwrapJumbleTarget(raw) {
+    try {
+      const u = new URL(String(raw || ''));
+      if (!/(^|\.)jumble\.social$/i.test(u.hostname)) return raw;
+      if (u.pathname !== '/external-content') return raw;
+      const inner = u.searchParams.get('id');
+      // Only unwrap to something that is itself a web page — an `id` of anything
+      // else (an npub, a note, junk) is left alone for normalizeWebUrl to refuse.
+      if (inner && /^https?:\/\//i.test(inner)) return inner;
+      return raw;
+    } catch (_) { return raw; }
   }
 
   function buildWebComment(url, content) {

--- a/styles.css
+++ b/styles.css
@@ -1157,6 +1157,24 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
 .modal label { color: var(--muted); font-size: 12px; letter-spacing: 0.03em; }
 .modal .actions { display: flex; flex-direction: column; gap: 8px; margin-top: 6px; }
 
+/* ---- comment on this page (NIP-22 kind 1111) ---- */
+/* The URL is shown verbatim because posting publishes it. Explicitly selectable —
+   this is exactly the kind of content the body-level `user-select: none` must not
+   swallow, since the whole point is being able to check it before committing. */
+.webcomment-url {
+  -webkit-user-select: text; user-select: text;
+  font-family: var(--font-ui); font-size: 11.5px; line-height: 1.45;
+  color: var(--text-2); word-break: break-all;
+  padding: 8px 10px; margin: 2px 0 10px; border-radius: 8px;
+  background: rgba(var(--well-rgb), 0.6);
+  border: 1px solid var(--border);
+}
+.webcomment-url.bad { color: var(--warn); border-color: rgba(var(--warn-rgb), 0.4); }
+.webcomment-text { min-height: 96px; width: 100%; }
+.webcomment-done { display: flex; flex-direction: column; gap: 7px; margin-top: 6px; }
+.webcomment-done-title { font-weight: 600; font-size: 13.5px; color: var(--success); }
+.webcomment-done .explore-link { text-align: left; }
+
 /* first-run profile setup wizard */
 .setup-progress { font-size: 10.5px; font-weight: 600; letter-spacing: 0.14em; text-transform: uppercase; color: var(--muted); margin-bottom: 6px; }
 .modal .setup-actions { flex-direction: row; margin-top: 18px; }

--- a/styles.css
+++ b/styles.css
@@ -1173,7 +1173,8 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
   font-family: var(--font-ui); font-size: 11px; line-height: 1.45;
   color: var(--faint); word-break: break-all; margin-top: 7px;
 }
-.webcomment-text { min-height: 96px; width: 100%; }
+/* The comment box itself needs no rules here: it IS the note composer's editor
+   (.compose-text.compose-editor), created by createMentionEditor. */
 /* The comment itself, shown under the card in Preview so the whole post can be read
    the way it will appear. */
 /* No margin, padding or border of its own: .compose-preview already supplies the

--- a/styles.css
+++ b/styles.css
@@ -1158,19 +1158,26 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
 .modal .actions { display: flex; flex-direction: column; gap: 8px; margin-top: 6px; }
 
 /* ---- comment on this page (NIP-22 kind 1111) ---- */
-/* The URL is shown verbatim because posting publishes it. Explicitly selectable —
-   this is exactly the kind of content the body-level `user-select: none` must not
-   swallow, since the whole point is being able to check it before committing. */
+/* Follows the note composer: same author header, tabs and link card. Only the bits
+   with no equivalent there are defined here.
+   The URL is a caption under the card rather than a box of its own — it IS what gets
+   published so it can't be hidden, but the card is what tells you which page this
+   is. Explicitly selectable: this is exactly the content the body-level
+   `user-select: none` must not swallow. */
 .webcomment-url {
   -webkit-user-select: text; user-select: text;
-  font-family: var(--font-ui); font-size: 11.5px; line-height: 1.45;
-  color: var(--text-2); word-break: break-all;
-  padding: 8px 10px; margin: 2px 0 10px; border-radius: 8px;
-  background: rgba(var(--well-rgb), 0.6);
-  border: 1px solid var(--border);
+  font-family: var(--font-ui); font-size: 11px; line-height: 1.45;
+  color: var(--faint); word-break: break-all; margin-top: 7px;
 }
-.webcomment-url.bad { color: var(--warn); border-color: rgba(var(--warn-rgb), 0.4); }
 .webcomment-text { min-height: 96px; width: 100%; }
+/* The comment itself, shown under the card in Preview so the whole post can be read
+   the way it will appear. */
+.webcomment-preview-text {
+  -webkit-user-select: text; user-select: text;
+  font-family: var(--font-ui); font-size: 13.5px; line-height: 1.5;
+  color: var(--text); margin-top: 12px; padding-top: 12px;
+  border-top: 1px solid var(--border); white-space: pre-wrap; word-break: break-word;
+}
 .webcomment-done { display: flex; flex-direction: column; gap: 7px; margin-top: 6px; }
 .webcomment-done-title { font-weight: 600; font-size: 13.5px; color: var(--success); }
 .webcomment-done .explore-link { text-align: left; }

--- a/styles.css
+++ b/styles.css
@@ -1176,11 +1176,14 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
 .webcomment-text { min-height: 96px; width: 100%; }
 /* The comment itself, shown under the card in Preview so the whole post can be read
    the way it will appear. */
+/* No margin, padding or border of its own: .compose-preview already supplies the
+   box. The separator this used to carry existed to divide the comment from the link
+   card when both shared the preview pane — moving the card above the tabs left it
+   as a stray rule and a doubled 12px above the first line. */
 .webcomment-preview-text {
   -webkit-user-select: text; user-select: text;
   font-family: var(--font-ui); font-size: 13.5px; line-height: 1.5;
-  color: var(--text); margin-top: 12px; padding-top: 12px;
-  border-top: 1px solid var(--border); white-space: pre-wrap; word-break: break-word;
+  color: var(--text); white-space: pre-wrap; word-break: break-word;
 }
 .webcomment-done { display: flex; flex-direction: column; gap: 7px; margin-top: 6px; }
 .webcomment-done-title { font-weight: 600; font-size: 13.5px; color: var(--success); }

--- a/styles.css
+++ b/styles.css
@@ -1164,6 +1164,10 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
    published so it can't be hidden, but the card is what tells you which page this
    is. Explicitly selectable: this is exactly the content the body-level
    `user-select: none` must not swallow. */
+/* The subject of the comment, pinned above the tabs — it's context, so it stays put
+   while Write/Preview switch beneath it. */
+.webcomment-target { margin: 4px 0 12px; }
+.webcomment-target:empty { display: none; }
 .webcomment-url {
   -webkit-user-select: text; user-select: text;
   font-family: var(--font-ui); font-size: 11px; line-height: 1.45;

--- a/test/web-comment.test.js
+++ b/test/web-comment.test.js
@@ -38,7 +38,8 @@ vm.runInContext(
   lift(/const TRACKING_PARAMS = \[[\s\S]*?\];/, 'TRACKING_PARAMS') + '\n' +
   lift(/function unwrapJumbleTarget\(raw\)\s*\{[\s\S]*?\n  \}/, 'unwrapJumbleTarget') + '\n' +
   lift(/function normalizeWebUrl\(raw\)\s*\{[\s\S]*?\n  \}/, 'normalizeWebUrl') + '\n' +
-  lift(/function buildWebComment\(url, content\)\s*\{[\s\S]*?\n  \}/, 'buildWebComment') + '\n' +
+  lift(/const CLIENT_TAG = [^\n]+/, 'CLIENT_TAG') + '\n' +
+  lift(/function buildWebComment\(url, content, includeClientTag\)\s*\{[\s\S]*?\n  \}/, 'buildWebComment') + '\n' +
   lift(/const jumbleThreadUrl = [^\n]+\n[^\n]+/, 'jumbleThreadUrl') + '\n' +
   lift(/const jumbleNoteUrl = [^\n]+/, 'jumbleNoteUrl') + '\n' +
   'globalThis.unwrapJumbleTarget = unwrapJumbleTarget;' +
@@ -186,7 +187,7 @@ test('unwrap never throws on junk', () => {
 // ---- the event ----------------------------------------------------------------
 
 test('the event matches the tag shape a real Jumble comment uses', () => {
-  const ev = buildWebComment(CNN, 'hello');
+  const ev = buildWebComment(CNN, 'hello', false);
   assert.equal(ev.kind, 1111);
   assert.equal(ev.content, 'hello');
   // Compared as JSON, not deepEqual: the tags are built inside the vm realm, so
@@ -201,15 +202,49 @@ test('the event matches the tag shape a real Jumble comment uses', () => {
 });
 
 test('root and parent are identical for a top-level comment', () => {
-  const ev = buildWebComment(CNN, 'x');
+  const ev = buildWebComment(CNN, 'x', false);
   const I = ev.tags.find((t) => t[0] === 'I');
   const i = ev.tags.find((t) => t[0] === 'i');
   assert.equal(I[1], i[1], 'a comment on the page, not a reply to a comment');
 });
 
 test('created_at is unix SECONDS', () => {
-  const ev = buildWebComment(CNN, 'x');
+  const ev = buildWebComment(CNN, 'x', false);
   assert.ok(ev.created_at > 1_000_000_000 && ev.created_at < 100_000_000_000);
+});
+
+// Jumble renders this as "via Sidecar" — ReplyNote and NotePage both mount
+// <ClientTag> with no kind gate, so a 1111 shows it just like a note does.
+test('the client tag is appended when enabled', () => {
+  const ev = buildWebComment(CNN, 'x', true);
+  assert.equal(JSON.stringify(ev.tags[ev.tags.length - 1]), JSON.stringify(['client', 'Sidecar']));
+});
+
+test('the four scope tags keep their verified leading order with the client tag on', () => {
+  // The I/K/i/k prefix is what was checked byte-for-byte against a real comment;
+  // appending must not disturb it, so a future diff against one stays clean.
+  const ev = buildWebComment(CNN, 'x', true);
+  assert.equal(JSON.stringify(ev.tags.slice(0, 4)), JSON.stringify([
+    ['I', CNN], ['K', 'web'], ['i', CNN], ['k', 'web'],
+  ]));
+  assert.equal(ev.tags.length, 5);
+});
+
+test('the tag is omitted when the setting is off — the toggle must actually work', () => {
+  for (const off of [false, undefined]) {
+    const ev = buildWebComment(CNN, 'x', off);
+    assert.equal(ev.tags.length, 4, 'no client tag expected for ' + String(off));
+    assert.ok(!ev.tags.some((t) => t[0] === 'client'));
+  }
+});
+
+test('the exported CLIENT_TAG is never mutated between events', () => {
+  // buildWebComment pushes a copy; without .slice() a later edit to one event's tag
+  // would reach back into the shared constant.
+  const a = buildWebComment(CNN, 'x', true);
+  a.tags[a.tags.length - 1][1] = 'Tampered';
+  const b = buildWebComment(CNN, 'y', true);
+  assert.equal(b.tags[b.tags.length - 1][1], 'Sidecar');
 });
 
 // ---- the Jumble links ---------------------------------------------------------

--- a/test/web-comment.test.js
+++ b/test/web-comment.test.js
@@ -36,10 +36,12 @@ vm.createContext(ctx);
 vm.runInContext(
   lift(/const WEB_COMMENT_KIND = \d+;/, 'WEB_COMMENT_KIND') + '\n' +
   lift(/const TRACKING_PARAMS = \[[\s\S]*?\];/, 'TRACKING_PARAMS') + '\n' +
+  lift(/function unwrapJumbleTarget\(raw\)\s*\{[\s\S]*?\n  \}/, 'unwrapJumbleTarget') + '\n' +
   lift(/function normalizeWebUrl\(raw\)\s*\{[\s\S]*?\n  \}/, 'normalizeWebUrl') + '\n' +
   lift(/function buildWebComment\(url, content\)\s*\{[\s\S]*?\n  \}/, 'buildWebComment') + '\n' +
   lift(/const jumbleThreadUrl = [^\n]+\n[^\n]+/, 'jumbleThreadUrl') + '\n' +
   lift(/const jumbleNoteUrl = [^\n]+/, 'jumbleNoteUrl') + '\n' +
+  'globalThis.unwrapJumbleTarget = unwrapJumbleTarget;' +
   'globalThis.normalizeWebUrl = normalizeWebUrl;' +
   'globalThis.buildWebComment = buildWebComment;' +
   'globalThis.jumbleThreadUrl = jumbleThreadUrl;' +
@@ -47,7 +49,7 @@ vm.runInContext(
   'globalThis.WEB_COMMENT_KIND = WEB_COMMENT_KIND;',
   ctx
 );
-const { normalizeWebUrl, buildWebComment, jumbleThreadUrl, jumbleNoteUrl } = ctx;
+const { normalizeWebUrl, buildWebComment, jumbleThreadUrl, jumbleNoteUrl, unwrapJumbleTarget } = ctx;
 
 // The exact URL from the real Jumble comment this was modelled on.
 const CNN = 'https://www.cnn.com/2026/07/28/politics/jay-clayton-director-national-intelligence';
@@ -135,6 +137,49 @@ test('junk input returns an error rather than throwing', () => {
   for (const junk of ['', '   ', 'not a url', null, undefined, 'http://']) {
     const r = normalizeWebUrl(junk);
     assert.ok(r.error, JSON.stringify(junk) + ' should error');
+  }
+});
+
+// ---- unwrapping a Jumble thread view ------------------------------------------
+//
+// Reading a thread on Jumble and then commenting from Sidecar would otherwise
+// address the comment to `jumble.social/external-content?id=…` — a different
+// identifier from the article, so it would never join the thread on screen. Silent,
+// and only caught because a screenshot happened to be taken on that exact page.
+
+test('a Jumble external-content view unwraps to the article', () => {
+  const wrapped = jumbleThreadUrl(CNN);
+  assert.equal(unwrapJumbleTarget(wrapped), CNN);
+  // ...and the round trip through normalization still lands on the reference URL.
+  assert.equal(normalizeWebUrl(unwrapJumbleTarget(wrapped)).url, CNN);
+});
+
+test('other Jumble pages are left alone', () => {
+  for (const u of [
+    'https://jumble.social/notes/nevent1abc',
+    'https://jumble.social/users/npub1abc',
+    'https://jumble.social/',
+  ]) {
+    assert.equal(unwrapJumbleTarget(u), u, u + ' should not be unwrapped');
+  }
+});
+
+test('an external-content id that is not a web URL is not unwrapped', () => {
+  // Jumble uses this view for other identifier types; only http(s) is a page.
+  for (const id of ['npub1abc', 'note1abc', 'isbn:123', 'javascript:alert(1)', '']) {
+    const u = 'https://jumble.social/external-content?id=' + encodeURIComponent(id);
+    assert.equal(unwrapJumbleTarget(u), u, id + ' should be left for normalizeWebUrl to refuse');
+  }
+});
+
+test('unwrapping only applies to jumble.social, not a lookalike host', () => {
+  const evil = 'https://jumble.social.attacker.example/external-content?id=' + encodeURIComponent(CNN);
+  assert.equal(unwrapJumbleTarget(evil), evil, 'suffix match must be anchored to the real host');
+});
+
+test('unwrap never throws on junk', () => {
+  for (const junk of ['', 'not a url', null, undefined]) {
+    assert.doesNotThrow(() => unwrapJumbleTarget(junk));
   }
 });
 

--- a/test/web-comment.test.js
+++ b/test/web-comment.test.js
@@ -1,0 +1,188 @@
+'use strict';
+
+// Unit coverage for the web-comment target logic in sidepanel.js:
+// normalizeWebUrl() and buildWebComment().
+//
+// A kind:1111 comment on a webpage is addressed BY the page URL, so normalization
+// decides whether two people commenting on the same page land in the same thread.
+// Getting it wrong doesn't raise an error — it silently splits the conversation, so
+// the rules are pinned here rather than left to manual checking.
+//
+// The tag shape asserted below was taken from a real Jumble comment, fetched from
+// relays and decoded, not inferred from the spec.
+//
+// One trap this guards against: nostr-tools' utils.normalizeURL — the obvious thing
+// to reuse, since Sidecar already imports it for relay URLs — rewrites https:// to
+// wss://. Using it here would tag every comment with an address that threads with
+// nothing at all.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const ROOT = path.join(__dirname, '..');
+const source = fs.readFileSync(path.join(ROOT, 'sidepanel.js'), 'utf8');
+
+function lift(pattern, label) {
+  const m = source.match(pattern);
+  if (!m) throw new Error('Could not find ' + label + ' in sidepanel.js');
+  return m[0];
+}
+
+const ctx = { console, URL, Date };
+vm.createContext(ctx);
+vm.runInContext(
+  lift(/const WEB_COMMENT_KIND = \d+;/, 'WEB_COMMENT_KIND') + '\n' +
+  lift(/const TRACKING_PARAMS = \[[\s\S]*?\];/, 'TRACKING_PARAMS') + '\n' +
+  lift(/function normalizeWebUrl\(raw\)\s*\{[\s\S]*?\n  \}/, 'normalizeWebUrl') + '\n' +
+  lift(/function buildWebComment\(url, content\)\s*\{[\s\S]*?\n  \}/, 'buildWebComment') + '\n' +
+  lift(/const jumbleThreadUrl = [^\n]+\n[^\n]+/, 'jumbleThreadUrl') + '\n' +
+  lift(/const jumbleNoteUrl = [^\n]+/, 'jumbleNoteUrl') + '\n' +
+  'globalThis.normalizeWebUrl = normalizeWebUrl;' +
+  'globalThis.buildWebComment = buildWebComment;' +
+  'globalThis.jumbleThreadUrl = jumbleThreadUrl;' +
+  'globalThis.jumbleNoteUrl = jumbleNoteUrl;' +
+  'globalThis.WEB_COMMENT_KIND = WEB_COMMENT_KIND;',
+  ctx
+);
+const { normalizeWebUrl, buildWebComment, jumbleThreadUrl, jumbleNoteUrl } = ctx;
+
+// The exact URL from the real Jumble comment this was modelled on.
+const CNN = 'https://www.cnn.com/2026/07/28/politics/jay-clayton-director-national-intelligence';
+
+test('the reference URL passes through byte-for-byte', () => {
+  // If this changes, Sidecar's comments stop threading with Jumble's.
+  assert.equal(normalizeWebUrl(CNN).url, CNN);
+});
+
+test('the fragment is stripped — NIP-73 requires it, and #section is the same page', () => {
+  assert.equal(normalizeWebUrl(CNN + '#comments').url, CNN);
+  assert.equal(normalizeWebUrl('https://example.com/a#x').url, 'https://example.com/a');
+});
+
+test('tracking params are dropped, so share links do not fork the thread', () => {
+  const cases = [
+    '?utm_source=twitter', '?utm_medium=social&utm_campaign=x', '?fbclid=abc',
+    '?gclid=abc', '?igshid=zzz', '?mc_cid=1&mc_eid=2', '?ttclid=q',
+  ];
+  for (const q of cases) {
+    assert.equal(normalizeWebUrl(CNN + q).url, CNN, 'failed for ' + q);
+  }
+});
+
+// This is the counterweight: for plenty of sites the query IS the page.
+test('a meaningful query is KEPT', () => {
+  assert.equal(
+    normalizeWebUrl('https://www.youtube.com/watch?v=dQw4w9WgXcQ').url,
+    'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
+  );
+  // ...even mixed with tracking noise, which is dropped around it.
+  assert.equal(
+    normalizeWebUrl('https://www.youtube.com/watch?v=abc&utm_source=x').url,
+    'https://www.youtube.com/watch?v=abc'
+  );
+});
+
+test('query order does not create two threads for one page', () => {
+  const a = normalizeWebUrl('https://example.com/p?b=2&a=1').url;
+  const b = normalizeWebUrl('https://example.com/p?a=1&b=2').url;
+  assert.equal(a, b);
+});
+
+test('a bare origin gets one trailing slash; a path never gains one', () => {
+  assert.equal(normalizeWebUrl('https://example.com').url, 'https://example.com/');
+  assert.equal(normalizeWebUrl('https://example.com/').url, 'https://example.com/');
+  assert.equal(normalizeWebUrl('https://example.com/path/').url, 'https://example.com/path');
+});
+
+test('the host is case-folded but the path is not', () => {
+  // Hosts are case-insensitive; paths are not, and folding them would point at a
+  // different resource on plenty of servers.
+  const out = normalizeWebUrl('https://Example.COM/Path/To/Thing').url;
+  assert.equal(out, 'https://example.com/Path/To/Thing');
+});
+
+// Refusals. Each of these would either be meaningless to another reader or would
+// publish something private, so they must fail closed with a reason rather than
+// being guessed at.
+test('non-web schemes are refused, not normalized', () => {
+  for (const bad of [
+    'chrome://extensions',
+    'about:debugging',
+    'moz-extension://abc/sidepanel.html',
+    'chrome-extension://abc/sidepanel.html',
+    'file:///Users/daniel/secret.txt',
+    'data:text/html,<h1>x',
+    'javascript:alert(1)',
+  ]) {
+    const r = normalizeWebUrl(bad);
+    assert.ok(r.error, bad + ' must be refused');
+    assert.equal(r.url, undefined, bad + ' must not yield a URL');
+  }
+});
+
+// file:// would publish a path from this machine to a public relay.
+test('a local path is never publishable', () => {
+  assert.ok(normalizeWebUrl('file:///Users/daniel/Documents/notes.txt').error);
+  assert.ok(normalizeWebUrl('http://localhost:3000/admin').error);
+  assert.ok(normalizeWebUrl('http://127.0.0.1:8080/').error);
+  assert.ok(normalizeWebUrl('http://192.168.1.1/router').error);
+});
+
+test('junk input returns an error rather than throwing', () => {
+  for (const junk of ['', '   ', 'not a url', null, undefined, 'http://']) {
+    const r = normalizeWebUrl(junk);
+    assert.ok(r.error, JSON.stringify(junk) + ' should error');
+  }
+});
+
+// ---- the event ----------------------------------------------------------------
+
+test('the event matches the tag shape a real Jumble comment uses', () => {
+  const ev = buildWebComment(CNN, 'hello');
+  assert.equal(ev.kind, 1111);
+  assert.equal(ev.content, 'hello');
+  // Compared as JSON, not deepEqual: the tags are built inside the vm realm, so
+  // their prototype differs from the host's Array and assert/strict's deepEqual
+  // fails on that alone ("same structure but not reference-equal").
+  assert.equal(JSON.stringify(ev.tags), JSON.stringify([
+    ['I', CNN],   // uppercase = root scope
+    ['K', 'web'], // uppercase = root kind
+    ['i', CNN],   // lowercase = parent scope
+    ['k', 'web'], // lowercase = parent kind
+  ]));
+});
+
+test('root and parent are identical for a top-level comment', () => {
+  const ev = buildWebComment(CNN, 'x');
+  const I = ev.tags.find((t) => t[0] === 'I');
+  const i = ev.tags.find((t) => t[0] === 'i');
+  assert.equal(I[1], i[1], 'a comment on the page, not a reply to a comment');
+});
+
+test('created_at is unix SECONDS', () => {
+  const ev = buildWebComment(CNN, 'x');
+  assert.ok(ev.created_at > 1_000_000_000 && ev.created_at < 100_000_000_000);
+});
+
+// ---- the Jumble links ---------------------------------------------------------
+
+test('the thread link matches the external-content format', () => {
+  assert.equal(
+    jumbleThreadUrl(CNN),
+    'https://jumble.social/external-content?id=' +
+      'https%3A%2F%2Fwww.cnn.com%2F2026%2F07%2F28%2Fpolitics%2Fjay-clayton-director-national-intelligence'
+  );
+});
+
+test('the URL is encoded, so a query in the target cannot break the link', () => {
+  const link = jumbleThreadUrl('https://example.com/a?b=1&c=2');
+  assert.ok(!link.slice('https://jumble.social/external-content?id='.length).includes('&'),
+    'an unencoded & would read as a second Jumble param');
+});
+
+test('the note link matches the notes format', () => {
+  assert.equal(jumbleNoteUrl('nevent1abc'), 'https://jumble.social/notes/nevent1abc');
+});

--- a/test/web-comment.test.js
+++ b/test/web-comment.test.js
@@ -250,6 +250,74 @@ test('the exported CLIENT_TAG is never mutated between events', () => {
   assert.equal(b.tags[b.tags.length - 1][1], 'Sidecar');
 });
 
+// ---- mentions ------------------------------------------------------------------
+// The comment box is the note composer's editor (createMentionEditor), so an
+// @mention serializes to a bare `nostr:npub1…` token in the content. Without a
+// matching p tag the person tagged is never notified — the comment renders their
+// name and they never find out, which is the bug these pin shut.
+
+const NT = require('nostr-tools');
+// Two arbitrary but fixed keys: the assertions are about tag plumbing, not identity.
+const PK_A = '3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d';
+const PK_B = '82341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6d2';
+const NPUB_A = NT.nip19.npubEncode(PK_A);
+const NPUB_B = NT.nip19.npubEncode(PK_B);
+
+// Spread into a HOST array: filter/map on vm-realm tags return vm-realm arrays, and
+// assert/strict's deepEqual rejects those on prototype alone ("same structure but not
+// reference-equal") even when every element matches. Same trap as the JSON.stringify
+// comparison above.
+const pTags = (ev) => [...ev.tags.filter((t) => t[0] === 'p').map((t) => t[1])];
+
+test('a mention in a comment becomes a p tag, so the person is actually notified', () => {
+  const ev = buildWebComment(CNN, 'good point nostr:' + NPUB_A, false);
+  assert.deepEqual(pTags(ev), [PK_A]);
+});
+
+test('an nprofile mention resolves to its pubkey', () => {
+  const nprofile = NT.nip19.nprofileEncode({ pubkey: PK_B, relays: ['wss://relay.example'] });
+  const ev = buildWebComment(CNN, 'nostr:' + nprofile + ' see this', false);
+  assert.deepEqual(pTags(ev), [PK_B], 'the relay hint must not end up in the tag');
+});
+
+test('several mentions are all tagged, in the order written', () => {
+  const ev = buildWebComment(CNN, 'nostr:' + NPUB_A + ' and nostr:' + NPUB_B, false);
+  assert.deepEqual(pTags(ev), [PK_A, PK_B]);
+});
+
+test('mentioning the same person twice tags them once', () => {
+  const ev = buildWebComment(CNN, 'nostr:' + NPUB_A + ' … also nostr:' + NPUB_A, false);
+  assert.deepEqual(pTags(ev), [PK_A], 'a duplicate p tag is a malformed event');
+});
+
+test('the p tags sit after the four scope tags and before the client tag', () => {
+  // Same ordering guarantee as the client-tag test: the I/K/i/k prefix was verified
+  // byte-for-byte against a real comment and mentions must not disturb it.
+  const ev = buildWebComment(CNN, 'hi nostr:' + NPUB_A, true);
+  assert.equal(JSON.stringify(ev.tags), JSON.stringify([
+    ['I', CNN], ['K', 'web'], ['i', CNN], ['k', 'web'],
+    ['p', PK_A],
+    ['client', 'Sidecar'],
+  ]));
+});
+
+test('a comment with no mention carries no p tags', () => {
+  assert.deepEqual(pTags(buildWebComment(CNN, 'just a plain comment', false)), []);
+});
+
+test('an npub-shaped token that is not valid bech32 is skipped, not thrown on', () => {
+  // A user can type or paste this by hand; mentionPTags swallows the decode error.
+  const ev = buildWebComment(CNN, 'nostr:npub1thisisnotarealkeyatall', false);
+  assert.deepEqual(pTags(ev), []);
+  assert.equal(ev.kind, 1111, 'the comment still builds');
+});
+
+test('a bare npub with no nostr: prefix is NOT tagged', () => {
+  // Only the serializer's `nostr:` form counts. A pasted bare npub renders as text
+  // in every client, so tagging it would notify someone the reader never sees named.
+  assert.deepEqual(pTags(buildWebComment(CNN, 'ask ' + NPUB_A, false)), []);
+});
+
 // ---- the Jumble links ---------------------------------------------------------
 
 test('the thread link matches the external-content format', () => {

--- a/test/web-comment.test.js
+++ b/test/web-comment.test.js
@@ -31,7 +31,8 @@ function lift(pattern, label) {
   return m[0];
 }
 
-const ctx = { console, URL, Date };
+// NT is the panel's alias for window.NostrTools; mentionPTags decodes npubs with it.
+const ctx = { console, URL, Date, NT: require('nostr-tools') };
 vm.createContext(ctx);
 vm.runInContext(
   lift(/const WEB_COMMENT_KIND = \d+;/, 'WEB_COMMENT_KIND') + '\n' +
@@ -39,6 +40,8 @@ vm.runInContext(
   lift(/function unwrapJumbleTarget\(raw\)\s*\{[\s\S]*?\n  \}/, 'unwrapJumbleTarget') + '\n' +
   lift(/function normalizeWebUrl\(raw\)\s*\{[\s\S]*?\n  \}/, 'normalizeWebUrl') + '\n' +
   lift(/const CLIENT_TAG = [^\n]+/, 'CLIENT_TAG') + '\n' +
+  // buildWebComment calls this to p-tag mentions, so it has to come along.
+  lift(/function mentionPTags\(content\)\s*\{[\s\S]*?\n  \}/, 'mentionPTags') + '\n' +
   lift(/function buildWebComment\(url, content, includeClientTag\)\s*\{[\s\S]*?\n  \}/, 'buildWebComment') + '\n' +
   lift(/const jumbleThreadUrl = [^\n]+\n[^\n]+/, 'jumbleThreadUrl') + '\n' +
   lift(/const jumbleNoteUrl = [^\n]+/, 'jumbleNoteUrl') + '\n' +


### PR DESCRIPTION
Comment on any webpage from the panel. A kind:1111 addressed by the page URL, so everyone commenting on the same page lands in the same thread.

## The tag shape is copied, not inferred

Taken from a real Jumble comment, fetched off relays and decoded:

```
["I", url], ["K", "web"]   uppercase = root scope
["i", url], ["k", "web"]   lowercase = parent scope
```

Root and parent are identical for a top-level comment. A test pins the leading order so a future diff against a real comment stays clean.

## URL normalization is the whole feature

Get this wrong and nothing errors — the conversation just silently splits. Fragment stripped (NIP-73 says normalized, no fragment; `#section` is the same page). Tracking params dropped so a shared link does not fork the thread, but a meaningful query is kept. Query order sorted. Host case-folded, path not. One trailing slash on a bare origin, never on a path. http/https only, and never a localhost or IP target — nobody else could open it.

**The trap:** nostr-tools' `normalizeURL` is the obvious thing to reuse, since we already import it for relay URLs. It rewrites `https://` to `wss://`. Using it here would tag every comment with an address that threads with nothing.

A `jumble.social/external-content?id=…` URL unwraps to the article, so commenting from a Jumble thread does not nest a link to Jumble inside Jumble.

## Links point at Jumble on purpose

Almost nothing else renders a kind:1111 over a web target. "View your comment" without saying where implies it is visible wherever you normally read Nostr, and it is not. Drop the name once other clients catch up.

## Layout

Author header, then the link card + URL caption ABOVE the tabs, then Write/Preview. The card is the *subject*, not one of the two views — a 1111 is defined by its target, so a blank box with no visible subject was the wrong shape. The URL stays visible even when a card renders, because the URL is what actually gets published. The tab is resolved only after the modal is open, never speculatively — this URL is about to be signed.

## Mentions

The comment box is the note composer's editor, hoisted to module scope as `createMentionEditor` (see the refactor commit). You could previously tag someone in a note but not in a comment. `buildWebComment` already ran `mentionPTags`, so the p tag was always emitted — the box just could not produce a mention.

## Notification path

Five sites needed kind 1111. The one that mattered: `notifLink` returned `''` for a 1111 because it has no `e` tag, so the entry was unclickable.

## Verified live

Posted, threaded, `via Sidecar` renders (Jumble's ClientTag has no kind gate), and a mention resolves to a name rather than a raw npub.

Not yet checked: whether it surfaces in our own notification bell as "mentioned you in a comment".

## Tests

33 in `test/web-comment.test.js`, 112 in the suite.

Untested because it needs a DOM: the NBSP-after-pill behavior. It nearly broke during the hoist and a diff will not show it — see the refactor commit.

🍸 Shaken with [Claude Code](https://claude.com/claude-code)