### PR TITLE
fix: tell the truth about which wallet is backed up, and which one is connected

### DIFF
--- a/sidepanel.js
+++ b/sidepanel.js
@@ -564,7 +564,7 @@
       // screen. The composer draft is autosaved, so it's offered again on unlock.
       closeModal();
       stopWalletMonitor();
-      if (nwc) { try { nwc.close(); } catch (_) {} nwc = null; nwcPubkey = null; }
+      if (nwc) { try { nwc.close(); } catch (_) {} nwc = null; nwcPubkey = null; nwcConn = null; }
       balanceCache = { pubkey: null, sats: null };
       show($('view-lock'));
       setTimeout(() => $('unlock-pin').focus(), 50);
@@ -5722,9 +5722,62 @@
   // replaceable kind:30078 record that can be restored on another device.
   const NWC_BACKUP_DTAG = 'sidecar:nwc-backup';
 
-  async function hasNwcBackup() {
-    return !!(await fetchBackupEvent(NWC_BACKUP_DTAG));
+  // Compare the backup against the wallet actually connected — don't just detect
+  // that some backup exists. The d-tag is replaceable, so connecting a new wallet
+  // leaves the previous ciphertext in place: a bare existence check then reports
+  // "Backed up" for a string the user no longer holds, which is the one case where
+  // the reassurance is actively harmful.
+  //
+  // Fails closed. Anything we can't verify (no connection, decrypt failed, relays
+  // timed out) is 'unknown', never 'current'.
+  //
+  //   none    → no backup event on the relays
+  //   current → the backup decrypts to the connected string
+  //   stale   → a backup exists, but for a different wallet
+  //   unknown → couldn't tell
+  //
+  // Compares the whole string rather than the parsed wallet pubkey + secret: two
+  // URIs for one wallet can differ in param order or an added lud16, so a byte
+  // compare can say 'stale' when the wallet is really the same. That false positive
+  // only prompts a harmless re-backup, where a false 'current' is the bug itself.
+  async function nwcBackupState() {
+    const ev = await fetchBackupEvent(NWC_BACKUP_DTAG);
+    if (!ev) return { state: 'none' };
+    let connection = '';
+    try {
+      connection = (await call({ type: 'SIDECAR_GET_NWC' })).connection || '';
+    } catch (_) {}
+    if (!connection) return { state: 'unknown', at: ev.created_at };
+    try {
+      const scheme = (ev.tags.find((x) => x[0] === 'encryption') || [])[1];
+      const backed = await call({
+        type: 'SIDECAR_OWNER_DECRYPT',
+        ciphertext: ev.content,
+        nip: scheme === 'nip04' ? 4 : 44,
+      });
+      const same = String(backed || '').trim() === connection.trim();
+      return { state: same ? 'current' : 'stale', at: ev.created_at };
+    } catch (_) {
+      return { state: 'unknown', at: ev.created_at };
+    }
   }
+
+  // Pubkey whose backup nudge was dismissed this session (see renderWalletConnected).
+  let nwcNudgeDismissed = null;
+
+  // Short by design — this renders in a ~360px sidebar and the pill ellipsizes.
+  //
+  // 'stale' and 'none' share a headline on purpose. If the stored copy isn't this
+  // wallet then this wallet isn't backed up, and that's the claim the user needs;
+  // describing the backup instead ("Out of date") reads as if the CONNECTION were
+  // old, since the pill sits beside a "Wallet connection" label. What separates the
+  // two is the warn color and the line underneath — don't "fix" the duplication.
+  const NWC_BACKUP_LABEL = {
+    current: 'Backed up ✓',
+    stale: 'Not backed up',
+    none: 'Not backed up',
+    unknown: "Couldn't check",
+  };
 
   async function backupNwcToRelays() {
     const { connection } = await call({ type: 'SIDECAR_GET_NWC' });
@@ -5761,6 +5814,10 @@
     await client.getInfo();
     client.close();
     await call({ type: 'SIDECAR_SET_NWC', connection });
+    // ensureNwc() drops the stale balance too, but it runs after the wallet screen
+    // has already painted from cache — clearing here means the restored wallet never
+    // shows the previous one's balance, not even for a frame.
+    balanceCache = { pubkey: null, sats: null };
   }
 
   // Plain signed-JSON export of the account's identity events (download, no relays).
@@ -6564,6 +6621,7 @@
   // ====================== Wallet (NWC / NIP-47) ======================
   let nwc = null; // active SidecarNWC client for the current account
   let nwcPubkey = null; // which account the client belongs to
+  let nwcConn = null; // the connection string it was built from — see ensureNwc
   let nwcNotifSub = null; // NIP-47 notification subscription handle
   let nwcPollTimer = null; // fallback balance polling interval
   const fmtSats = (n) => Math.round(n).toLocaleString('en-US');
@@ -7029,15 +7087,29 @@
   }
 
   // Build (or reuse) the NWC client for the active account from its stored string.
