### PR TITLE
feat: review countdown for page comments, wider tracker stripping, draft recovery

### DIFF
--- a/sidepanel.html
+++ b/sidepanel.html
@@ -63,14 +63,23 @@
         <button id="search-btn" class="icon-btn" title="Find a profile or note" aria-expanded="false" aria-controls="search-bar">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="10" cy="10" r="9"></circle><line x1="21" y1="21" x2="16.35" y2="16.35"></line></svg>
         </button>
-        <!-- Comment on the current page (NIP-22 kind 1111). Feather's message-square
-             with three dots inside: a pencil reads as "edit", and the composer FAB
-             already owns the quill. Grouped with the bell and search — those three act
-             on content, while help/settings/lock are app chrome.
-             Dots sit at y=10 with 3 units' clearance from every wall, which renders as
-             ~3.2px dots at the topbar's 19px icon size: still legible, not mud. -->
+        <!-- Comment on the current page (NIP-22 kind 1111). Feather's message-circle:
+             a pencil reads as "edit", and the composer FAB already owns the quill.
+             Grouped with the bell and search — those three act on content, while
+             help/settings/lock are app chrome.
+             No dots inside the bubble. At the topbar's 19px they collapsed into a
+             smudge instead of reading as speech, and the rounded bubble carries the
+             meaning without them; the tail is what tells it apart from the magnifier
+             sitting beside it.
+             The path is stock message-circle scaled 1.10x about the viewBox center —
+             don't "restore" it to Feather's numbers. Its bubble is only 17 units
+             across where search's circle is 18 and help's is 20, and a circle reads
+             optically smaller than shapes that reach the corners, so unscaled it sat
+             visibly small in the row. Scaling the geometry inside the same 24-unit box
+             (rather than bumping the CSS size) keeps stroke-width 2 rendering at the
+             same weight as every other icon. -->
         <button id="comment-btn" class="icon-btn" title="Comment on this page">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path><circle cx="8" cy="10" r="1"></circle><circle cx="12" cy="10" r="1"></circle><circle cx="16" cy="10" r="1"></circle></svg>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.9 11.45a9.22 9.22 0 0 1-.99 4.18 9.35 9.35 0 0 1-8.36 5.17 9.22 9.22 0 0 1-4.18-.99L2.1 21.9l2.09-6.27a9.22 9.22 0 0 1-.99-4.18 9.35 9.35 0 0 1 5.17-8.36 9.22 9.22 0 0 1 4.18-.99h.55a9.33 9.33 0 0 1 8.8 8.8z"></path></svg>
         </button>
         <button id="help-btn" class="icon-btn" title="Help &amp; guides">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><circle cx="12" cy="12" r="4"></circle><line x1="4.93" y1="4.93" x2="9.17" y2="9.17"></line><line x1="14.83" y1="14.83" x2="19.07" y2="19.07"></line><line x1="14.83" y1="9.17" x2="19.07" y2="4.93"></line><line x1="9.17" y1="14.83" x2="4.93" y2="19.07"></line></svg>

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -805,12 +805,44 @@
     if (a) showNotifModal(a);
   });
 
