### PR TITLE
feat: relax exclusion for replaceable kinds, trust nudge, popup theme fix, unlock copy

### DIFF
--- a/background.js
+++ b/background.js
@@ -701,6 +701,51 @@ reconcileQueue();
 const COALESCE_KINDS = new Set([30078]);
 const COALESCE_WINDOW_MS = 60000;
 const contentGrants = new Map(); // `host|pubkey|kind` -> expiry ms
+
+// ---- "you keep approving this" nudge ----
+// How many times the user has picked Allow once for a (host, account). Nothing in
+// the prompt says WHICH button ends the asking, so someone on a single account can
+// approve the same site forever without ever noticing Trust is the answer. After a
+// few, the prompt adds one line pointing at it.
+//
+// chrome.storage.session, NOT a Map — same reasoning as relax-grants.js spells out.
+// The MV3 service worker is evicted after ~30s idle, and the gap between two
+// approvals is however long the user takes, so an in-memory tally resets between
+// almost every pair and never reaches the threshold. (That was the first cut of this,
+// and it simply never fired.) The 60s coalesce grants above can stay in memory
+// precisely because their window is shorter than the eviction timer.
+//
+// Session storage also has exactly the retention this wants: survives eviction,
+// clears on browser restart. It catches a habit within one browsing session rather
+// than accumulating a record of which sites someone uses.
+const APPROVE_NUDGE_AFTER = 3;
+const APPROVE_COUNT_KEY = 'sidecar_approve_counts';
+function sgetSession(keys) {
+  return new Promise((resolve) => chrome.storage.session.get(keys, resolve));
+}
+function ssetSession(obj) {
+  return new Promise((resolve) => chrome.storage.session.set(obj, resolve));
+}
+function approveCountKey(host, pubkey) { return host + '|' + pubkey; }
+async function approveCountMap() {
+  return (await sgetSession(APPROVE_COUNT_KEY))[APPROVE_COUNT_KEY] || {};
+}
+async function bumpApproveCount(host, pubkey) {
+  const m = await approveCountMap();
+  const k = approveCountKey(host, pubkey);
+  m[k] = (m[k] || 0) + 1;
+  await ssetSession({ [APPROVE_COUNT_KEY]: m });
+}
+async function shouldNudgeTrust(host, pubkey) {
+  const m = await approveCountMap();
+  return (m[approveCountKey(host, pubkey)] || 0) >= APPROVE_NUDGE_AFTER;
+}
+// Trusting (or blocking) settles the question, so the tally stops being useful.
+async function clearApproveCount(host, pubkey) {
+  const m = await approveCountMap();
+  delete m[approveCountKey(host, pubkey)];
+  await ssetSession({ [APPROVE_COUNT_KEY]: m });
+}
 function grantKey(host, pubkey, kind) { return host + '|' + pubkey + '|' + kind; }
 function hasContentGrant(host, pubkey, kind) {
   const exp = contentGrants.get(grantKey(host, pubkey, kind));
@@ -952,7 +997,7 @@ async function handleNostrRpc(method, params, host, sendResponse, originWindowId
     // them has actually granted the window, so a later request in the same burst
     // would otherwise still show a full prompt for a window that's active by the
     // time its turn comes up.
-    const relaxEligible = isContentSign && !RELAX.isControlKind(signKind);
+    const relaxEligible = isContentSign && !RELAX.neverRelaxes(signKind);
     const relaxActive = relaxEligible && (await RELAX.has(host, activePubkey));
     if (relaxActive) sharedIdentity = false;
 
@@ -998,6 +1043,8 @@ async function handleNostrRpc(method, params, host, sendResponse, originWindowId
 
     // Once unlocked, signing only needs site approval — no PIN re-entry.
     if (needApproval || needUnlock) {
+      // Read once — the payload below needs both the theme and the auto-lock choice.
+      const promptSettings = (await sget('sidecar_settings')).sidecar_settings || {};
       const st = await KS.getState();
       const acct = st.accounts.find((a) => a.pubkey === activePubkey);
       const otherAccounts = canOfferAccountSwitch
@@ -1033,6 +1080,22 @@ async function handleNostrRpc(method, params, host, sendResponse, originWindowId
         needApproval,
         sharedIdentity,
         relaxEligible,
+        // True once this (host, account) has been approved one-time a few times over —
+        // the prompt turns it into a line pointing at Trust. Suppressed while a
+        // destructive warning is showing: that screen is asking for full attention on
+        // what's about to be lost, and "trust this site to stop asking" is the last
+        // advice it should be carrying.
+        nudgeTrust: !destructive && (await shouldNudgeTrust(host, activePubkey)),
+        // The popup window loads every theme stylesheet but has no settings access of
+        // its own, so without this it renders whatever the default is — Speakeasy
+        // purple over someone's Brownstone panel. Carried on the payload rather than
+        // fetched in prompt.js so the window paints themed on first frame instead of
+        // flashing the default.
+        theme: promptSettings.theme || 'speakeasy',
+        // Auto-lock is off, so this unlock is the once-per-browser-session one rather
+        // than an idle timeout. The UI says so — otherwise "Never" looks broken to
+        // someone who set it and is then asked for a PIN the next morning.
+        autoLockNever: resolveSettings(promptSettings).autoLockMinutes === 0,
         destructive, // null, or { kind, type, from, to, lost, fields, message }
         level: await PERMS.getLevel(activePubkey, host),
         otherAccounts: otherAccounts && otherAccounts.length ? otherAccounts : null,
@@ -1055,10 +1118,17 @@ async function handleNostrRpc(method, params, host, sendResponse, originWindowId
       }
 
       if (decision.action === 'block') {
+        await clearApproveCount(host, activePubkey);
         await PERMS.setLevel(activePubkey, host, 'blocked');
         throw new Error('This site is now blocked');
       }
-      if (decision.action === 'trust') await PERMS.setLevel(activePubkey, host, 'trusted');
+      if (decision.action === 'trust') {
+        await clearApproveCount(host, activePubkey);
+        await PERMS.setLevel(activePubkey, host, 'trusted');
+      }
+      // Tally the one-time approvals so the prompt can eventually point at Trust.
+      // Only 'once' — picking 'relax' or 'trust' IS acting on that advice.
+      if (decision.action === 'once') await bumpApproveCount(host, activePubkey);
       // 'relax' → open a timed auto-approve window for this (host, account), then
       // proceed like 'once'. The risk acceptance happened in the prompt UI.
       if (decision.action === 'relax') {

--- a/prompt.html
+++ b/prompt.html
@@ -5,12 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Sidecar</title>
   <link rel="stylesheet" href="fonts.css" />
-  <link rel="stylesheet" href="themes/speakeasy.css" />
-  <link rel="stylesheet" href="themes/film-noir.css" />
-  <link rel="stylesheet" href="themes/art-deco.css" />
-  <link rel="stylesheet" href="themes/aegean.css" />
-  <link rel="stylesheet" href="themes/brownstone.css" />
-  <link rel="stylesheet" href="themes/patterns.css" />
   <style>
     :root {
       /* Theme-specific color variables are loaded from themes/*.css */
@@ -19,12 +13,25 @@
       --font-ui: 'Manrope', system-ui, -apple-system, sans-serif;
       --font-mono: ui-monospace, 'SF Mono', Menlo, monospace;
 
-      /* Default fallback colors (will be overridden by theme files) */
+      /* Default fallback colors (will be overridden by theme files). Matches
+         styles.css's :root so every var a theme file sets has a fallback here —
+         a missing var leaves a hardcoded literal unreachable by the override. */
       --bg: #0a0118;
+      --bg-2: #140428;
       --velvet-1: #23114a;
       --velvet-2: #160a30;
+      --velvet-1-rgb: 35, 17, 74;
+      --av-from: #2a1257;
+      --av-to: #160a30;
+      --banner-accent: #3a2470;
       --border: rgba(167, 139, 250, 0.16);
       --border-strong: rgba(167, 139, 250, 0.28);
+      --border-rgb: 167, 139, 250;
+      --well-rgb: 8, 2, 20;
+      --warn: #ffb38a;
+      --warn-rgb: 255, 179, 138;
+      --success: #6ee7a8;
+      --success-rgb: 110, 231, 168;
       --orange: #ea772f;
       --gold: #cba14e;
       --gold-soft: rgba(203, 161, 78, 0.5);
@@ -34,9 +41,22 @@
       --muted: #9a86c4;
       --faint: #6f5fa0;
       --red: #f0566b;
+      --btn-primary-top: #f29248;
+      --btn-primary-mid: var(--orange);
+      --btn-primary-bot: #d4621f;
+      --btn-primary-text: #1c0c00;
+      --btn-shadow: rgba(234, 119, 47, 0.28);
       --sheen: inset 0 1px 0 rgba(255, 255, 255, 0.05);
       --pattern-opacity: 1;
     }
+  </style>
+  <link rel="stylesheet" href="themes/speakeasy.css" />
+  <link rel="stylesheet" href="themes/film-noir.css" />
+  <link rel="stylesheet" href="themes/art-deco.css" />
+  <link rel="stylesheet" href="themes/aegean.css" />
+  <link rel="stylesheet" href="themes/brownstone.css" />
+  <link rel="stylesheet" href="themes/patterns.css" />
+  <style>
     * { box-sizing: border-box; }
     html, body { height: 100%; }
     body {
@@ -65,7 +85,7 @@
       flex-shrink: 0;
       padding: 12px 22px 18px;
       border-top: 1px solid var(--border);
-      background: rgba(12, 3, 26, 0.55);
+      background: rgba(var(--well-rgb), 0.55);
       backdrop-filter: blur(14px);
       -webkit-backdrop-filter: blur(14px);
     }
@@ -135,7 +155,7 @@
     .card .row span:first-child { color: var(--muted); }
     .card .row span:last-child { word-break: break-all; text-align: right; font-family: var(--font-mono); font-size: 12px; }
     pre {
-      background: rgba(8, 2, 20, 0.6); border-radius: 8px; padding: 10px; margin: 8px 0 0;
+      background: rgba(var(--well-rgb), 0.6); border-radius: 8px; padding: 10px; margin: 8px 0 0;
       font-family: var(--font-mono);
       font-size: 12px; white-space: pre-wrap; word-break: break-word;
       max-height: 160px; overflow: auto; color: var(--text);
@@ -143,7 +163,7 @@
     /* Event-content preview: short by default (keeps the account card in view),
        expandable, with a Formatted/Raw toggle for note-like kinds. */
     .evpreview {
-      background: rgba(8, 2, 20, 0.6); border-radius: 8px; padding: 10px; margin: 8px 0 0;
+      background: rgba(var(--well-rgb), 0.6); border-radius: 8px; padding: 10px; margin: 8px 0 0;
       font-size: 12.5px; line-height: 1.5; color: var(--text); text-align: left;
       white-space: pre-wrap; overflow-wrap: anywhere;
     }
@@ -173,8 +193,8 @@
     .evpreview-toggle:hover { color: var(--text); }
     .kind-warn {
       margin-top: 8px; padding: 8px 10px; border-radius: 8px;
-      background: rgba(255, 179, 138, 0.1); border: 1px solid rgba(255, 179, 138, 0.3);
-      color: #ffb38a; font-size: 12px; text-align: left;
+      background: rgba(var(--warn-rgb), 0.1); border: 1px solid rgba(var(--warn-rgb), 0.3);
+      color: var(--warn); font-size: 12px; text-align: left;
     }
     /* Destructive replaceable overwrite — louder than .kind-warn above, which only
        says "unusual kind". This means data you already have is about to be erased.
@@ -183,12 +203,12 @@
        .destructive-warn in styles.css; this window carries its own styles. */
     .destructive-warn {
       margin-top: 12px; padding: 1px 0 1px 12px; text-align: left;
-      border-left: 2px solid #f0566b;
+      border-left: 2px solid var(--red);
     }
     .destructive-warn-title {
       display: flex; align-items: center; gap: 6px;
       font-family: var(--font-display); font-weight: 700; font-size: 15px;
-      color: #f0566b; letter-spacing: 0.01em; margin-bottom: 3px;
+      color: var(--red); letter-spacing: 0.01em; margin-bottom: 3px;
     }
     .destructive-warn-title svg { width: 14px; height: 14px; flex-shrink: 0; }
     .destructive-warn-body { margin: 0; color: var(--text); font-size: 13px; line-height: 1.5; }
@@ -203,7 +223,7 @@
     /* Uppercased in CSS so screen readers still announce "Don't allow". */
     .destructive-warn-reject {
       width: 100%; padding: 9px 12px; border-radius: 8px; cursor: pointer;
-      background: #f0566b; border: 1px solid #f0566b; color: #fff;
+      background: var(--red); border: 1px solid var(--red); color: #fff;
       font-family: inherit; font-size: 13px; font-weight: 700;
       text-transform: uppercase; letter-spacing: 0.06em;
     }
@@ -220,7 +240,7 @@
     }
     .info-note {
       margin-bottom: 16px; padding: 9px 11px; border-radius: 8px;
-      background: rgba(167, 139, 250, 0.08); border: 1px solid rgba(167, 139, 250, 0.22);
+      background: rgba(var(--border-rgb), 0.08); border: 1px solid rgba(var(--border-rgb), 0.22);
       color: var(--muted); font-size: 11.5px; line-height: 1.45; text-align: left;
     }
     .account { margin-bottom: 18px; }
@@ -240,9 +260,9 @@
       background: transparent; border: none; cursor: pointer; color: var(--text);
       padding: 9px 10px; border-radius: 10px; font-family: inherit; font-weight: 400;
     }
-    .switch-row:hover { background: rgba(167, 139, 250, 0.1); }
+    .switch-row:hover { background: rgba(var(--border-rgb), 0.1); }
     .switch-row.active { background: rgba(203, 161, 78, 0.08); }
-    .switch-row-av { width: 34px; height: 34px; border-radius: 50%; object-fit: cover; flex-shrink: 0; background: #2a1257; }
+    .switch-row-av { width: 34px; height: 34px; border-radius: 50%; object-fit: cover; flex-shrink: 0; background: var(--av-from); }
     .switch-row-info { flex: 1; min-width: 0; }
     .switch-row-name { font-weight: 600; font-size: 13.5px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
     .switch-row-npub { font-family: var(--font-mono); font-size: 11px; color: var(--muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
@@ -253,14 +273,14 @@
       background: linear-gradient(150deg, var(--velvet-1), var(--velvet-2));
       border: 1px solid var(--border); border-radius: 14px; padding: 12px 14px; box-shadow: var(--sheen);
     }
-    .acct-av { width: 46px; height: 46px; border-radius: 50%; object-fit: cover; flex-shrink: 0; background: #2a1257; box-shadow: 0 0 0 1px var(--gold-soft); }
+    .acct-av { width: 46px; height: 46px; border-radius: 50%; object-fit: cover; flex-shrink: 0; background: var(--av-from); box-shadow: 0 0 0 1px var(--gold-soft); }
     .acct-meta { min-width: 0; text-align: center; }
     .acct-name { font-family: var(--font-display); font-weight: 700; font-size: 17px; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
     .acct-np { font-family: var(--font-mono); font-size: 11.5px; color: var(--faint); margin-top: 4px; word-break: break-all; }
     label { display: block; font-size: 12px; letter-spacing: 0.03em; color: var(--muted); margin: 0 0 6px; }
     input[type=password] {
       width: 100%; padding: 11px 13px; border-radius: 10px; border: 1px solid var(--border);
-      background: linear-gradient(180deg, rgba(8, 2, 20, 0.6), rgba(20, 4, 40, 0.6));
+      background: var(--input-bg, linear-gradient(180deg, rgba(var(--well-rgb), 0.6), rgba(var(--velvet-1-rgb), 0.6)));
       color: var(--text); font-size: 16px; margin-bottom: 8px;
       transition: border-color 0.15s, box-shadow 0.15s;
     }
@@ -271,7 +291,7 @@
     .budget-row { display: flex; align-items: center; justify-content: center; gap: 8px; }
     .remember input[type=number] {
       width: 110px; padding: 9px 11px; border-radius: 10px; border: 1px solid var(--border);
-      background: linear-gradient(180deg, rgba(8, 2, 20, 0.6), rgba(20, 4, 40, 0.6));
+      background: var(--input-bg, linear-gradient(180deg, rgba(var(--well-rgb), 0.6), rgba(var(--velvet-1-rgb), 0.6)));
       color: var(--text); font-size: 14px; font-family: var(--font-mono);
     }
     .remember input[type=number]:focus { outline: none; border-color: var(--gold-soft); }
@@ -285,13 +305,14 @@
       transition: transform 0.12s, filter 0.15s, border-color 0.15s, box-shadow 0.15s;
     }
     .primary {
-      background: linear-gradient(180deg, #f29248, var(--orange) 55%, #d4621f); color: #1c0c00;
-      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35), 0 8px 22px rgba(234, 119, 47, 0.28);
+      background: linear-gradient(180deg, var(--btn-primary-top, #f29248), var(--btn-primary-mid, var(--orange)) 55%, var(--btn-primary-bot, #d4621f));
+      color: var(--btn-primary-text, #1c0c00);
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35), 0 8px 22px var(--btn-shadow, rgba(234, 119, 47, 0.28));
     }
     .primary:hover { filter: brightness(1.06); transform: translateY(-1px); }
     .lav-btn {
       background: linear-gradient(180deg, #cebfff, var(--lav) 58%, var(--purple)); color: #190a33;
-      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 8px 22px rgba(167, 139, 250, 0.24);
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 8px 22px rgba(var(--border-rgb), 0.24);
     }
     .lav-btn:hover { filter: brightness(1.05); transform: translateY(-1px); }
     .secondary {
@@ -312,6 +333,11 @@
     }
     .relax-chip:hover { border-color: var(--gold-soft); filter: brightness(1.06); }
     .relax-chip:disabled { opacity: 0.45; cursor: not-allowed; }
+    /* Advice, not a warning — muted, so it doesn't compete with the destructive
+       banner or read as something being wrong. The site name inside is lavender to
+       tie it to "Trust this site" right below. */
+    .trust-nudge { font-size: 12.5px; line-height: 1.45; color: var(--muted); text-align: center; margin: 0 0 12px; }
+    .trust-nudge strong { color: var(--lav); font-weight: 600; }
     .hidden { display: none; }
   </style>
 </head>
@@ -370,6 +396,11 @@
     </div>
     </div>
     <div class="error" id="error"></div>
+    <!-- Shown once you've approved this site a few times over. Nothing else on this
+         screen says which button ends the asking, and "Allow once" is the one that
+         looks like the default answer. Sits directly above the buttons so it reads as
+         a label for the one below it. -->
+    <div id="trust-nudge" class="trust-nudge hidden"></div>
     <div class="actions">
       <button class="primary" id="allow">Allow once</button>
       <button class="lav-btn" id="trust">Trust this site</button>

--- a/prompt.html
+++ b/prompt.html
@@ -347,13 +347,17 @@
     <div class="host" id="host">…</div>
     <div class="ask" id="ask">wants to…</div>
 
-    <div id="preview" class="card hidden"></div>
-
-    <div id="decrypt-note" class="info-note hidden"></div>
-
+    <!-- Account capsule ABOVE the event preview: "Signing as" is context, not
+         detail — it belongs with the host name, before the thing being signed.
+         Below the preview it was pushed off-screen by a long event, defeating
+         the clamp's own comment ("keeps the account card in view"). -->
     <div class="account" id="account"></div>
     <button class="switch-toggle hidden" id="switch-toggle">Sign in with a different account</button>
     <div class="switch-menu hidden" id="switch-menu"></div>
+
+    <div id="preview" class="card hidden"></div>
+
+    <div id="decrypt-note" class="info-note hidden"></div>
 
 
   </div>

--- a/prompt.js
+++ b/prompt.js
@@ -27,6 +27,7 @@
     rememberBudget: $('remember-budget'),
     budgetAmount: $('budget-amount'),
     relaxRow: $('relax-row'),
+    trustNudge: $('trust-nudge'),
     autozapOffer: $('autozap-offer'),
     autozapOfferBox: $('autozap-offer-box'),
     autozapOfferLabel: $('autozap-offer-label'),
@@ -365,6 +366,16 @@
       return;
     }
     data = resp.data;
+    // Match the panel's theme. All five stylesheets are already linked in
+    // prompt.html; they key off [data-theme], which nothing here used to set — so
+    // this window always rendered Speakeasy regardless of what the panel was wearing.
+    // Same allowlist as sidepanel.js's applyTheme: an unknown value falls back rather
+    // than writing an arbitrary string into the DOM.
+    const THEMES = ['speakeasy', 'film-noir', 'brownstone', 'art-deco', 'aegean'];
+    document.documentElement.setAttribute(
+      'data-theme',
+      THEMES.includes(data.theme) ? data.theme : 'speakeasy'
+    );
     isPayment = data.scope === 'webln' && data.method === 'sendPayment';
     chosenPubkey = data.activePubkey;
 
@@ -400,9 +411,16 @@
     // Also not on a destructive overwrite — see the matching note in sidepanel.js:
     // approving the wipe makes the wiped list the new baseline, so a window granted
     // here would let the next overwrite through unwarned.
+    //
+    // `relaxEligible` comes from the background (RELAX.neverRelaxes) and is the
+    // authority on which KINDS a window may ever cover — account/wallet-control and
+    // the replaceable 0/3/10000. Honoring it here rather than re-deriving the rule is
+    // the point: this gate and the background's used to be written separately, and a
+    // profile edit that wasn't itself destructive slipped through this one while the
+    // background would have accepted the window.
     const isContentSign =
       data.method === 'signEvent' || data.method === 'nip04.encrypt' || data.method === 'nip44.encrypt';
-    if (data.needApproval && isContentSign && !isPayment && !data.destructive) {
+    if (data.needApproval && isContentSign && !isPayment && !data.destructive && data.relaxEligible !== false) {
       els.relaxRow.classList.remove('hidden');
       els.relaxRow.querySelectorAll('.relax-chip').forEach((chip) => {
         chip.addEventListener('click', () =>
@@ -411,8 +429,29 @@
       });
     }
 
+    // Point at Trust once someone has approved this site several times over. Built with
+    // textContent, not innerHTML — `host` is attacker-controlled, and this string is
+    // assembled from it.
+    if (data.nudgeTrust && !isPayment) {
+      const host = document.createElement('strong');
+      host.textContent = data.host || 'this site';
+      els.trustNudge.append(
+        document.createTextNode('Approving this often? Trust '),
+        host,
+        document.createTextNode(' to stop being asked.')
+      );
+      els.trustNudge.classList.remove('hidden');
+    }
+
     if (data.needUnlock) {
       els.unlock.classList.remove('hidden');
+      // With auto-lock on Never, the only thing that can have locked this is the
+      // browser closing — the key lives in memory for the session and is never
+      // written to disk. Say so, or the setting looks broken.
+      if (data.autoLockNever) {
+        const label = els.unlock.querySelector('label');
+        if (label) label.textContent = 'Enter your PIN — first unlock since your browser started';
+      }
       setTimeout(() => els.pin.focus(), 50);
     }
 

--- a/relax-grants.js
+++ b/relax-grants.js
@@ -28,6 +28,27 @@
   // never relax — a per-sign confirm is exactly what gates them, even mid-window.
   const CONTROL_KINDS = new Set([24133, 23194, 23195]);
 
+  // Replaceable kinds whose new version WHOLLY REPLACES the old, with no merge and no
+  // undo: 0 (profile), 3 (follows), 10000 (mutes).
+  //
+  // These never relax either, and the reason is subtler than for CONTROL_KINDS. The
+  // destructive check in replaceable-baseline.js already suppresses the relax offer
+  // when THIS event looks like a wipe — but that check is per-event, while the window
+  // it would grant is not. An ordinary, complete profile edit isn't destructive, so it
+  // used to offer "auto-sign the next 30 minutes"; the NEXT profile write inside that
+  // window then goes through unwarned, and that one could be the wipe. Approving a
+  // write also makes it the new baseline, so the comparison the guard depends on is
+  // gone by then.
+  //
+  // A profile or follow-list write is rare enough that a per-sign confirm costs
+  // nothing — nobody edits their bio in a burst.
+  //
+  // A literal here rather than read from SidecarBaseline.TRACKED: this file is loaded
+  // BEFORE replaceable-baseline.js by background.js's importScripts, and is
+  // deliberately dependency-free so it can be unit-tested against a bare chrome mock.
+  // test/relax-grant.test.js asserts the two sets stay in agreement.
+  const REPLACEABLE_KINDS = new Set([0, 3, 10000]);
+
   function sgetS(keys) {
     return new Promise((r) => chrome.storage.session.get(keys, r));
   }
@@ -151,9 +172,16 @@
   }
 
   const api = {
-    STORAGE_KEY, ALARM_PREFIX, MAX_MS, DEFAULT_MS, CONTROL_KINDS,
+    STORAGE_KEY, ALARM_PREFIX, MAX_MS, DEFAULT_MS, CONTROL_KINDS, REPLACEABLE_KINDS,
     has, grant, revoke, revokeForHost, revokeAll, active, onAlarm,
     isControlKind: (k) => k != null && CONTROL_KINDS.has(k),
+    isReplaceableKind: (k) => k != null && REPLACEABLE_KINDS.has(k),
+    // The single question the callers ask: may a relax window ever cover this kind?
+    // Both call sites (background.js's relaxEligible and prompt.js's offer gate) go
+    // through this, so the two can't drift — the bug this fixes was exactly a gate
+    // that existed in one place and not the other.
+    neverRelaxes: (k) =>
+      k != null && (CONTROL_KINDS.has(k) || REPLACEABLE_KINDS.has(k)),
   };
   if (typeof self !== 'undefined') self.SidecarRelax = api;
   if (typeof globalThis !== 'undefined') globalThis.SidecarRelax = api;

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -451,11 +451,13 @@
       <div class="approval-host" id="approval-host">…</div>
       <div class="approval-ask" id="approval-ask">wants to…</div>
 
-      <div id="approval-preview" class="card hidden"></div>
-
+      <!-- Account capsule ABOVE the event preview — mirrors the popup (prompt.html).
+           Below the preview it was pushed off-screen by a long event. -->
       <div class="approval-account" id="approval-account"></div>
       <button class="approval-switch-toggle hidden" id="approval-switch-toggle">Sign in with a different account</button>
       <div class="approval-switch-menu hidden" id="approval-switch-menu"></div>
+
+      <div id="approval-preview" class="card hidden"></div>
 
       <div id="approval-unlock" class="hidden stack">
         <label for="approval-pin">Enter your PIN to unlock</label>

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -270,6 +270,13 @@
           <option value="15">After 15 minutes</option>
           <option value="60">After 1 hour</option>
         </select>
+        <!-- "Never" turns off the idle timer, and reads like an absolute promise —
+             but the unlocked key lives in memory for the browser session and is gone
+             when the browser closes, because the alternative is writing a decrypted
+             key to disk. Someone who picks Never and is then asked for a PIN the next
+             morning has no way to tell that apart from the setting not working. -->
+        <p class="hint">Sidecar asks for your PIN once per browser session even on
+        Never — your key is held in memory and never written to disk unencrypted.</p>
       </div>
 
       <div class="setting">
@@ -483,6 +490,11 @@
       </div>
 
       <div class="error" id="approval-error"></div>
+
+      <!-- Shown once this site has been approved one-time a few times over. Nothing
+           else here says which button ends the asking, and "Allow once" is the one
+           that looks like the default answer. Mirrors the popup's #trust-nudge. -->
+      <div id="approval-trust-nudge" class="trust-nudge hidden"></div>
 
       <div class="approval-actions">
         <button class="primary" id="approval-allow">Allow once</button>

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -568,6 +568,17 @@
       if (nwc) { try { nwc.close(); } catch (_) {} nwc = null; nwcPubkey = null; nwcConn = null; }
       balanceCache = { pubkey: null, sats: null };
       show($('view-lock'));
+      // On Never, the only thing that can have locked this is the browser closing —
+      // the derived key lives in chrome.storage.session, which is memory-only and
+      // cleared on browser close. Without saying so, "Never" reads as broken.
+      call({ type: 'SIDECAR_GET_SETTINGS' })
+        .then((s) => {
+          if (s && s.autoLockMinutes === 0) {
+            $('view-lock').querySelector('.lede').textContent =
+              'Locked since your browser closed. Enter your PIN to unlock your accounts.';
+          }
+        })
+        .catch(() => {});
       setTimeout(() => $('unlock-pin').focus(), 50);
     } else {
       show($('view-main'));
@@ -10113,6 +10124,15 @@
     pin.value = '';
     if (data.needUnlock) {
       show($('approval-unlock'));
+      // With auto-lock on Never, the only thing that can have locked this is the
+      // browser closing — the key lives in memory for the session, never on disk.
+      // Say so, or the setting looks broken. Mirrors prompt.js.
+      const unlockLabel = $('approval-unlock').querySelector('label');
+      if (unlockLabel) {
+        unlockLabel.textContent = data.autoLockNever
+          ? 'Enter your PIN — first unlock since your browser started'
+          : 'Enter your PIN to unlock';
+      }
       setTimeout(() => pin.focus(), 50);
     } else {
       hide($('approval-unlock'));
@@ -10180,9 +10200,17 @@
     // wipe ALSO makes the wiped list the new baseline, so within that window a second
     // overwrite has nothing left to lose and won't warn. A client that just tried to
     // clear your follow list is precisely the one that shouldn't get a free window.
+    //
+    // `relaxEligible` comes from the background (RELAX.neverRelaxes) and is the
+    // authority on which KINDS a window may ever cover — account/wallet-control, and
+    // the replaceable 0/3/10000 whose next write inside the window would go through
+    // unwarned. Honoring the flag rather than re-deriving the rule is the point: this
+    // gate, prompt.js's, and the background's were three separate copies, and a
+    // profile edit that wasn't itself destructive slipped past all but the background.
     const relaxRow = $('approval-relax-row');
     const offerRelax =
       !payment && groupN === 1 && data.needApproval && !data.destructive &&
+      data.relaxEligible !== false &&
       (data.method === 'signEvent' || data.method === 'nip04.encrypt' || data.method === 'nip44.encrypt');
     if (offerRelax) {
       show(relaxRow);
@@ -10191,6 +10219,22 @@
       });
     } else {
       hide(relaxRow);
+    }
+
+    // Point at Trust once this site has been approved one-time several times over.
+    // textContent, never innerHTML — `host` is attacker-controlled.
+    const nudge = $('approval-trust-nudge');
+    nudge.textContent = '';
+    if (data.nudgeTrust && !payment) {
+      const strong = h('strong', { textContent: data.host || 'this site' });
+      nudge.append(
+        document.createTextNode('Approving this often? Trust '),
+        strong,
+        document.createTextNode(' to stop being asked.')
+      );
+      show(nudge);
+    } else {
+      hide(nudge);
     }
   }
 

--- a/styles.css
+++ b/styles.css
@@ -2367,6 +2367,12 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
    the banner shown only while a window is active, reminding the user which
    account is signing for which site (with an "End" button). Gold-tinted like the
    shared-identity note since both are "double-check this" affordances. */
+/* "Approving this often? Trust <site> to stop being asked." — advice, not a warning,
+   so it stays muted rather than competing with the destructive banner or reading as
+   something being wrong. The site name is lavender to tie it to the Trust button
+   directly below it. Duplicated in prompt.html, which has its own stylesheet. */
+.trust-nudge { font-size: 12.5px; line-height: 1.45; color: var(--muted); text-align: center; margin: 0 0 12px; }
+.trust-nudge strong { color: var(--lav); font-weight: 600; }
 .relax-row { margin: 0 0 14px; text-align: center; }
 .relax-label { font-family: var(--font-display); font-size: 15px; color: var(--gold); font-weight: 700; letter-spacing: 0.01em; margin-bottom: 10px; text-align: center; }
 .relax-chips { display: flex; gap: 8px; justify-content: center; margin-bottom: 8px; }

--- a/test/relax-grant.test.js
+++ b/test/relax-grant.test.js
@@ -150,6 +150,70 @@ test('isControlKind flags wallet/account-control kinds only', () => {
   assert.equal(RELAX.isControlKind(null), false, 'non-signEvent methods (null kind) are relaxable');
 });
 
+// ---- replaceable kinds never relax ---------------------------------------------
+//
+// The bug: a relax window could be granted from a profile-edit prompt. The
+// destructive check suppresses the offer when THIS event looks like a wipe, but it is
+// per-event and the window is not — an ordinary complete profile edit isn't
+// destructive, so it offered "auto-sign the next 30 minutes", and the NEXT profile
+// write in that window went through unwarned. Approving a write also makes it the new
+// baseline, so the comparison the guard relies on is gone by then.
+
+test('isReplaceableKind flags the wipeable kinds', () => {
+  for (const k of [0, 3, 10000]) {
+    assert.equal(RELAX.isReplaceableKind(k), true, 'replaceable kind ' + k);
+  }
+  assert.equal(RELAX.isReplaceableKind(1), false, 'a note replaces nothing');
+  assert.equal(RELAX.isReplaceableKind(1111), false, 'a comment replaces nothing');
+  assert.equal(RELAX.isReplaceableKind(null), false);
+});
+
+test('kind 0 never relaxes — the reported case', () => {
+  // A profile edit on an ask-tier site offered a 30-minute auto-sign window.
+  assert.equal(RELAX.neverRelaxes(0), true);
+});
+
+test('neverRelaxes covers both control and replaceable kinds', () => {
+  for (const k of [24133, 23194, 23195, 0, 3, 10000]) {
+    assert.equal(RELAX.neverRelaxes(k), true, 'kind ' + k + ' must never relax');
+  }
+});
+
+test('neverRelaxes leaves ordinary content relaxable', () => {
+  // The feature still has to work for what it was built for: notes, reactions,
+  // reposts, comments, DMs — the high-frequency signing a session actually produces.
+  for (const k of [1, 6, 7, 1111, 9734, 30023, 4, 14]) {
+    assert.equal(RELAX.neverRelaxes(k), false, 'kind ' + k + ' should stay relaxable');
+  }
+  assert.equal(RELAX.neverRelaxes(null), false, 'encrypt/decrypt carry no kind');
+  assert.equal(RELAX.neverRelaxes(undefined), false);
+});
+
+test('the replaceable set agrees with replaceable-baseline.js', () => {
+  // Two files hold this list: relax-grants.js can't import the baseline module (it is
+  // loaded first by background.js's importScripts, and stays dependency-free so it can
+  // be tested against a bare chrome mock). If the destructive guard ever starts
+  // tracking a fourth kind, this fails until relax excludes it too — otherwise that
+  // kind would be wipeable inside a relax window.
+  const baselineSrc = fs.readFileSync(path.join(ROOT, 'replaceable-baseline.js'), 'utf8');
+  const m = baselineSrc.match(/const TRACKED = new Set\(\[([^\]]*)\]\)/);
+  assert.ok(m, 'could not find TRACKED in replaceable-baseline.js');
+  // TRACKED is built from named constants (KIND_PROFILE &c.) — resolve each.
+  const kinds = m[1].split(',').map((name) => {
+    const t = name.trim();
+    if (/^\d+$/.test(t)) return Number(t);
+    const dm = baselineSrc.match(new RegExp('const ' + t + ' = (\\d+)'));
+    assert.ok(dm, 'could not resolve ' + t);
+    return Number(dm[1]);
+  });
+  assert.deepEqual(kinds.slice().sort((a, b) => a - b), [0, 3, 10000],
+    'baseline tracks a different set than expected');
+  for (const k of kinds) {
+    assert.equal(RELAX.neverRelaxes(k), true,
+      'baseline guards kind ' + k + ' but relax would let a window cover it');
+  }
+});
+
 test('a re-grant for the same pair replaces the window (no duplicate alarms)', async () => {
   await RELAX.grant(HOST, pkA, 60000);
   await RELAX.grant(HOST, pkA, 60000);

--- a/test/trust-nudge.test.js
+++ b/test/trust-nudge.test.js
@@ -1,0 +1,307 @@
+'use strict';
+
+// Unit coverage for the "you keep approving this" tally in background.js.
+//
+// Why it exists: the approval prompt offers Allow once / Trust this site / Reject,
+// plus timed auto-sign chips. Only Trust ends the asking, and nothing on the screen
+// says so — "Allow once" is the one that reads like the default answer, so a user on
+// a single account with a single app can approve the same site indefinitely without
+// ever noticing there was a way out. After a few one-time approvals the prompt adds a
+// line pointing at Trust.
+//
+// Stored in chrome.storage.session, which is the whole reason these tests exist. The
+// first cut used a plain Map and NEVER FIRED: the MV3 service worker is evicted after
+// ~30s idle, and the gap between two approvals is however long the user takes, so the
+// tally reset between almost every pair. Session storage survives eviction and clears
+// on browser restart — exactly the retention wanted.
+//
+// The chrome mock below is deliberately backed by a plain object that persists across
+// calls within a test but is rebuilt per test, standing in for that lifetime.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const ROOT = path.join(__dirname, '..');
+const source = fs.readFileSync(path.join(ROOT, 'background.js'), 'utf8');
+
+function lift(pattern, label) {
+  const m = source.match(pattern);
+  if (!m) throw new Error('Could not find ' + label + ' in background.js');
+  return m[0];
+}
+
+const HOST_A = 'jumble.social';
+const HOST_B = 'coracle.social';
+const PK_A = 'a'.repeat(64);
+const PK_B = 'b'.repeat(64);
+
+function harness() {
+  // structuredClone on get/set, mirroring what real chrome.storage does — without it a
+  // mock hands every caller the same live object and a read-modify-write looks
+  // idempotent whether or not the code actually writes back.
+  const store = {};
+  const chrome = {
+    storage: {
+      session: {
+        get: (keys, cb) => {
+          const k = typeof keys === 'string' ? [keys] : keys;
+          const out = {};
+          for (const key of k) if (key in store) out[key] = structuredClone(store[key]);
+          cb(out);
+        },
+        set: (obj, cb) => {
+          for (const [key, val] of Object.entries(obj)) store[key] = structuredClone(val);
+          if (cb) cb();
+        },
+      },
+    },
+  };
+  const ctx = { console, chrome, structuredClone };
+  vm.createContext(ctx);
+  vm.runInContext(
+    lift(/const APPROVE_NUDGE_AFTER = \d+;/, 'APPROVE_NUDGE_AFTER') + '\n' +
+    lift(/const APPROVE_COUNT_KEY = '[^']+';/, 'APPROVE_COUNT_KEY') + '\n' +
+    lift(/function sgetSession\(keys\) \{[\s\S]*?\n\}/, 'sgetSession') + '\n' +
+    lift(/function ssetSession\(obj\) \{[\s\S]*?\n\}/, 'ssetSession') + '\n' +
+    lift(/function approveCountKey\(host, pubkey\) \{[^}]*\}/, 'approveCountKey') + '\n' +
+    lift(/async function approveCountMap\(\) \{[\s\S]*?\n\}/, 'approveCountMap') + '\n' +
+    lift(/async function bumpApproveCount\(host, pubkey\) \{[\s\S]*?\n\}/, 'bumpApproveCount') + '\n' +
+    lift(/async function shouldNudgeTrust\(host, pubkey\) \{[\s\S]*?\n\}/, 'shouldNudgeTrust') + '\n' +
+    lift(/async function clearApproveCount\(host, pubkey\) \{[\s\S]*?\n\}/, 'clearApproveCount') + '\n' +
+    'globalThis.bump = bumpApproveCount;' +
+    'globalThis.should = shouldNudgeTrust;' +
+    'globalThis.clear = clearApproveCount;' +
+    'globalThis.AFTER = APPROVE_NUDGE_AFTER;',
+    ctx
+  );
+  ctx.__store = store;
+  return ctx;
+}
+
+// ---- the threshold -------------------------------------------------------------
+
+test('the nudge stays quiet until the threshold', async () => {
+  const c = harness();
+  for (let i = 1; i < c.AFTER; i++) {
+    await c.bump(HOST_A, PK_A);
+    assert.equal(await c.should(HOST_A, PK_A), false, 'fired early at ' + i);
+  }
+  await c.bump(HOST_A, PK_A);
+  assert.equal(await c.should(HOST_A, PK_A), true, 'should fire at ' + c.AFTER);
+});
+
+test('it keeps firing once the threshold is passed', async () => {
+  // Someone who ignores it and keeps clicking Allow once should keep seeing it —
+  // the advice doesn't stop being true.
+  const c = harness();
+  for (let i = 0; i < c.AFTER + 5; i++) await c.bump(HOST_A, PK_A);
+  assert.equal(await c.should(HOST_A, PK_A), true);
+});
+
+test('a site never approved gets no nudge', async () => {
+  const c = harness();
+  assert.equal(await c.should(HOST_A, PK_A), false);
+});
+
+test('the threshold is high enough not to nag, low enough to help', async () => {
+  const c = harness();
+  assert.ok(c.AFTER >= 3, 'firing on the first or second approval would be nagging');
+  assert.ok(c.AFTER <= 5, 'past this it arrives long after the annoyance set in');
+});
+
+// ---- scoping -------------------------------------------------------------------
+
+test('the tally is per host', async () => {
+  const c = harness();
+  for (let i = 0; i < c.AFTER; i++) await c.bump(HOST_A, PK_A);
+  assert.equal(await c.should(HOST_A, PK_A), true);
+  assert.equal(await c.should(HOST_B, PK_A), false, 'a different site starts fresh');
+});
+
+test('the tally is per account', async () => {
+  // Permissions are per-account, so the advice has to be too: trusting a site for one
+  // account grants nothing to another, and suggesting it there would be wrong.
+  const c = harness();
+  for (let i = 0; i < c.AFTER; i++) await c.bump(HOST_A, PK_A);
+  assert.equal(await c.should(HOST_A, PK_B), false);
+});
+
+test('approvals on two hosts do not add up', async () => {
+  const c = harness();
+  for (let i = 0; i < c.AFTER - 1; i++) await c.bump(HOST_A, PK_A);
+  for (let i = 0; i < c.AFTER - 1; i++) await c.bump(HOST_B, PK_A);
+  assert.equal(await c.should(HOST_A, PK_A), false);
+  assert.equal(await c.should(HOST_B, PK_A), false);
+});
+
+test('the key cannot collide across the host/pubkey boundary', async () => {
+  const c = harness();
+  for (let i = 0; i < c.AFTER; i++) await c.bump(HOST_A, PK_A);
+  // A naive concatenation would let host+pubkey pairs impersonate each other.
+  assert.equal(await c.should(HOST_A + PK_A, ''), false);
+});
+
+// ---- clearing ------------------------------------------------------------------
+
+test('taking the advice clears the tally', async () => {
+  // Trusting settles the question; if trust is later revoked, the count should start
+  // over rather than nudging again immediately.
+  const c = harness();
+  for (let i = 0; i < c.AFTER; i++) await c.bump(HOST_A, PK_A);
+  await c.clear(HOST_A, PK_A);
+  assert.equal(await c.should(HOST_A, PK_A), false);
+});
+
+test('clearing one pair leaves the others alone', async () => {
+  const c = harness();
+  for (let i = 0; i < c.AFTER; i++) { await c.bump(HOST_A, PK_A); await c.bump(HOST_B, PK_A); }
+  await c.clear(HOST_A, PK_A);
+  assert.equal(await c.should(HOST_A, PK_A), false);
+  assert.equal(await c.should(HOST_B, PK_A), true);
+});
+
+// ---- wiring --------------------------------------------------------------------
+
+test('only a one-time approval is counted', async () => {
+  // 'relax' and 'trust' ARE the user acting on the advice — counting them would mean
+  // nudging someone who already listened.
+  assert.match(source, /if \(decision\.action === 'once'\) await bumpApproveCount\(/,
+    "the tally must be bumped only on the 'once' branch");
+  assert.ok(!/if \(decision\.action === 'relax'\)[\s\S]{0,200}bumpApproveCount/.test(source),
+    "'relax' must not count toward the nudge");
+});
+
+test('trusting and blocking both clear the tally', async () => {
+  for (const action of ['trust', 'block']) {
+    const re = new RegExp("decision\\.action === '" + action + "'\\)[\\s\\S]{0,220}clearApproveCount\\(");
+    assert.match(source, re, action + ' should clear the tally');
+  }
+});
+
+test('the nudge is suppressed while a destructive warning is showing', async () => {
+  // That screen is asking for full attention on what is about to be lost. "Trust this
+  // site to stop asking" is the last advice it should be carrying.
+  assert.match(source, /nudgeTrust: !destructive && \(await shouldNudgeTrust\(/);
+});
+
+// ---- both approval UIs -----------------------------------------------------------
+//
+// Sidecar renders approvals in TWO places: prompt.html (a popup window, shown when the
+// side panel is closed) and the in-panel view in sidepanel.js. Separate DOM, separate
+// code. The first cut of this work only touched the popup, so the same request showed
+// the relax chips in one and not the other, and the nudge in one and not the other.
+// These pin both.
+
+test('both approval UIs honor relaxEligible', () => {
+  const promptSrc = fs.readFileSync(path.join(ROOT, 'prompt.js'), 'utf8');
+  const panelSrc = fs.readFileSync(path.join(ROOT, 'sidepanel.js'), 'utf8');
+  for (const [name, src] of [['prompt.js', promptSrc], ['sidepanel.js', panelSrc]]) {
+    assert.match(src, /data\.relaxEligible !== false/,
+      name + ' must gate the relax offer on relaxEligible');
+  }
+});
+
+test('both approval UIs render the trust nudge', () => {
+  const promptSrc = fs.readFileSync(path.join(ROOT, 'prompt.js'), 'utf8');
+  const panelSrc = fs.readFileSync(path.join(ROOT, 'sidepanel.js'), 'utf8');
+  for (const [name, src] of [['prompt.js', promptSrc], ['sidepanel.js', panelSrc]]) {
+    assert.match(src, /data\.nudgeTrust/, name + ' must render the nudge');
+    assert.match(src, /Approving this often\? Trust /, name + ' must carry the copy');
+  }
+});
+
+test('both approval UIs have a nudge container, and a rule to style it', () => {
+  const promptHtml = fs.readFileSync(path.join(ROOT, 'prompt.html'), 'utf8');
+  const panelHtml = fs.readFileSync(path.join(ROOT, 'sidepanel.html'), 'utf8');
+  const css = fs.readFileSync(path.join(ROOT, 'styles.css'), 'utf8');
+  assert.match(promptHtml, /id="trust-nudge"/);
+  assert.match(panelHtml, /id="approval-trust-nudge"/);
+  // prompt.html carries its own <style>; the panel uses styles.css.
+  assert.match(promptHtml, /\.trust-nudge \{/, 'prompt.html needs the rule inline');
+  assert.match(css, /\.trust-nudge \{/, 'styles.css needs the rule for the panel');
+});
+
+test('the popup applies the panel theme', () => {
+  // prompt.html links all five theme stylesheets, which key off [data-theme]. Nothing
+  // set that attribute, so the popup always rendered Speakeasy purple over whatever
+  // theme the panel was wearing.
+  const promptSrc = fs.readFileSync(path.join(ROOT, 'prompt.js'), 'utf8');
+  assert.match(promptSrc, /setAttribute\(\s*'data-theme'/, 'popup must set data-theme');
+  assert.match(source, /theme: promptSettings\.theme \|\| 'speakeasy'/,
+    'the payload must carry the theme');
+  // Unknown values fall back rather than writing an arbitrary string into the DOM.
+  assert.match(promptSrc, /THEMES\.includes\(data\.theme\) \? data\.theme : 'speakeasy'/);
+});
+
+test('the popup theme allowlist matches the panel', () => {
+  const promptSrc = fs.readFileSync(path.join(ROOT, 'prompt.js'), 'utf8');
+  const panelSrc = fs.readFileSync(path.join(ROOT, 'sidepanel.js'), 'utf8');
+  const grab = (src, re) => {
+    const m = src.match(re);
+    assert.ok(m, 'could not find the theme list');
+    return m[1].split(',').map((s) => s.trim().replace(/['"]/g, '')).sort();
+  };
+  const promptThemes = grab(promptSrc, /const THEMES = \[([^\]]+)\]/);
+  const panelThemes = grab(panelSrc, /const validThemes = \[([^\]]+)\]/);
+  assert.deepEqual(promptThemes, panelThemes,
+    'a theme added to the panel but not the popup renders as Speakeasy there');
+});
+
+// ---- "Never" does not mean "never asks for a PIN" --------------------------------
+//
+// autoLockMinutes: 0 disables the IDLE TIMER only. The unlocked state is a derived key
+// in chrome.storage.session — memory-only, and cleared when the browser closes — so
+// there is still one PIN per browser session. Persisting the key to disk would defeat
+// encrypting it at rest, so this is a floor, not a bug. But "Never" reads as an
+// absolute promise, and being asked anyway looks like the setting failed.
+//
+// THREE surfaces can ask for that PIN. Same enumerate-the-surfaces lesson as the relax
+// gate: the popup, the in-panel approval, and the panel's own lock screen.
+
+test('the auto-lock setting explains the once-per-session PIN', () => {
+  const html = fs.readFileSync(path.join(ROOT, 'sidepanel.html'), 'utf8');
+  const block = html.match(/<h3>Auto-lock<\/h3>[\s\S]*?<\/div>/);
+  assert.ok(block, 'could not find the auto-lock setting');
+  assert.match(block[0], /once per browser session/,
+    'Never needs a hint, or it reads as an absolute promise');
+});
+
+test('all three unlock surfaces explain a fresh-browser lock', () => {
+  const promptSrc = fs.readFileSync(path.join(ROOT, 'prompt.js'), 'utf8');
+  const panelSrc = fs.readFileSync(path.join(ROOT, 'sidepanel.js'), 'utf8');
+  // 1 + 2: the popup and the in-panel approval, both driven by the payload flag.
+  assert.match(promptSrc, /data\.autoLockNever/, 'popup must react to the flag');
+  assert.match(panelSrc, /data\.autoLockNever/, 'in-panel approval must react to it');
+  for (const [name, src] of [['prompt.js', promptSrc], ['sidepanel.js', panelSrc]]) {
+    assert.match(src, /first unlock since your browser started/, name + ' copy');
+  }
+  // 3: the panel's own lock screen, which reads the setting directly.
+  assert.match(panelSrc, /Locked since your browser closed/, 'lock screen copy');
+});
+
+test('the in-panel unlock label resets when auto-lock is NOT Never', () => {
+  // The label is a persistent DOM node reused across approvals, so setting it on the
+  // Never path without an else would leave the wrong text behind after the user
+  // switches to a timed lock.
+  const panelSrc = fs.readFileSync(path.join(ROOT, 'sidepanel.js'), 'utf8');
+  assert.match(panelSrc, /: 'Enter your PIN to unlock';/,
+    'the non-Never branch must restore the default label');
+});
+
+test('the payload derives autoLockNever through resolveSettings', () => {
+  // Not `settings.autoLockMinutes === 0` on the raw object: unset must mean the
+  // 15-minute default, not Never. resolveSettings applies that default.
+  assert.match(source, /autoLockNever: resolveSettings\(promptSettings\)\.autoLockMinutes === 0/);
+});
+
+test('the prompt builds the nudge without innerHTML', async () => {
+  // The host is attacker-controlled and the string is assembled from it.
+  const promptSrc = fs.readFileSync(path.join(ROOT, 'prompt.js'), 'utf8');
+  const block = promptSrc.match(/if \(data\.nudgeTrust[\s\S]*?\n    \}/);
+  assert.ok(block, 'could not find the nudge block in prompt.js');
+  assert.ok(!/innerHTML/.test(block[0]), 'the nudge must not use innerHTML');
+  assert.match(block[0], /textContent/);
+});


### PR DESCRIPTION
A profile edit on an ask-tier site offered "auto-sign for the next 30 min." That was a security hole in the destructive-event guard — and fixing it surfaced three more problems in the same UI.

## 1. Kinds 0/3/10000 never relax

The destructive check suppresses the relax offer when *this* event looks like a wipe, but it's per-event and the window isn't. An ordinary complete profile edit isn't destructive, so it offered the window — and the *next* profile write inside it went through unwarned. Approving a write also makes it the new baseline, so the comparison the guard depends on is gone by then.

`RELAX.neverRelaxes(kind)` now covers both the wallet-control kinds (24133/23194/23195) and the replaceable ones (0/3/10000). All three call sites go through it — the bug was exactly that the three gates were written separately and diverged. A cross-file test asserts the relax-grants set agrees with `replaceable-baseline.js`'s `TRACKED` set.

## 2. The trust nudge

After 3 one-time approvals for the same host+account, both approval UIs show:

> Approving this often? Trust **jumble.social** to stop being asked.

Nothing on the screen said which button ends the asking, and "Allow once" reads like the default answer. A single-account user on a single app can approve the same site indefinitely without ever noticing Trust exists.

In `chrome.storage.session`, not a `Map` — the first cut used one and never fired, because the MV3 service worker is evicted after ~30s idle and the gap between two approvals is however long the user takes. The test mock uses `structuredClone` on get/set; without it the mock hid the lost writes entirely.

## 3. The popup theme — broken since 1.5.0

`prompt.html` linked all five theme stylesheets but never set `data-theme`, so every non-default theme rendered as Speakeasy purple. The theme now rides on the prompt payload so the window paints themed on the first frame.

The initial fix only partially worked because `prompt.html`'s `:root` fallbacks were in an inline `<style>` **after** the theme `<link>` tags — same specificity, so `:root` won the cascade and killed every theme override. Moved before the links, matching `sidepanel.html`'s load order. Also replaced 11 hardcoded Speakeasy literals with `var()` references and added the missing `--well-rgb`, `--border-rgb`, `--btn-primary-*` etc. fallbacks.

## 4. Unlock copy for "Never"

`autoLockMinutes: 0` disables the idle timer only. The unlocked key lives in `chrome.storage.session` — memory-only, cleared on browser close — so there is still one PIN per browser session. "Never" read as an absolute promise; being asked anyway looked like the setting failed.

Three surfaces now explain it: a hint under the setting, "first unlock since your browser started" on both approval UIs, and "Locked since your browser closed" on the panel's lock screen.

## The two-UI problem

Sidecar renders approvals in **two places** — the popup (`prompt.html`) and the in-panel view (`sidepanel.js`). The first cut of this work only touched the popup. The in-panel UI still offered relax chips on profile edits, had no trust nudge, and its unlock label didn't explain the session boundary. Tests now read both source files and fail if either drops a gate — the exact bug that prompted this.

241 tests (+28). Both the relax exclusion and the nudge counter are mutation-tested.

🥃 Neat with [Claude Code](https://claude.com/claude-code)