+  // Keyed on the CONNECTION, not just the account. Swapping wallets within one
+  // account (Restore, or connecting a different string) leaves activePubkey
+  // unchanged, so an account-only key handed back a client still talking to the
+  // previous wallet: the balance and history came from the wallet you just replaced.
+  // Disconnect happened to nulls the client by hand, which is why removing and
+  // re-importing the same string "fixed" it.
+  //
+  // Reading the connection every call costs a message round-trip, but it can't go
+  // stale. The alternative — having each write broadcast an invalidation — is the
+  // shape that produced this bug: Disconnect remembered to reset, Restore didn't.
   async function ensureNwc() {
     const pk = state.activePubkey;
-    if (nwc && nwcPubkey === pk) return nwc;
-    stopWalletMonitor();
-    if (nwc) { try { nwc.close(); } catch (_) {} nwc = null; nwcPubkey = null; }
     const { connection } = await call({ type: 'SIDECAR_GET_NWC' });
+    if (nwc && nwcPubkey === pk && nwcConn === connection) return nwc;
+    stopWalletMonitor();
+    if (nwc) { try { nwc.close(); } catch (_) {} nwc = null; nwcPubkey = null; nwcConn = null; }
+    // A balance for the old wallet must not survive into the new one — it's keyed by
+    // account, so nothing else would notice it's now the wrong number.
+    if (balanceCache && balanceCache.pubkey === pk) balanceCache = { pubkey: null, sats: null };
     if (!connection) return null;
     nwc = window.SidecarNWC.makeClient(connection);
     nwcPubkey = pk;
+    nwcConn = connection;
     startWalletMonitor(nwc);
     return nwc;
   }
@@ -7252,6 +7324,56 @@
     actions.append(sendBtn, recvBtn);
     view.append(actions);
 
+    // Backup nudge. The Backup card is far below the transaction list, so after
+    // connecting a wallet nothing on the first screen says it isn't saved — and a
+    // stale backup used to read as "Backed up" down there. One line, dismissible:
+    // some people deliberately never put a connection string on relays.
+    const backupState = nwcBackupState();
+    let nudgeStateName = 'unknown';
+    const nudge = h('p', { className: 'hint wallet-notice wallet-backup-nudge hidden' });
+    const nudgeText = h('span', { textContent: '' });
+    const nudgeBtn = h('button', { className: 'explore-link', textContent: 'Back up' });
+    const doNudgeBackup = async () => {
+      nudgeBtn.disabled = true;
+      try {
+        await backupNwcToRelays();
+        toast('Wallet backed up', 'success');
+        renderWallet();
+      } catch (e) {
+        toast(e.message, 'error');
+        nudgeBtn.disabled = false;
+      }
+    };
+    nudgeBtn.addEventListener('click', () => {
+      // Same guard as the Backup card: from here the nudge only ever shows for
+      // 'none' or 'stale', so this asks exactly when a stored wallet is at risk.
+      if (nudgeStateName === 'stale') {
+        confirmOverwriteNwcBackup('stale', doNudgeBackup);
+        return;
+      }
+      doNudgeBackup();
+    });
+    const nudgeX = h('button', { className: 'wallet-nudge-x', textContent: '×', title: 'Dismiss' });
+    nudgeX.addEventListener('click', () => {
+      // Per account, and only for this session — renderWallet() runs often enough
+      // that a render-scoped dismissal would reappear immediately, but a permanent
+      // opt-out isn't right either for "your wallet isn't saved anywhere".
+      nwcNudgeDismissed = state.activePubkey;
+      hide(nudge);
+    });
+    nudge.append(nudgeText, ' ', nudgeBtn, nudgeX);
+    view.append(nudge);
+    backupState.then((r) => {
+      const s = (r && r.state) || 'unknown';
+      if (s !== 'none' && s !== 'stale') return;
+      if (nwcNudgeDismissed === state.activePubkey) return;
+      nudgeStateName = s;
+      nudgeText.textContent = s === 'stale'
+        ? 'Your backup is a different wallet.'
+        : "This wallet isn't backed up.";
+      nudge.classList.remove('hidden');
+    }).catch(() => {});
+
     // Lightning address card (only if one is available). Shows the copyable
     // address with a QR icon that toggles a scannable QR inline.
     const addrCard = h('div', { className: 'setting address-card hidden' });
@@ -7299,7 +7421,7 @@
     view.append(txWrap);
 
     // Backup to relays (detection mirrors zap.cooking)
-    view.append(renderWalletBackup());
+    view.append(renderWalletBackup(backupState));
 
     // Per-site WebLN spending budgets
     view.append(renderSitePayments());
@@ -7598,29 +7720,103 @@
     );
   }
 