+  // In-progress comment text, keyed by account + target URL. Clicking the overlay
+  // dismisses the modal, and losing a half-written comment to a stray click is
+  // infuriating in a panel this narrow.
+  //
+  // Memory only, NOT chrome.storage, unlike the note composer's drafts. A comment is
+  // tied to a page you're looking at, so it only has to survive reopening the modal
+  // while that URL is still around — outliving the panel would mean stashing text
+  // about someone's browsing on disk, which is a worse trade than retyping.
+  //
+  // Keyed by pubkey too: the note composer scopes drafts per account, and finding
+  // another account's half-written comment waiting for you would be a surprise.
+  const webCommentDrafts = new Map();
+  const WEB_COMMENT_DRAFT_MAX = 20; // abandoned drafts shouldn't accumulate forever
+
+  const webCommentDraftKey = (pubkey, url) => String(pubkey) + '\n' + String(url);
+
+  function saveWebCommentDraft(pubkey, url, text) {
+    if (!url) return; // no target resolved yet — nothing to key on
+    const key = webCommentDraftKey(pubkey, url);
+    if (!text || !text.trim()) { webCommentDrafts.delete(key); return; }
+    webCommentDrafts.delete(key); // re-insert so eviction below is least-recent-first
+    webCommentDrafts.set(key, text);
+    while (webCommentDrafts.size > WEB_COMMENT_DRAFT_MAX) {
+      webCommentDrafts.delete(webCommentDrafts.keys().next().value);
+    }
+  }
+
   // Comment on the page in the active tab. Opened from the topbar pencil.
   //
   // Deliberately built to the New-note convention rather than its own shape: same
   // "Posting as" header, same Write/Preview tabs, same link card, same button
   // order. A second composer that looked different would read as a different app.
   function webCommentModal() {
+    // Declared out here so the modal's onClose can reach it. Without that teardown a
+    // countdown left running after the modal is dismissed would still fire and
+    // publish the comment — closing the dialog has to mean it doesn't go out.
+    let countdown = null;
+    const stopCountdown = () => { if (countdown) { countdown.stop(); countdown = null; } };
     openModal((modal) => {
       const err = h('div', { className: 'error' });
 
@@ -834,8 +866,12 @@
       // The note composer's editor, reused verbatim, so a comment can tag people
       // the same way a note can. Mentions land as nostr: pills that
       // buildWebComment turns into the p tags a client needs to notify them.
+      // onChange keeps the draft current on every keystroke rather than saving on
+      // close \u2014 the overlay click path tears the modal down without going through
+      // Cancel, so anything deferred to teardown is the thing that gets lost.
       const commentEditor = createMentionEditor({
         placeholder: 'Write a comment about this page\u2026',
+        onChange: (text) => saveWebCommentDraft(state.activePubkey, target, text),
       });
       const previewPane = h('div', { className: 'compose-preview hidden' });
 
@@ -855,29 +891,44 @@
       // box with no subject.
       const targetBlock = h('div', { className: 'webcomment-target' });
 
-      function renderTarget() {
-        targetBlock.innerHTML = '';
+      // Takes a container so the review countdown can render its own copy rather
+      // than borrowing this one out of the editor pane and having to put it back.
+      function renderTargetInto(into) {
+        into.innerHTML = '';
         if (!target) return;
         if (ogMeta === undefined) {
-          targetBlock.append(h('div', { className: 'link-card loading' }));
+          into.append(h('div', { className: 'link-card loading' }));
         } else if (ogMeta) {
           const card = h('a', { className: 'link-card' });
           renderLinkCard(card, target, ogMeta);
-          targetBlock.append(card);
+          into.append(card);
         }
         // The URL is what actually gets published, so it stays visible even when a
         // card renders — as a caption, not the headline.
-        targetBlock.append(h('div', { className: 'webcomment-url', textContent: target }));
+        into.append(h('div', { className: 'webcomment-url', textContent: target }));
       }
+      function renderTarget() { renderTargetInto(targetBlock); }
 
       // Preview now shows only the comment itself, since the target is permanent
       // above.
       function renderPreview() {
         previewPane.innerHTML = '';
         const text = commentEditor.getText().trim();
-        previewPane.append(text
-          ? h('div', { className: 'webcomment-preview-text', textContent: text })
-          : h('p', { className: 'hint', textContent: 'Nothing written yet.' }));
+        if (!text) {
+          previewPane.append(h('p', { className: 'hint', textContent: 'Nothing written yet.' }));
+          return;
+        }
+        // renderNotePreview, not textContent: a mention serializes to a bare
+        // `nostr:npub1…` token, so the raw string showed the reader a 63-character
+        // key where the published comment shows a name.
+        previewPane.append(commentBodyPreview(text));
+      }
+
+      // Shared by the Preview tab and the review countdown so they can't drift.
+      function commentBodyPreview(text) {
+        const body = h('div', { className: 'webcomment-preview-text' });
+        renderNotePreview(body, text);
+        return body;
       }
 
       function showTab(which) {
@@ -900,11 +951,30 @@
         return a;
       };
 
-      post.addEventListener('click', async () => {
+      const heading = h('h3', { textContent: 'Comment on this page' });
+      const actions = h('div', { className: 'actions' }, [post, cancel]);
+
+      // The editor pane. Re-appending the same nodes is enough to come back from the
+      // countdown, which clears the modal to take it over.
+      function showCommentEditor() {
+        stopCountdown();
+        modal.innerHTML = '';
+        modal.append(
+          heading,
+          author,
+          targetBlock, // above the tabs: the subject, not one of the two views
+          tabBar,
+          commentEditor.wrap,
+          previewPane,
+          err,
+          done,
+          actions
+        );
+      }
+
+      async function doPost() {
         const text = commentEditor.getText().trim();
-        if (!target) return (err.textContent = 'No page to comment on.');
-        if (!text) return (err.textContent = 'Write something first.');
-        err.textContent = '';
+        showCommentEditor(); // the countdown may have replaced the pane
         post.disabled = true;
         post.textContent = 'Posting\u2026';
         try {
@@ -916,6 +986,9 @@
             event: buildWebComment(target, text, withClient),
           });
           await publishSigned(signed);
+          // Only after it's actually out. Dropping the draft on a failed publish would
+          // lose the text at the exact moment the user still needs it.
+          saveWebCommentDraft(state.activePubkey, target, '');
           let nevent = '';
           try {
             nevent = NT.nip19.neventEncode({ id: signed.id, author: signed.pubkey, relays: [] });
@@ -942,19 +1015,42 @@
           post.disabled = false;
           post.textContent = 'Post comment';
         }
+      }
+
+      post.addEventListener('click', async () => {
+        const text = commentEditor.getText().trim();
+        if (!target) return (err.textContent = 'No page to comment on.');
+        if (!text) return (err.textContent = 'Write something first.');
+        err.textContent = '';
+        // Same setting the note composer reads — "Review countdown before posting"
+        // covers everything publishable, so this doesn't get a switch of its own.
+        const { on, secs } = await postCountdownSetting();
+        if (!on) return doPost();
+        // The review screen leads with the page, not the text. A comment inherits its
+        // target from whichever tab was active when the modal opened, and that is the
+        // mistake nothing else in the flow would catch — posting on the wrong page
+        // isn't visible until it's already published on someone else's site.
+        const cdPreview = h('div', { className: 'countdown-preview' });
+        const cdTarget = h('div', { className: 'webcomment-target' });
+        renderTargetInto(cdTarget);
+        cdPreview.append(cdTarget, commentBodyPreview(text));
+        countdown = showPostCountdown({
+          modal,
+          secs,
+          title: 'Posting your comment',
+          hint: 'Check the page and your comment before it posts.',
+          preview: cdPreview,
+          onFire: doPost,
+          onCancel: () => {
+            showCommentEditor();
+            post.disabled = false;
+            post.textContent = 'Post comment';
+            commentEditor.focus();
+          },
+        });
       });
 
-      modal.append(
-        h('h3', { textContent: 'Comment on this page' }),
-        author,
-        targetBlock, // above the tabs: the subject, not one of the two views
-        tabBar,
-        commentEditor.wrap,
-        previewPane,
-        err,
-        done,
-        h('div', { className: 'actions' }, [post, cancel])
-      );
+      showCommentEditor();
 
       // Resolve the tab only after the modal is up \u2014 never speculatively, since this
       // URL is about to be published.
@@ -968,6 +1064,19 @@
         }
         target = url;
         post.disabled = false;
+
+        // Bring back whatever was being written for this page. The target resolves
+        // asynchronously, so anything typed in the meantime already exists in the
+        // editor and wins — restoring over it would delete what the user just typed
+        // to hand them something older.
+        const typedAlready = commentEditor.getText().trim();
+        if (typedAlready) {
+          saveWebCommentDraft(state.activePubkey, target, commentEditor.getText());
+        } else {
+          const saved = webCommentDrafts.get(webCommentDraftKey(state.activePubkey, target));
+          if (saved) commentEditor.setText(saved);
+        }
+
         renderTarget(); // shows the URL and a loading card immediately
         commentEditor.focus();
         // The card fills in when the fetch lands; the Write pane is usable throughout
@@ -977,7 +1086,7 @@
           .catch(() => { ogMeta = null; })
           .then(renderTarget);
       });
-    });
+    }, stopCountdown);
   }
 
   // ---- search: paste an identifier, open it in your client ----
@@ -1628,11 +1737,49 @@
 
   // Params that identify where a visitor came FROM, never which page they're on.
   // Left in, every share link spawns its own thread.
+  //
+  // Deliberately a denylist, never "strip the whole query". For plenty of sites the
+  // query IS the page (youtube.com/watch?v=…), and dropping a load-bearing param is
+  // strictly worse than a split thread: the published identifier would then point at
+  // a URL rendering different content, or nothing. Anything ambiguous stays — `ref`
+  // in particular is functional often enough to leave alone.
   const TRACKING_PARAMS = [
-    'utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content', 'utm_id',
-    'fbclid', 'gclid', 'gbraid', 'wbraid', 'msclkid', 'twclid', 'igshid', 'mc_cid',
-    'mc_eid', 'ref_src', 'ref_url', 's_kwcid', 'yclid', '_ga', 'ttclid',
+    // ad-click IDs
+    'fbclid', 'gclid', 'dclid', 'gbraid', 'wbraid', 'msclkid', 'twclid', 'ttclid',
+    'yclid', 'igshid', 'li_fat_id', 'epik', 'rdt_cid', 'sccid', 'srsltid', 's_kwcid',
+    // email + marketing platforms
+    'mc_cid', 'mc_eid', 'mkt_tok', '_hsenc', '_hsmi', 'vero_conv', 'vero_id',
+    'oly_anon_id', 'oly_enc_id', '__s',
+    // analytics and referrer echoes
+    '_ga', '_openstat', 'ref_src', 'ref_url', 'ncid', 'spm', 'at_medium', 'at_campaign',
+    // Yahoo consent-redirect residue
+    'guccounter', 'guce_referrer', 'guce_referrer_sig',
+    // Facebook share callbacks
+    'fb_action_ids', 'fb_action_types', 'fb_ref', 'fb_source',
+    'action_object_map', 'action_type_map', 'action_ref_map',
   ];
+
+  // Namespaces that exist only for analytics, so the whole family goes without
+  // enumerating it. `utm_` alone has a dozen variants past the common five
+  // (utm_name, utm_source_platform, utm_marketing_tactic, …) and vendors keep adding
+  // more — matching the prefix is what actually answers "utm junk", where a fixed
+  // list silently rots.
+  const TRACKING_PREFIXES = ['utm_', 'pk_', 'piwik_', 'mtm_', 'hsa_'];
+
+  // Pure tracking on a specific host, but possibly load-bearing elsewhere, so only
+  // stripped where we know what it means. YouTube's `si` is the most common
+  // real-world splitter there is: every press of Share mints a fresh one, so one
+  // video would otherwise carry a separate thread per sharer.
+  const HOST_TRACKING_PARAMS = [
+    { host: /(^|\.)(youtube\.com|youtu\.be)$/i, params: ['si', 'pp', 'feature', 'kw'] },
+  ];
+
+  // Case-insensitive: the same vendor ships both `ScCid` and `sccid`, and a param
+  // that survives on a capital letter splits the thread just as effectively.
+  function isTrackingParam(name) {
+    const n = String(name).toLowerCase();
+    return TRACKING_PARAMS.includes(n) || TRACKING_PREFIXES.some((p) => n.startsWith(p));
+  }
 
   // Reduce a page URL to the identifier the comment is tagged with.
   // Returns { url } or { error } — never throws, and never guesses on refusal.
@@ -1653,7 +1800,13 @@
       return { error: 'That page is local, so nobody else could open the comment.' };
     }
     u.hash = ''; // NIP-73 requires no fragment: #section is the same document
-    for (const p of TRACKING_PARAMS) u.searchParams.delete(p);
+    // Snapshot the keys first: deleting while iterating searchParams skips entries.
+    for (const name of [...u.searchParams.keys()]) {
+      if (isTrackingParam(name)) u.searchParams.delete(name);
+    }
+    for (const rule of HOST_TRACKING_PARAMS) {
+      if (rule.host.test(u.hostname)) for (const p of rule.params) u.searchParams.delete(p);
+    }
     // The query itself stays — for plenty of sites it IS the page identity
     // (youtube.com/watch?v=…), so stripping it would merge unrelated pages.
     u.searchParams.sort(); // ?b=1&a=2 and ?a=2&b=1 are the same page
@@ -5330,6 +5483,93 @@
     });
   }
 