-  function renderWalletBackup() {
+  // Backing up replaces the stored wallet. The d-tag is replaceable, so the old
+  // ciphertext is discarded — and if the relays were the only place that connection
+  // lived, it's gone.
+  //
+  // Deliberately does NOT say "export it first": Export reveals the CONNECTED
+  // wallet, which is the new one. Saving the old string means restoring it first,
+  // so that's what this points at.
+  function confirmOverwriteNwcBackup(backupState, onConfirm) {
+    openModal((modal) => {
+      const body = h('p', { className: 'hint' });
+      body.append(
+        document.createTextNode(
+          backupState === 'stale'
+            ? 'Your relays hold a different wallet. Backing up replaces it. '
+            : "Sidecar couldn't check what your relays hold. Backing up replaces it. "
+        ),
+        h('strong', { textContent: 'Restore it first if you still need it.' })
+      );
+      const cancel = h('button', { className: 'ghost', textContent: 'Cancel' });
+      cancel.addEventListener('click', closeModal);
+      // Action first, Cancel last — matching disconnectModal, the other wallet
+      // confirm. 'danger' not 'primary': this discards a stored wallet, so it
+      // shouldn't wear the color reserved for the encouraged choice.
+      const go = h('button', { className: 'danger', textContent: 'Replace backup' });
+      go.addEventListener('click', () => { closeModal(); onConfirm(); });
+      modal.append(
+        h('h3', { textContent: 'Replace saved backup?' }),
+        body,
+        h('div', { className: 'actions' }, [go, cancel])
+      );
+    });
+  }
+
+  // Restore replaces the connected wallet. Say what is lost, in one line.
+  function confirmRestoreNwc(backupState, onConfirm) {
+    openModal((modal) => {
+      const body = h('p', { className: 'hint' });
+      body.append(
+        document.createTextNode(
+          backupState === 'stale'
+            ? 'The backup is a different wallet. '
+            : "Sidecar couldn't check what the backup holds. "
+        ),
+        h('strong', { textContent: 'The wallet you have connected now will be replaced.' })
+      );
+      const cancel = h('button', { className: 'ghost', textContent: 'Cancel' });
+      cancel.addEventListener('click', closeModal);
+      const go = h('button', { className: 'danger', textContent: 'Replace it' });
+      go.addEventListener('click', () => { closeModal(); onConfirm(); });
+      modal.append(
+        h('h3', { textContent: 'Replace connected wallet?' }),
+        body,
+        h('div', { className: 'actions' }, [go, cancel])
+      );
+    });
+  }
+
+  // `statePromise` is shared with the nudge in renderWalletConnected so the relay
+  // fetch + decrypt happens once per wallet render, not once per consumer.
+  function renderWalletBackup(statePromise) {
     const wrap = h('div', { className: 'setting wallet-backup' });
     wrap.append(h('h3', { textContent: 'Backup' }));
     wrap.append(h('p', { className: 'hint', textContent: 'Encrypt your wallet connection to your own key and store it on your relays (NIP-78). Restore it on another device or after a reset.' }));
 
+    let backupState = 'unknown';
     const status = h('span', { className: 'backup-status', textContent: 'Checking…' });
+    // Only shown for 'stale', where the pill alone can't say what's wrong.
+    const staleNote = h('p', { className: 'hint backup-stale-note hidden', textContent: 'The backup is a different wallet.' });
     const back = h('button', { className: 'secondary', textContent: 'Back up' });
     const restore = h('button', { className: 'secondary', textContent: 'Restore' });
-    back.addEventListener('click', async () => {
+    const doBackup = async () => {
       back.disabled = true;
       back.textContent = 'Backing up…';
       try {
         await backupNwcToRelays();
-        status.textContent = 'Backed up ✓';
+        backupState = 'current';
+        status.textContent = NWC_BACKUP_LABEL.current;
         status.classList.add('done');
+        status.classList.remove('warn');
+        staleNote.classList.add('hidden');
         toast('Wallet backed up', 'success');
       } catch (e) {
         toast(e.message, 'error');
       }
       back.disabled = false;
       back.textContent = 'Back up';
+    };
+    back.addEventListener('click', () => {
+      // Only when there's something to lose. 'none' has no stored wallet and
+      // 'current' would rewrite the same string.
+      if (backupState === 'stale' || backupState === 'unknown') {
+        confirmOverwriteNwcBackup(backupState, doBackup);
+        return;
+      }
+      doBackup();
     });
-    restore.addEventListener('click', async () => {
+    const doRestore = async () => {
       restore.disabled = true;
       restore.textContent = 'Restoring…';
       try {
@@ -7632,6 +7828,17 @@
         restore.disabled = false;
         restore.textContent = 'Restore';
       }
+    };
+    restore.addEventListener('click', () => {
+      // Restore overwrites the connected wallet via SIDECAR_SET_NWC. When the
+      // backup is a different wallet, that silently discards the string in use —
+      // and it's the case where someone reaching for Restore is most likely to be
+      // guessing. Confirm first; 'current' is a no-op so it doesn't ask.
+      if (backupState === 'stale' || backupState === 'unknown') {
+        confirmRestoreNwc(backupState, doRestore);
+        return;
+      }
+      doRestore();
     });
     const exportBtn = h('button', { className: 'wallet-export-link', textContent: 'Export connection string' });
     exportBtn.append(icon('key'));
@@ -7643,18 +7850,23 @@
         h('span', { className: 'item-label', textContent: 'Wallet connection' }),
         status,
       ]),
+      staleNote,
       h('div', { className: 'wallet-backup-actions' }, [back, restore]),
       exportBtn,
     ]);
     wrap.append(card);
 
-    hasNwcBackup()
-      .then((has) => {
-        status.textContent = has ? 'Backed up ✓' : 'Not backed up';
-        status.classList.toggle('done', has);
+    (statePromise || nwcBackupState())
+      .then((r) => {
+        backupState = (r && r.state) || 'unknown';
+        status.textContent = NWC_BACKUP_LABEL[backupState] || NWC_BACKUP_LABEL.unknown;
+        status.classList.toggle('done', backupState === 'current');
+        status.classList.toggle('warn', backupState === 'stale');
+        staleNote.classList.toggle('hidden', backupState !== 'stale');
       })
       .catch(() => {
-        status.textContent = 'Not backed up';
+        backupState = 'unknown';
+        status.textContent = NWC_BACKUP_LABEL.unknown;
       });
     // Only offer export when this account actually has a connection saved.
     call({ type: 'SIDECAR_HAS_NWC', pubkey: state.activePubkey })
@@ -8016,7 +8228,7 @@
       go.addEventListener('click', async () => {
         await call({ type: 'SIDECAR_CLEAR_NWC' });
         stopWalletMonitor();
-        if (nwc) { try { nwc.close(); } catch (_) {} nwc = null; nwcPubkey = null; }
+        if (nwc) { try { nwc.close(); } catch (_) {} nwc = null; nwcPubkey = null; nwcConn = null; }
         closeModal();
         toast('Wallet disconnected', 'success');
         renderWallet();

--- a/styles.css
+++ b/styles.css
@@ -330,6 +330,22 @@ input:focus, select:focus, textarea:focus {
 .error.unlock-danger { font-weight: 700; }
 /* A wallet notice isn't a mistake to correct, just an explanation — gold, not red. */
 .wallet-notice { color: var(--gold); margin-bottom: 16px; }
+/* Backup nudge: one line, so it sits inline with its action and dismiss control
+   rather than becoming a stacked banner in a ~360px panel. */
+.wallet-backup-nudge { position: relative; color: var(--warn); margin: 2px 0 16px; padding-right: 18px; }
+/* The action is a <button> (it performs something, it doesn't navigate), but
+   .explore-link was only ever used on <a> so it resets no button chrome — without
+   these the UA's grey box and padding show through. */
+.wallet-backup-nudge .explore-link {
+  display: inline; color: inherit; text-decoration: underline; text-align: left;
+  background: none; border: 0; padding: 0; font: inherit; cursor: pointer;
+}
+.wallet-backup-nudge .explore-link:hover { color: var(--text); }
+.wallet-nudge-x {
+  position: absolute; top: -2px; right: 0; padding: 0 2px; line-height: 1;
+  background: none; border: 0; color: var(--faint); font-size: 15px; cursor: pointer;
+}
+.wallet-nudge-x:hover { color: var(--text); }
 .wallet-notice .explore-link { display: inline; color: inherit; text-decoration: underline; }
 .unlock-forgot { align-self: center; margin-top: 16px; font-size: 13px; color: var(--muted); text-decoration: none; text-align: center; }
 .unlock-forgot:hover { color: var(--lav); text-decoration: underline; }
@@ -985,6 +1001,10 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 100%;
 }
 .backup-status.done { color: var(--gold); }
+/* A backup that exists but holds a different wallet — the reassuring gold ✓ would
+   be exactly wrong here, so it reads as a warning instead. */
+.backup-status.warn { color: var(--warn); }
+.backup-stale-note { margin: -6px 0 12px; color: var(--warn); }
 .export-block { margin-top: 14px; }
 .export-block .hint { margin-bottom: 10px; }
 .export-block .secondary { display: block; width: 100%; margin-bottom: 8px; }

--- a/test/nwc-backup-state.test.js
+++ b/test/nwc-backup-state.test.js
@@ -1,0 +1,197 @@
+'use strict';
+
+// Unit coverage for nwcBackupState() in sidepanel.js.
+//
+// The bug this pins shut: the old check was `!!(await fetchBackupEvent(dtag))` — a
+// bare existence test. kind:30078 is replaceable by (pubkey, kind, d-tag), so
+// connecting a new wallet leaves the PREVIOUS ciphertext on the relays and the
+// status line kept reading "Backed up ✓". The reassurance pointed at a connection
+// string the user no longer held, so the one case where the UI needed to speak up
+// was the exact case it stayed quiet.
+//
+// Every assertion here is really the same assertion: nothing but a verified match
+// may report 'current'. A false 'stale' just prompts a harmless re-backup; a false
+// 'current' loses a wallet.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const ROOT = path.join(__dirname, '..');
+const source = fs.readFileSync(path.join(ROOT, 'sidepanel.js'), 'utf8');
+
+function lift(pattern, label) {
+  const m = source.match(pattern);
+  if (!m) throw new Error('Could not find ' + label + ' in sidepanel.js');
+  return m[0];
+}
+
+const CONN = 'nostr+walletconnect://b889ff5b1513b641e2a139f661a661364979c5beee91842f8f0ef42ab558e9d4?relay=wss%3A%2F%2Frelay.example&secret=71a8c14c1774f1e0e2b7c0d0f3f0b4e5';
+const OTHER = 'nostr+walletconnect://a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90?relay=wss%3A%2F%2Frelay.other&secret=0f0e0d0c0b0a09080706050403020100';
+
+// Builds a context where fetchBackupEvent and call() are stubs, so the state
+// machine is exercised without relays or a keystore.
+function harness({ event, connection, decrypt, getNwcThrows }) {
+  const calls = [];
+  const ctx = {
+    console,
+    NWC_BACKUP_DTAG: 'sidecar:nwc-backup',
+    fetchBackupEvent: async () => (event === undefined ? null : event),
+    call: async (msg) => {
+      calls.push(msg);
+      if (msg.type === 'SIDECAR_GET_NWC') {
+        if (getNwcThrows) throw new Error('locked');
+        return { connection };
+      }
+      if (msg.type === 'SIDECAR_OWNER_DECRYPT') {
+        if (typeof decrypt === 'function') return decrypt(msg);
+        return decrypt;
+      }
+      throw new Error('unexpected call ' + msg.type);
+    },
+  };
+  vm.createContext(ctx);
+  vm.runInContext(
+    lift(/async function nwcBackupState\(\)\s*\{[\s\S]*?\n  \}/, 'nwcBackupState') + '\n' +
+    lift(/const NWC_BACKUP_LABEL = \{[\s\S]*?\n  \};/, 'NWC_BACKUP_LABEL') + '\n' +
+    'globalThis.nwcBackupState = nwcBackupState;' +
+    'globalThis.NWC_BACKUP_LABEL = NWC_BACKUP_LABEL;',
+    ctx
+  );
+  return { ctx, calls };
+}
+
+const evt = (content, algo) => ({
+  content: content || 'CIPHERTEXT',
+  created_at: 1750000000,
+  tags: algo ? [['d', 'sidecar:nwc-backup'], ['encryption', algo]] : [['d', 'sidecar:nwc-backup']],
+});
+
+// ---- the four states ------------------------------------------------------------
+
+test('no backup event on the relays is "none"', async () => {
+  const { ctx } = harness({ event: undefined, connection: CONN });
+  assert.equal((await ctx.nwcBackupState()).state, 'none');
+});
+
+test('a backup that decrypts to the connected string is "current"', async () => {
+  const { ctx } = harness({ event: evt(), connection: CONN, decrypt: CONN });
+  const r = await ctx.nwcBackupState();
+  assert.equal(r.state, 'current');
+  assert.equal(r.at, 1750000000, 'the event timestamp comes back for display');
+});
+
+test('a backup holding a DIFFERENT wallet is "stale", not "current" — the whole bug', async () => {
+  const { ctx } = harness({ event: evt(), connection: CONN, decrypt: OTHER });
+  assert.equal((await ctx.nwcBackupState()).state, 'stale');
+});
+
+test('a backup with no wallet connected is "unknown", never "current"', async () => {
+  const { ctx } = harness({ event: evt(), connection: '', decrypt: CONN });
+  assert.equal((await ctx.nwcBackupState()).state, 'unknown');
+});
+
+// ---- fail closed ---------------------------------------------------------------
+
+test('a decrypt failure is "unknown" — an unreadable backup must not vouch for itself', async () => {
+  const { ctx } = harness({
+    event: evt(), connection: CONN,
+    decrypt: () => { throw new Error('bad ciphertext'); },
+  });
+  assert.equal((await ctx.nwcBackupState()).state, 'unknown');
+});
+
+test('a locked keystore is "unknown", not "none" — "none" would understate what exists', async () => {
+  const { ctx } = harness({ event: evt(), connection: CONN, getNwcThrows: true });
+  const r = await ctx.nwcBackupState();
+  assert.equal(r.state, 'unknown');
+  assert.equal(r.at, 1750000000);
+});
+
+test('a decrypt returning empty or null is never "current"', async () => {
+  for (const bad of ['', null, undefined]) {
+    const { ctx } = harness({ event: evt(), connection: CONN, decrypt: bad });
+    const r = await ctx.nwcBackupState();
+    assert.notEqual(r.state, 'current', 'decrypt returned ' + String(bad));
+    assert.equal(r.state, 'stale');
+  }
+});
+
+// ---- comparison details --------------------------------------------------------
+
+test('surrounding whitespace does not read as a different wallet', async () => {
+  const { ctx } = harness({ event: evt(), connection: '  ' + CONN + '\n', decrypt: CONN + ' ' });
+  assert.equal((await ctx.nwcBackupState()).state, 'current');
+});
+
+test('a same-wallet string differing only in query order reports "stale"', async () => {
+  // Accepted false positive, asserted so the tradeoff is deliberate rather than a
+  // surprise: it prompts a re-backup, which is harmless. The alternative — parsing
+  // out wallet pubkey + secret and ignoring the rest — risks calling two genuinely
+  // different connections equal, which is the failure that loses money.
+  const reordered = CONN.replace(
+    /\?relay=([^&]+)&secret=(.+)$/,
+    (_, relay, secret) => '?secret=' + secret + '&relay=' + relay
+  );
+  assert.notEqual(reordered, CONN, 'the fixture must actually differ');
+  const { ctx } = harness({ event: evt(), connection: CONN, decrypt: reordered });
+  assert.equal((await ctx.nwcBackupState()).state, 'stale');
+});
+
+// ---- encryption scheme ---------------------------------------------------------
+
+test('an nip04 tag decrypts with nip 4, not 44', async () => {
+  const { ctx, calls } = harness({ event: evt('C', 'nip04'), connection: CONN, decrypt: CONN });
+  await ctx.nwcBackupState();
+  const dec = calls.find((c) => c.type === 'SIDECAR_OWNER_DECRYPT');
+  assert.equal(dec.nip, 4, 'older backups were NIP-04 and must stay readable');
+});
+
+test('nip44 is used for a nip44 tag and for a missing tag', async () => {
+  for (const algo of ['nip44', undefined]) {
+    const { ctx, calls } = harness({ event: evt('C', algo), connection: CONN, decrypt: CONN });
+    await ctx.nwcBackupState();
+    assert.equal(calls.find((c) => c.type === 'SIDECAR_OWNER_DECRYPT').nip, 44,
+      'algo tag ' + String(algo));
+  }
+});
+
+test('the ciphertext handed to decrypt is the event content', async () => {
+  const { ctx, calls } = harness({ event: evt('ABC123', 'nip44'), connection: CONN, decrypt: CONN });
+  await ctx.nwcBackupState();
+  assert.equal(calls.find((c) => c.type === 'SIDECAR_OWNER_DECRYPT').ciphertext, 'ABC123');
+});
+
+// ---- the labels ----------------------------------------------------------------
+
+test('every state has a label, and none is long enough to ellipsize in the sidebar', async () => {
+  const { ctx } = harness({ event: undefined, connection: CONN });
+  for (const s of ['none', 'current', 'stale', 'unknown']) {
+    const label = ctx.NWC_BACKUP_LABEL[s];
+    assert.ok(label, 'missing label for ' + s);
+    // .backup-status is nowrap + ellipsis in a ~360px panel; these sit beside
+    // "Wallet connection" on one row, so they have to stay short.
+    assert.ok(label.length <= 16, s + ' label too long: ' + label);
+  }
+});
+
+test('only "current" carries the reassuring check mark', async () => {
+  const { ctx } = harness({ event: undefined, connection: CONN });
+  const L = ctx.NWC_BACKUP_LABEL;
+  assert.ok(L.current.includes('✓'));
+  for (const s of ['none', 'stale', 'unknown']) {
+    assert.ok(!L[s].includes('✓'), s + ' must not look like success');
+  }
+});
+
+test('"stale" and "none" deliberately share a label', () => {
+  // Not an oversight to be tidied up. A backup holding some other wallet means this
+  // wallet is not backed up, which is the fact the user acts on. The two are told
+  // apart by the warn color and the note beneath, not by the pill text — and naming
+  // the backup's age instead ("Out of date") misreads against the adjacent
+  // "Wallet connection" label as though the connection were the stale thing.
+  const { ctx } = harness({ event: undefined, connection: CONN });
+  assert.equal(ctx.NWC_BACKUP_LABEL.stale, ctx.NWC_BACKUP_LABEL.none);
+});

--- a/test/nwc-client-cache.test.js
+++ b/test/nwc-client-cache.test.js
@@ -1,0 +1,170 @@
+'use strict';
+
+// Unit coverage for ensureNwc() in sidepanel.js — which wallet the panel is actually
+// talking to.
+//
+// The bug: the client was cached under `state.activePubkey` alone. Swapping wallets
+// inside one account (Restore, or connecting a different string) doesn't change the
+// account, so ensureNwc() returned a client still pointed at the PREVIOUS wallet.
+// Balance and history came back for the wallet that had just been replaced — a
+// restored wallet holding 400 sats displayed 0. Disconnect nulls the client by hand,
+// which is why removing and re-importing the very same string appeared to fix it.
+//
+// Nothing about that failure looks like a bug from the outside: no error, no empty
+// state, just a confidently wrong number. Hence these.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const ROOT = path.join(__dirname, '..');
+const source = fs.readFileSync(path.join(ROOT, 'sidepanel.js'), 'utf8');
+
+function lift(pattern, label) {
+  const m = source.match(pattern);
+  if (!m) throw new Error('Could not find ' + label + ' in sidepanel.js');
+  return m[0];
+}
+
+const PK_A = 'a'.repeat(64);
+const PK_B = 'b'.repeat(64);
+const CONN_1 = 'nostr+walletconnect://w1?relay=wss%3A%2F%2Fr.example&secret=s1';
+const CONN_2 = 'nostr+walletconnect://w2?relay=wss%3A%2F%2Fr.example&secret=s2';
+
+// `var` so the mutable module state lands on the context's global object and the
+// assertions can read it back after each call.
+function harness({ pubkey, connection }) {
+  const made = [];      // connection string per client constructed
+  const closed = [];    // clients torn down
+  const monitors = [];  // start/stop of the balance monitor
+  const ctx = {
+    console,
+    state: { activePubkey: pubkey },
+    call: async (msg) => {
+      if (msg.type === 'SIDECAR_GET_NWC') return { connection: ctx.__conn };
+      throw new Error('unexpected call ' + msg.type);
+    },
+    window: {
+      SidecarNWC: {
+        makeClient: (conn) => {
+          made.push(conn);
+          const c = { conn, close: () => closed.push(conn) };
+          return c;
+        },
+      },
+    },
+    stopWalletMonitor: () => monitors.push('stop'),
+    startWalletMonitor: () => monitors.push('start'),
+    __conn: connection,
+  };
+  vm.createContext(ctx);
+  vm.runInContext(
+    'var nwc = null, nwcPubkey = null, nwcConn = null;' +
+    'var balanceCache = { pubkey: null, sats: null };' +
+    lift(/  async function ensureNwc\(\)\s*\{[\s\S]*?\n  \}/, 'ensureNwc') + '\n' +
+    'globalThis.ensureNwc = ensureNwc;',
+    ctx
+  );
+  return {
+    ctx, made, closed, monitors,
+    setConn: (c) => { ctx.__conn = c; },
+    setPubkey: (p) => { ctx.state.activePubkey = p; },
+    seedBalance: (pk, sats) => vm.runInContext(
+      `balanceCache = { pubkey: ${JSON.stringify(pk)}, sats: ${sats} };`, ctx
+    ),
+    balance: () => vm.runInContext('balanceCache', ctx),
+  };
+}
+
+// ---- caching ------------------------------------------------------------------
+
+test('the same account and the same connection reuses one client', async () => {
+  const h = harness({ pubkey: PK_A, connection: CONN_1 });
+  const a = await h.ctx.ensureNwc();
+  const b = await h.ctx.ensureNwc();
+  assert.equal(h.made.length, 1, 'a second client would mean a leaked socket per call');
+  assert.equal(a, b, 'same client instance');
+});
+
+test('a NEW connection on the SAME account rebuilds the client — the bug', async () => {
+  const h = harness({ pubkey: PK_A, connection: CONN_1 });
+  const first = await h.ctx.ensureNwc();
+  h.setConn(CONN_2);                       // Restore / connect a different wallet
+  const second = await h.ctx.ensureNwc();
+  assert.notEqual(first, second, 'kept talking to the wallet that was replaced');
+  assert.deepEqual([...h.made], [CONN_1, CONN_2]);
+  assert.deepEqual([...h.closed], [CONN_1], 'the old client must be closed, not leaked');
+});
+
+test('switching account rebuilds the client', async () => {
+  const h = harness({ pubkey: PK_A, connection: CONN_1 });
+  await h.ctx.ensureNwc();
+  h.setPubkey(PK_B);
+  h.setConn(CONN_2);
+  await h.ctx.ensureNwc();
+  assert.deepEqual([...h.made], [CONN_1, CONN_2]);
+});
+
+test('the client is rebuilt for a new connection even when the string only just changed', async () => {
+  // Guards the exact report: restoring a string that MATCHED a previous backup still
+  // has to rebuild, because what matters is the string in use, not its provenance.
+  const h = harness({ pubkey: PK_A, connection: CONN_1 });
+  await h.ctx.ensureNwc();
+  h.setConn(CONN_2);
+  await h.ctx.ensureNwc();
+  h.setConn(CONN_1);                       // restored back to the original
+  await h.ctx.ensureNwc();
+  assert.deepEqual([...h.made], [CONN_1, CONN_2, CONN_1]);
+});
+
+// ---- the stale balance --------------------------------------------------------
+
+test('a balance from the previous wallet is dropped when the connection changes', async () => {
+  const h = harness({ pubkey: PK_A, connection: CONN_1 });
+  await h.ctx.ensureNwc();
+  h.seedBalance(PK_A, 0);                  // the replaced wallet's balance
+  h.setConn(CONN_2);
+  await h.ctx.ensureNwc();
+  assert.equal(h.balance().sats, null, 'a wrong number is worse than no number');
+  assert.equal(h.balance().pubkey, null);
+});
+
+test('the balance is NOT dropped when nothing changed', async () => {
+  const h = harness({ pubkey: PK_A, connection: CONN_1 });
+  await h.ctx.ensureNwc();
+  h.seedBalance(PK_A, 400);
+  await h.ctx.ensureNwc();                 // same account, same connection
+  assert.equal(h.balance().sats, 400, 'clearing every call would flicker the balance');
+});
+
+// ---- no wallet ----------------------------------------------------------------
+
+test('no connection returns null and tears down any live client', async () => {
+  const h = harness({ pubkey: PK_A, connection: CONN_1 });
+  await h.ctx.ensureNwc();
+  h.setConn(undefined);                    // disconnected
+  const r = await h.ctx.ensureNwc();
+  assert.equal(r, null);
+  assert.deepEqual([...h.closed], [CONN_1], 'the old client kept polling a wallet that is gone');
+  assert.equal(h.monitors.filter((m) => m === 'stop').length, 2);
+});
+
+test('no connection and no client is a quiet null', async () => {
+  const h = harness({ pubkey: PK_A, connection: undefined });
+  assert.equal(await h.ctx.ensureNwc(), null);
+  assert.equal(h.made.length, 0);
+});
+
+// ---- the monitor -------------------------------------------------------------
+
+test('the balance monitor follows the client it belongs to', async () => {
+  const h = harness({ pubkey: PK_A, connection: CONN_1 });
+  await h.ctx.ensureNwc();
+  h.setConn(CONN_2);
+  await h.ctx.ensureNwc();
+  // Each rebuild stops the old monitor before starting one on the new client;
+  // otherwise the old wallet keeps pushing balance updates over the new one.
+  assert.deepEqual([...h.monitors], ['stop', 'start', 'stop', 'start']);
+});


### PR DESCRIPTION
Two bugs that both showed a confident wrong answer rather than an error, plus the guards that were missing around them.

## 1. "Backed up ✓" vouched for the wrong wallet

`hasNwcBackup()` was a bare existence test:

```js
return !!(await fetchBackupEvent(NWC_BACKUP_DTAG));
```

kind:30078 is replaceable by `(pubkey, kind, d-tag)`, so connecting a new wallet left the previous ciphertext sitting on the relays and the status line kept reading "Backed up ✓". It pointed at a connection string the user no longer had — the one case that needed to speak up was the case that stayed quiet.

`nwcBackupState()` now decrypts the backup and compares it to the connected string. Four states, **failing closed**: no connection, a failed decrypt, or a relay timeout all report `unknown`, never `current`.

| state | pill | color | second line | confirms? |
|---|---|---|---|---|
| `current` | Backed up ✓ | gold | — | no |
| `stale` | Not backed up | warn | The backup is a different wallet. | **yes** |
| `none` | Not backed up | faint | — | no |
| `unknown` | Couldn't check | faint | — | **yes** |

`stale` and `none` share a label on purpose. If the stored copy isn't this wallet then this wallet isn't backed up, and that's what the user acts on. Naming the backup's age instead ("Out of date") misreads against the adjacent "Wallet connection" label, as though the connection were the stale thing. A test pins the duplication so nobody tidies it away.

Compares whole strings rather than parsed pubkey + secret — two URIs for one wallet can differ in param order, so this can report `stale` for the same wallet. That false positive prompts a harmless re-backup; a false `current` loses a wallet.

## 2. Restoring a wallet showed the previous wallet's balance

Reported from testing: restoring a wallet with 400 sats displayed 0, history came back empty, and the only fix was removing and re-importing the identical string.

`ensureNwc()` cached the client under `state.activePubkey` alone. Swapping wallets inside one account doesn't change the account, so it handed back a client still pointed at the wallet that had just been replaced. The numbers were real — just from the wrong wallet. Disconnect nulls the client by hand, which is why the remove-and-re-import dance worked; it had nothing to do with the string.

Now keyed on `(account, connection)`. Fixed at the choke point rather than adding an invalidation call to Restore, because "every writer must remember to invalidate" is the shape that produced this: Disconnect remembered, Restore didn't, and the manual connect path doesn't either — it's only masked by being unreachable while a wallet is attached.

`balanceCache` is keyed by account too, so it survived the swap and painted the old number from cache. `ensureNwc` drops it when the connection changes, and `restoreNwcFromRelays` drops it as well, since the former runs after the screen has already painted. Lock already did both; Restore never followed that precedent. The balance monitor was leaking the same way, still bound to the replaced wallet's client.

## Guards, none of which existed

- **Back up** warns when the relays hold a *different* wallet — that overwrite is irreversible. It points at **Restore**, not Export: Export reveals the **connected** wallet, so "export it first" would save the wrong string. The old one only exists in that relay record.
- **Restore** warns that it replaces the connected wallet.
- Neither asks for `none` (nothing stored) or `current` (same string).

Both confirms use `[action, Cancel]` and `danger`, matching `disconnectModal` — mine were the only two reversed, and orange is the encouraged-action color.

Also fixes the nudge's Back up button rendering as a grey UA box: `.explore-link` had only ever been used on `<a>`, so it resets no button chrome.

## Tests

23 new (103 total). Both fixes are **mutation-tested** — reverting either implementation fails the tests that describe it: 3 of 14 for the comparison, 5 of 9 for the cache key. Worth doing, since a harness that passes with and without the fix proves nothing.

Verified live: restore now shows the right balance and history immediately.

🍷 Decanted with [Claude Code](https://claude.com/claude-code)