+  // The review window before something irreversible goes out, shared by the note
+  // composer and page comments. Takes over `modal` and returns a stop() so the caller
+  // can clear the interval if it tears the modal down another way.
+  //
+  // Signing happens inside onFire, never here — cancelling must not have produced a
+  // signature, and the countdown is the last point where cancelling is still free.
+  //
+  // `preview` is whatever the caller wants reviewed: the note composer passes its
+  // rendered note, a comment passes the target link card plus the comment text. That
+  // is the whole reason this is parameterized rather than duplicated — for a comment
+  // the URL is the thing most worth a second look, since it was captured from
+  // whichever tab happened to be active.
+  function showPostCountdown(opts) {
+    const { modal, secs, title, hint, preview, confirmLabel, onFire, onCancel } = opts;
+    modal.innerHTML = '';
+    let remaining = secs;
+    let timer = null;
+
+    const R = 30;
+    const C = 2 * Math.PI * R;
+    const ring = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    ring.setAttribute('viewBox', '0 0 72 72');
+    ring.setAttribute('class', 'countdown-ring');
+    ring.innerHTML =
+      '<circle cx="36" cy="36" r="' + R + '" class="ring-track"/>' +
+      '<circle cx="36" cy="36" r="' + R + '" class="ring-fill" ' +
+      'stroke-dasharray="' + C + '" stroke-dashoffset="0" transform="rotate(-90 36 36)"/>';
+    const num = h('div', { className: 'countdown-num', textContent: String(remaining) });
+    const ringWrap = h('div', { className: 'countdown-wrap' }, [ring, num]);
+
+    // Same identity strip as the editor — who's posting shouldn't be ambiguous right
+    // before it actually publishes.
+    const active = state.accounts.find((acc) => acc.pubkey === state.activePubkey);
+    const author = h('div', { className: 'compose-author' });
+    author.append(avatarEl(active || {}, 'compose-author-av'));
+    author.append(
+      h('div', { className: 'compose-author-info' }, [
+        h('span', { className: 'compose-author-eyebrow', textContent: 'Posting as' }),
+        h('span', { className: 'compose-author-name', textContent: active ? displayName(active) : '—' }),
+      ])
+    );
+
+    const stop = () => { if (timer) { clearInterval(timer); timer = null; } };
+    const now = h('button', { className: 'primary', textContent: confirmLabel || 'Post now' });
+    const cancel = h('button', { className: 'ghost', textContent: 'Cancel' });
+
+    async function fire() {
+      stop();
+      now.disabled = true;
+      now.textContent = 'Posting…';
+      await onFire();
+    }
+    now.addEventListener('click', fire);
+    cancel.addEventListener('click', () => { stop(); onCancel(); });
+
+    modal.append(
+      h('h3', { textContent: title }),
+      author,
+      h('p', { className: 'hint', textContent: hint || 'Review before it posts.' }),
+      preview,
+      ringWrap,
+      h('div', { className: 'actions' }, [now, cancel])
+    );
+
+    const fill = ring.querySelector('.ring-fill');
+    timer = setInterval(() => {
+      remaining -= 1;
+      num.textContent = String(Math.max(remaining, 0));
+      fill.setAttribute('stroke-dashoffset', String(C * (1 - remaining / secs)));
+      if (remaining <= 0) fire();
+    }, 1000);
+
+    return { stop };
+  }
+
+  // Resolved once per post: the toggle is worded "Review countdown before posting"
+  // and covers everything publishable, so comments read the same setting as notes
+  // rather than adding a second switch that would drift out of step.
+  async function postCountdownSetting() {
+    let s = {};
+    try { s = (await call({ type: 'SIDECAR_GET_SETTINGS' })) || {}; } catch (_) {}
+    const secs = NOTE_COUNTDOWN_PRESETS.includes(s.noteCountdownSecs)
+      ? s.noteCountdownSecs
+      : NOTE_COUNTDOWN_DEFAULT;
+    return { on: s.noteCountdown !== false, secs }; // default on
+  }
+
   async function openComposer(initialText) {
     if (!state.activePubkey) {
       toast('Add an account first', 'error');
@@ -5338,7 +5578,7 @@
     const pubkey = state.activePubkey;
     let draft = { text: initialText || '', media: [] };
     const modal = $('modal');
-    let timer = null;
+    let countdown = null; // active review countdown, if any (see showPostCountdown)
     let saveTimer = null;
     let published = false;
     let enteredEditor = false;
@@ -5369,7 +5609,7 @@
     }
 
     function showEditor() {
-      if (timer) { clearInterval(timer); timer = null; }
+      stopCountdown();
       enteredEditor = true;
       modal.innerHTML = '';
 
@@ -5526,9 +5766,7 @@
       function updatePostState() { post.disabled = !draft.text.trim() && !draft.media.length; }
       post.addEventListener('click', async () => {
         if (post.disabled) return;
-        const s = await call({ type: 'SIDECAR_GET_SETTINGS' });
-        const on = s.noteCountdown !== false; // default on
-        const secs = NOTE_COUNTDOWN_PRESETS.includes(s.noteCountdownSecs) ? s.noteCountdownSecs : NOTE_COUNTDOWN_DEFAULT;
+        const { on, secs } = await postCountdownSetting();
         if (on) {
           showCountdown(secs);
         } else {
@@ -5583,71 +5821,27 @@
       }
     }
 
+    // Delegates to the shared countdown; the composer supplies the note preview and
+    // what to do when it fires or is cancelled.
     function showCountdown(secs) {
-      modal.innerHTML = '';
-      let remaining = secs;
-
-      // Full-size countdown ring, centered below the note preview.
-      const R = 30;
-      const C = 2 * Math.PI * R;
-      const ring = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-      ring.setAttribute('viewBox', '0 0 72 72');
-      ring.setAttribute('class', 'countdown-ring');
-      ring.innerHTML =
-        '<circle cx="36" cy="36" r="' + R + '" class="ring-track"/>' +
-        '<circle cx="36" cy="36" r="' + R + '" class="ring-fill" ' +
-        'stroke-dasharray="' + C + '" stroke-dashoffset="0" transform="rotate(-90 36 36)"/>';
-      const num = h('div', { className: 'countdown-num', textContent: String(remaining) });
-      const ringWrap = h('div', { className: 'countdown-wrap' }, [ring, num]);
-
-      // Same identity strip as the editor — who's posting shouldn't be ambiguous
-      // right before it actually publishes.
-      const active = state.accounts.find((acc) => acc.pubkey === state.activePubkey);
-      const author = h('div', { className: 'compose-author' });
-      author.append(avatarEl(active || {}, 'compose-author-av'));
-      author.append(
-        h('div', { className: 'compose-author-info' }, [
-          h('span', { className: 'compose-author-eyebrow', textContent: 'Posting as' }),
-          h('span', { className: 'compose-author-name', textContent: active ? displayName(active) : '—' }),
-        ])
-      );
-
-      // The note exactly as it will be published, for a last review.
       const previewScroll = h('div', { className: 'countdown-preview' });
       const previewBody = h('div', { className: 'preview-body' });
       const bodyText = draft.text.trim();
       if (bodyText) renderNotePreview(previewBody, bodyText);
       else previewBody.append(h('p', { className: 'hint', textContent: 'Empty note.' }));
       previewScroll.append(previewBody);
+      countdown = showPostCountdown({
+        modal,
+        secs,
+        title: 'Posting your note',
+        preview: previewScroll,
+        onFire: finishPublish,
+        onCancel: showEditor,
+      });
+    }
 
-      const now = h('button', { className: 'primary', textContent: 'Post now' });
-      const cancel = h('button', { className: 'ghost', textContent: 'Cancel' });
-
-      async function fire() {
-        if (timer) { clearInterval(timer); timer = null; }
-        now.disabled = true;
-        now.textContent = 'Posting…';
-        await finishPublish();
-      }
-      now.addEventListener('click', fire);
-      cancel.addEventListener('click', () => { showEditor(); });
-
-      modal.append(
-        h('h3', { textContent: 'Posting your note' }),
-        author,
-        h('p', { className: 'hint', textContent: 'Review before it posts.' }),
-        previewScroll,
-        ringWrap,
-        h('div', { className: 'actions' }, [now, cancel])
-      );
-
-      const fill = ring.querySelector('.ring-fill');
-      timer = setInterval(() => {
-        remaining -= 1;
-        num.textContent = String(Math.max(remaining, 0));
-        fill.setAttribute('stroke-dashoffset', String(C * (1 - remaining / secs)));
-        if (remaining <= 0) fire();
-      }, 1000);
+    function stopCountdown() {
+      if (countdown) { countdown.stop(); countdown = null; }
     }
 
     // Offer to resume a saved draft (or start fresh) before opening the editor.
@@ -5699,7 +5893,7 @@
     openModal(
       () => { if (hasSaved) showDraftChooser(saved); else showEditor(); },
       () => {
-        if (timer) { clearInterval(timer); timer = null; }
+        stopCountdown();
         if (saveTimer) { clearTimeout(saveTimer); saveTimer = null; }
         // Persist on close only once the user has actually edited — closing the
         // chooser without choosing must not overwrite the saved draft.

--- a/test/post-countdown.test.js
+++ b/test/post-countdown.test.js
@@ -1,0 +1,128 @@
+'use strict';
+
+// Unit coverage for postCountdownSetting() — the gate that decides whether the review
+// window appears before something irreversible is published.
+//
+// The countdown itself is DOM work and isn't unit-testable here, but WHETHER it runs
+// is pure logic, and it fails in the dangerous direction if it gets this wrong: a
+// missing countdown means a note or comment goes out with no chance to catch it. So
+// the default has to be on, and anything unreadable has to resolve to on as well.
+//
+// Comments deliberately read the SAME setting as notes. The toggle is worded "Review
+// countdown before posting" and covers everything publishable; a second switch would
+// drift out of step with the first.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const ROOT = path.join(__dirname, '..');
+const source = fs.readFileSync(path.join(ROOT, 'sidepanel.js'), 'utf8');
+
+function lift(pattern, label) {
+  const m = source.match(pattern);
+  if (!m) throw new Error('Could not find ' + label + ' in sidepanel.js');
+  return m[0];
+}
+
+function harness(settings, { throws } = {}) {
+  const ctx = {
+    console,
+    call: async (msg) => {
+      if (msg.type !== 'SIDECAR_GET_SETTINGS') throw new Error('unexpected ' + msg.type);
+      if (throws) throw new Error('locked');
+      return settings;
+    },
+  };
+  vm.createContext(ctx);
+  vm.runInContext(
+    lift(/const NOTE_COUNTDOWN_PRESETS = \[[^\]]*\];/, 'NOTE_COUNTDOWN_PRESETS') + '\n' +
+    lift(/const NOTE_COUNTDOWN_DEFAULT = \d+;/, 'NOTE_COUNTDOWN_DEFAULT') + '\n' +
+    lift(/async function postCountdownSetting\(\)\s*\{[\s\S]*?\n  \}/, 'postCountdownSetting') + '\n' +
+    'globalThis.postCountdownSetting = postCountdownSetting;' +
+    'globalThis.PRESETS = NOTE_COUNTDOWN_PRESETS;' +
+    'globalThis.DEFAULT_SECS = NOTE_COUNTDOWN_DEFAULT;',
+    ctx
+  );
+  return ctx;
+}
+
+// ---- the default is ON ---------------------------------------------------------
+
+test('a user who has never touched the setting gets the countdown', async () => {
+  const ctx = harness({});
+  const r = await ctx.postCountdownSetting();
+  assert.equal(r.on, true, 'absent must mean on, not off');
+  assert.equal(r.secs, ctx.DEFAULT_SECS);
+});
+
+test('only an explicit false turns it off', async () => {
+  assert.equal((await harness({ noteCountdown: false }).postCountdownSetting()).on, false);
+  for (const v of [true, undefined, null, 0, '', 'no']) {
+    // Anything that isn't literally `false` keeps the guard on. A stored 0 or ''
+    // from some future migration must not silently disable it.
+    const r = await harness({ noteCountdown: v }).postCountdownSetting();
+    assert.equal(r.on, true, 'noteCountdown=' + JSON.stringify(v) + ' should stay on');
+  }
+});
+
+test('unreadable settings fail toward showing the countdown', async () => {
+  // A locked keystore or a dead message port must not be a silent way to skip the
+  // review window — the whole point is that publishing is irreversible.
+  const r = await harness(null, { throws: true }).postCountdownSetting();
+  assert.equal(r.on, true);
+  assert.equal(r.secs, 15);
+});
+
+test('a null settings object does not throw', async () => {
+  const r = await harness(null).postCountdownSetting();
+  assert.equal(r.on, true);
+});
+
+// ---- the duration -------------------------------------------------------------
+
+test('a stored preset is honored', async () => {
+  const ctx = harness({ noteCountdownSecs: 5 });
+  for (const secs of ctx.PRESETS) {
+    assert.equal((await harness({ noteCountdownSecs: secs }).postCountdownSetting()).secs, secs);
+  }
+});
+
+test('a value outside the presets falls back to the default', async () => {
+  // Guards against a hand-edited or migrated setting producing a 0-second countdown,
+  // which would look like the feature is on while giving no time to react.
+  for (const bad of [0, -5, 1, 999, 7.5, '10', null, undefined, NaN]) {
+    const r = await harness({ noteCountdownSecs: bad }).postCountdownSetting();
+    assert.equal(r.secs, 15, 'noteCountdownSecs=' + JSON.stringify(bad));
+  }
+});
+
+test('every preset is a usable number of seconds', async () => {
+  const ctx = harness({});
+  for (const s of ctx.PRESETS) {
+    assert.equal(typeof s, 'number');
+    assert.ok(s >= 3, 'a countdown under 3s leaves no time to cancel: ' + s);
+  }
+  assert.ok(ctx.PRESETS.includes(ctx.DEFAULT_SECS), 'the default must be selectable');
+});
+
+// ---- one setting, not two -----------------------------------------------------
+
+test('comments and notes read the same setting key', () => {
+  // Structural, on purpose. If someone adds a `commentCountdown` later, the two
+  // controls will disagree and the Settings pane will carry two switches for one
+  // idea — the thing this design decision was made to avoid.
+  assert.ok(!/commentCountdown/.test(source),
+    'a separate comment countdown setting was introduced');
+  // Both post paths go through the shared resolver rather than reading settings inline.
+  const readers = source.match(/noteCountdown\b/g) || [];
+  assert.ok(readers.length <= 3,
+    'noteCountdown is read in ' + readers.length + ' places; it should be the resolver + settings UI only');
+});
+
+test('the shared countdown is used by both callers', () => {
+  const uses = source.match(/showPostCountdown\(\{/g) || [];
+  assert.equal(uses.length, 2, 'expected exactly the note composer and the comment modal');
+});

--- a/test/web-comment-draft.test.js
+++ b/test/web-comment-draft.test.js
@@ -1,0 +1,168 @@
+'use strict';
+
+// Unit coverage for the web-comment draft store in sidepanel.js.
+//
+// The bug: clicking the overlay dismisses the comment modal, and the half-written
+// comment went with it. Nothing was saved, so a stray click outside a narrow panel
+// meant retyping. Saving is now done on every keystroke rather than at teardown —
+// the overlay path never goes through Cancel, so anything deferred to close is
+// exactly what gets lost.
+//
+// Scope is deliberately narrower than the note composer's drafts: memory only, no
+// chrome.storage. A comment belongs to a page you're looking at, so it only has to
+// survive reopening the modal while that URL is still around. Persisting it would
+// mean writing text about someone's browsing to disk.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const ROOT = path.join(__dirname, '..');
+const source = fs.readFileSync(path.join(ROOT, 'sidepanel.js'), 'utf8');
+
+function lift(pattern, label) {
+  const m = source.match(pattern);
+  if (!m) throw new Error('Could not find ' + label + ' in sidepanel.js');
+  return m[0];
+}
+
+const PK_A = 'a'.repeat(64);
+const PK_B = 'b'.repeat(64);
+const URL_1 = 'https://example.com/one';
+const URL_2 = 'https://example.com/two';
+
+function harness() {
+  const ctx = { console };
+  vm.createContext(ctx);
+  vm.runInContext(
+    lift(/const webCommentDrafts = new Map\(\);/, 'webCommentDrafts') + '\n' +
+    lift(/const WEB_COMMENT_DRAFT_MAX = \d+;[^\n]*/, 'WEB_COMMENT_DRAFT_MAX') + '\n' +
+    lift(/const webCommentDraftKey = [^\n]+/, 'webCommentDraftKey') + '\n' +
+    lift(/function saveWebCommentDraft\(pubkey, url, text\)\s*\{[\s\S]*?\n  \}/, 'saveWebCommentDraft') + '\n' +
+    'globalThis.save = saveWebCommentDraft;' +
+    'globalThis.key = webCommentDraftKey;' +
+    'globalThis.drafts = webCommentDrafts;' +
+    'globalThis.MAX = WEB_COMMENT_DRAFT_MAX;',
+    ctx
+  );
+  const get = (pk, url) => ctx.drafts.get(ctx.key(pk, url));
+  return { ctx, save: ctx.save, get, size: () => ctx.drafts.size };
+}
+
+// ---- the reported bug ----------------------------------------------------------
+
+test('a draft survives to be read back for the same page', () => {
+  const h = harness();
+  h.save(PK_A, URL_1, 'half a thought');
+  assert.equal(h.get(PK_A, URL_1), 'half a thought');
+});
+
+test('each URL keeps its own draft', () => {
+  const h = harness();
+  h.save(PK_A, URL_1, 'about page one');
+  h.save(PK_A, URL_2, 'about page two');
+  assert.equal(h.get(PK_A, URL_1), 'about page one');
+  assert.equal(h.get(PK_A, URL_2), 'about page two');
+});
+
+test('a draft is scoped to the account that wrote it', () => {
+  // The note composer scopes drafts per account; finding someone else's half-written
+  // comment waiting in your editor would be a surprise.
+  const h = harness();
+  h.save(PK_A, URL_1, 'written as A');
+  assert.equal(h.get(PK_B, URL_1), undefined);
+});
+
+test('the key cannot collide across a pubkey/url boundary', () => {
+  // Concatenation with a separator that cannot appear in either half. A naive
+  // pubkey+url join would let one pair impersonate another.
+  const h = harness();
+  assert.notEqual(h.ctx.key(PK_A, URL_1), h.ctx.key(PK_A + URL_1, ''));
+  assert.ok(h.ctx.key(PK_A, URL_1).includes('\n'));
+});
+
+// ---- clearing -----------------------------------------------------------------
+
+test('empty text removes the entry instead of storing a blank', () => {
+  const h = harness();
+  h.save(PK_A, URL_1, 'typed then deleted');
+  h.save(PK_A, URL_1, '');
+  assert.equal(h.get(PK_A, URL_1), undefined);
+  assert.equal(h.size(), 0, 'a blank entry would still count against the cap');
+});
+
+test('whitespace-only text counts as empty', () => {
+  const h = harness();
+  h.save(PK_A, URL_1, 'real');
+  for (const blank of ['   ', '\n\n', '\t', ' \n ']) {
+    h.save(PK_A, URL_1, blank);
+    assert.equal(h.get(PK_A, URL_1), undefined, JSON.stringify(blank));
+    h.save(PK_A, URL_1, 'real');
+  }
+});
+
+test('leading and trailing whitespace is preserved in a real draft', () => {
+  // Only *emptiness* is trimmed for the decision — the stored text is verbatim, since
+  // trimming it would move the caret on restore.
+  const h = harness();
+  h.save(PK_A, URL_1, '  indented thought\n');
+  assert.equal(h.get(PK_A, URL_1), '  indented thought\n');
+});
+
+// ---- no target yet ------------------------------------------------------------
+
+test('nothing is stored before a target URL is known', () => {
+  // The target resolves asynchronously after the modal opens, so onChange can fire
+  // with url still null. Storing under null would make one bucket shared by every
+  // page — the next page opened would inherit the wrong draft.
+  const h = harness();
+  for (const noTarget of [null, undefined, '']) {
+    h.save(PK_A, noTarget, 'typed before the tab resolved');
+  }
+  assert.equal(h.size(), 0);
+});
+
+// ---- the cap ------------------------------------------------------------------
+
+test('abandoned drafts do not accumulate without bound', () => {
+  const h = harness();
+  for (let i = 0; i < h.ctx.MAX + 12; i++) h.save(PK_A, 'https://example.com/p' + i, 'draft ' + i);
+  assert.equal(h.size(), h.ctx.MAX);
+});
+
+test('the cap evicts the least recently written, keeping the newest', () => {
+  const h = harness();
+  for (let i = 0; i < h.ctx.MAX; i++) h.save(PK_A, 'https://example.com/p' + i, 'draft ' + i);
+  h.save(PK_A, 'https://example.com/NEW', 'the one being typed');
+  assert.equal(h.get(PK_A, 'https://example.com/p0'), undefined, 'oldest should go');
+  assert.equal(h.get(PK_A, 'https://example.com/NEW'), 'the one being typed',
+    'the draft in front of the user must never be the one evicted');
+  assert.equal(h.size(), h.ctx.MAX);
+});
+
+test('editing an existing draft refreshes its position, not just its text', () => {
+  // Without the delete-then-set, a long-lived draft the user keeps returning to would
+  // stay at its original insertion point and be evicted while still in active use.
+  const h = harness();
+  for (let i = 0; i < h.ctx.MAX; i++) h.save(PK_A, 'https://example.com/p' + i, 'draft ' + i);
+  h.save(PK_A, 'https://example.com/p0', 'still working on this one'); // touch the oldest
+  h.save(PK_A, 'https://example.com/NEW', 'newest');
+  assert.equal(h.get(PK_A, 'https://example.com/p0'), 'still working on this one',
+    'a touched draft should no longer be the eviction candidate');
+  assert.equal(h.get(PK_A, 'https://example.com/p1'), undefined, 'p1 is now the oldest');
+});
+
+// ---- not persisted ------------------------------------------------------------
+
+test('drafts are held in memory, never written to storage', () => {
+  // Structural: the whole point of the narrower scope. If this ever moves to
+  // chrome.storage it becomes a record of pages visited, sitting on disk.
+  const block = source.match(
+    /const webCommentDrafts = new Map\(\);[\s\S]*?\n  function webCommentModal\(\)/
+  );
+  assert.ok(block, 'could not isolate the draft store');
+  assert.ok(!/chrome\.storage/.test(block[0]),
+    'comment drafts must not be persisted to disk');
+});

--- a/test/web-comment.test.js
+++ b/test/web-comment.test.js
@@ -36,7 +36,10 @@ const ctx = { console, URL, Date, NT: require('nostr-tools') };
 vm.createContext(ctx);
 vm.runInContext(
   lift(/const WEB_COMMENT_KIND = \d+;/, 'WEB_COMMENT_KIND') + '\n' +
-  lift(/const TRACKING_PARAMS = \[[\s\S]*?\];/, 'TRACKING_PARAMS') + '\n' +
+  lift(/const TRACKING_PARAMS = \[[\s\S]*?\n  \];/, 'TRACKING_PARAMS') + '\n' +
+  lift(/const TRACKING_PREFIXES = \[[^\]]*\];/, 'TRACKING_PREFIXES') + '\n' +
+  lift(/const HOST_TRACKING_PARAMS = \[[\s\S]*?\n  \];/, 'HOST_TRACKING_PARAMS') + '\n' +
+  lift(/function isTrackingParam\(name\)\s*\{[\s\S]*?\n  \}/, 'isTrackingParam') + '\n' +
   lift(/function unwrapJumbleTarget\(raw\)\s*\{[\s\S]*?\n  \}/, 'unwrapJumbleTarget') + '\n' +
   lift(/function normalizeWebUrl\(raw\)\s*\{[\s\S]*?\n  \}/, 'normalizeWebUrl') + '\n' +
   lift(/const CLIENT_TAG = [^\n]+/, 'CLIENT_TAG') + '\n' +
@@ -45,6 +48,7 @@ vm.runInContext(
   lift(/function buildWebComment\(url, content, includeClientTag\)\s*\{[\s\S]*?\n  \}/, 'buildWebComment') + '\n' +
   lift(/const jumbleThreadUrl = [^\n]+\n[^\n]+/, 'jumbleThreadUrl') + '\n' +
   lift(/const jumbleNoteUrl = [^\n]+/, 'jumbleNoteUrl') + '\n' +
+  'globalThis.isTrackingParam = isTrackingParam;' +
   'globalThis.unwrapJumbleTarget = unwrapJumbleTarget;' +
   'globalThis.normalizeWebUrl = normalizeWebUrl;' +
   'globalThis.buildWebComment = buildWebComment;' +
@@ -53,7 +57,7 @@ vm.runInContext(
   'globalThis.WEB_COMMENT_KIND = WEB_COMMENT_KIND;',
   ctx
 );
-const { normalizeWebUrl, buildWebComment, jumbleThreadUrl, jumbleNoteUrl, unwrapJumbleTarget } = ctx;
+const { normalizeWebUrl, buildWebComment, jumbleThreadUrl, jumbleNoteUrl, unwrapJumbleTarget, isTrackingParam } = ctx;
 
 // The exact URL from the real Jumble comment this was modelled on.
 const CNN = 'https://www.cnn.com/2026/07/28/politics/jay-clayton-director-national-intelligence';
@@ -75,6 +79,102 @@ test('tracking params are dropped, so share links do not fork the thread', () =>
   ];
   for (const q of cases) {
     assert.equal(normalizeWebUrl(CNN + q).url, CNN, 'failed for ' + q);
+  }
+});
+
+// Asked publicly (nevent1qqs27heeae…): "does the comment thread key off the raw url,
+// or a normalized one so utm junk and trackers don't split the same page into three
+// threads?" These pin the answer.
+
+test('the whole utm_ family goes, not just the common five', () => {
+  // A fixed list of utm_source/medium/campaign/term/content rots: vendors keep
+  // minting new ones. Matched by prefix instead, so future variants are covered.
+  for (const p of ['utm_name', 'utm_cid', 'utm_reader', 'utm_referrer', 'utm_social',
+                   'utm_source_platform', 'utm_marketing_tactic', 'utm_creative_format',
+                   'utm_pubreferrer', 'utm_brand', 'utm_anythingatall']) {
+    assert.equal(normalizeWebUrl(CNN + '?' + p + '=x').url, CNN, 'survived: ' + p);
+  }
+});
+
+test('the other analytics namespaces go by prefix too', () => {
+  // Matomo/Piwik (pk_, piwik_, mtm_) and HubSpot ads (hsa_).
+  for (const p of ['pk_campaign', 'pk_kwd', 'piwik_campaign', 'mtm_source',
+                   'mtm_placement', 'hsa_acc', 'hsa_cam']) {
+    assert.equal(normalizeWebUrl(CNN + '?' + p + '=x').url, CNN, 'survived: ' + p);
+  }
+});
+
+test('a capitalized tracker is still a tracker', () => {
+  // Vendors ship both `ScCid` and `sccid`; surviving on a capital letter splits the
+  // thread just as effectively as surviving outright.
+  for (const p of ['UTM_Source', 'FBCLID', 'ScCid', 'GCLid']) {
+    assert.equal(normalizeWebUrl(CNN + '?' + p + '=x').url, CNN, 'survived: ' + p);
+  }
+});
+
+test('the newer ad-click and marketing IDs are covered', () => {
+  for (const p of ['dclid', 'srsltid', 'li_fat_id', 'epik', 'rdt_cid', 'sccid',
+                   'mkt_tok', '_hsenc', '_hsmi', 'vero_id', '__s', '_openstat',
+                   'guccounter', 'guce_referrer', 'fb_ref', 'action_object_map']) {
+    assert.equal(normalizeWebUrl(CNN + '?' + p + '=x').url, CNN, 'survived: ' + p);
+  }
+});
+
+test('a pile of trackers at once collapses to the bare page', () => {
+  const junk = '?utm_source=nostr&utm_medium=social&utm_campaign=launch' +
+    '&fbclid=IwAR123&gclid=xyz&mkt_tok=abc&_hsenc=def';
+  assert.equal(normalizeWebUrl(CNN + junk + '#section-3').url, CNN,
+    'three shares of one page = one thread');
+  // But `si` is host-scoped, so on a non-YouTube host it survives. Asserted rather
+  // than left implicit: this is the one spot where "we strip trackers" and what
+  // actually happens diverge. Note it goes in the QUERY — after the '#' it would be
+  // part of the fragment and vanish for an unrelated reason.
+  assert.equal(normalizeWebUrl(CNN + junk + '&si=ghi#section-3').url, CNN + '?si=ghi');
+});
+
+// YouTube's `si` is host-scoped: it is the most common splitter in practice (every
+// Share press mints a new one) but `si` is too short a name to strip everywhere.
+test("YouTube's share token is dropped, and the video id survives", () => {
+  assert.equal(
+    normalizeWebUrl('https://www.youtube.com/watch?v=dQw4w9WgXcQ&si=xLpQ99').url,
+    'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
+  );
+  assert.equal(
+    normalizeWebUrl('https://youtu.be/dQw4w9WgXcQ?si=xLpQ99&feature=shared').url,
+    'https://youtu.be/dQw4w9WgXcQ'
+  );
+});
+
+test('`si` is NOT stripped off a host where it might mean something', () => {
+  // Host-scoped on purpose. Removing a load-bearing param is worse than a split
+  // thread: the identifier would point at a page that renders different content.
+  assert.equal(
+    normalizeWebUrl('https://example.com/search?si=42').url,
+    'https://example.com/search?si=42'
+  );
+});
+
+test('a lookalike host does not get the YouTube rule', () => {
+  assert.equal(
+    normalizeWebUrl('https://notyoutube.com/watch?v=a&si=b').url,
+    'https://notyoutube.com/watch?si=b&v=a'
+  );
+});
+
+test('`ref` is deliberately KEPT — too often functional to guess at', () => {
+  assert.equal(
+    normalizeWebUrl('https://example.com/p?ref=nav').url,
+    'https://example.com/p?ref=nav'
+  );
+});
+
+test('isTrackingParam does not fire on params that merely start similarly', () => {
+  // Guards the prefix rule against over-reach: `utmost` is not `utm_`.
+  for (const p of ['utmost', 'utm', 'pkg', 'picture', 'mtmx', 'reference', 'q', 'id', 'v']) {
+    assert.equal(isTrackingParam(p), false, 'wrongly stripped: ' + p);
+  }
+  for (const p of ['utm_x', 'pk_x', 'piwik_x', 'mtm_x', 'hsa_x', 'fbclid']) {
+    assert.equal(isTrackingParam(p), true, 'missed: ' + p);
   }
 });
 


### PR DESCRIPTION
Four follow-ups to page comments (#156), three of them fixes, plus the icon rework.

## Tracker stripping now answers the question it was asked

A user asked publicly whether the thread keys off the raw URL or a normalized one, "so utm junk and trackers don't split the same page into three threads." Normalization already shipped — but the list carried only six of the `utm_` family, so `utm_name`, `utm_source_platform`, `utm_marketing_tactic` and the rest sailed through.

Whole namespaces now match by **prefix** (`utm_`, `pk_`, `piwik_`, `mtm_`, `hsa_`), because a fixed list rots as vendors mint new ones. ~20 more exact params join it, matched case-insensitively since the same vendor ships `ScCid` and `sccid`.

Two judgment calls, both asserted by tests:

- **YouTube's `si` is host-scoped, not global.** It's the most common real splitter there is — every Share press mints a new one — but `si` is too short a name to strip everywhere. A test asserts it *survives* on other hosts.
- **`ref` is deliberately kept.** Removing a load-bearing param is worse than a split thread: the identifier would point at a page rendering different content.

Checked relays first: of 331 kind:1111 events, 17 over a web target, 9 distinct URLs — **none** carried trackers or fragments. No evidence anyone is splitting threads today, so this is prophylactic.

## Comments get the review countdown

`showCountdown` hoisted out of `openComposer` into `showPostCountdown`. Signing stays inside `onFire`, so cancelling never produces a signature.

Comments read the **same** `noteCountdown` setting rather than adding a second switch — the toggle already says "Review countdown before posting" and covers everything publishable. A test greps for `commentCountdown` to make sure nobody adds one.

The review screen leads with **the page**, reusing the link card via a parameterized `renderTargetInto`. That's why it was worth sharing rather than duplicating: a comment inherits its target from whichever tab was active, and posting on the wrong page is invisible until it's live on someone else's site.

**Fixed while wiring it:** `webCommentModal` passed no `onClose`, so a countdown left running after the modal was dismissed would still fire and publish.

## Comment previews render mentions as names

Both the Preview tab and the countdown used `textContent`, and a mention serializes to a bare `nostr:npub1...` token — so you saw a 63-character key where the published comment shows a name. The Preview tab shipped that way in #156. Both now share one `commentBodyPreview()` built on `renderNotePreview`.

## A comment draft survives a stray click

Clicking the overlay dismissed the modal and took the half-written comment with it. There was no `onChange` at all — and the overlay path calls `closeModal` directly without passing through Cancel, so a teardown hook would not have helped either. Saved on every keystroke, keyed by account + normalized URL.

**Memory only, never `chrome.storage`**, unlike note drafts. A comment belongs to a page you are looking at, so it only has to survive reopening the modal while that URL is around. Persisting it would put a record of pages visited on disk. A test asserts the store touches no `chrome.storage`.

Three edges: typing before the target resolves stores nothing (a null key would be one bucket every page inherits); anything already typed wins over a saved draft on restore; and the draft clears only after the publish succeeds, since dropping it on failure loses the text exactly when it is needed. Capped at 20, evicted least-recently-written, saves re-inserting so a draft under active use stops being the eviction candidate.

## Icon

Feather's message-square-with-three-dots read as a smudge at 19px. Replaced with message-circle, path scaled 1.10x about the viewBox center — Feather's bubble is 17 units where search is 18 and help is 20, and a circle reads optically smaller than shapes reaching the corners. Arc flags left at 1; scaling those would corrupt the curves. Ink lands at 1.10..22.90 against help's 1.00..23.00.

## Tests

189 total (+31). The countdown default, the tracker prefix rule, and the draft eviction order are each **mutation-tested** — reverting them fails the tests that describe them.

Verified no conflict with #158, which is still open.

🫗 Strained with [Claude Code](https://claude.com/claude-code)
