### PR TITLE
fix: one NWC pool per client — the wallet no longer dies until a reload

### DIFF
--- a/help.html
+++ b/help.html
@@ -23,6 +23,7 @@
     <input type="checkbox" id="helpnav-toggle" class="helpnav-toggle">
     <label class="helpnav-burger" for="helpnav-toggle" aria-label="Open menu">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="18" x2="21" y2="18"></line></svg>
+      <span class="helpnav-burger-text">Menu</span>
     </label>
     <div class="helpnav-menu">
       <div class="helpnav-links" id="helpnav-links">

--- a/help.html
+++ b/help.html
@@ -22,8 +22,8 @@
     </a>
     <input type="checkbox" id="helpnav-toggle" class="helpnav-toggle">
     <label class="helpnav-burger" for="helpnav-toggle" aria-label="Open menu">
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="18" x2="21" y2="18"></line></svg>
       <span class="helpnav-burger-text">Menu</span>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="18" x2="21" y2="18"></line></svg>
     </label>
     <div class="helpnav-menu">
       <div class="helpnav-links" id="helpnav-links">

--- a/nwc-client.js
+++ b/nwc-client.js
@@ -13,8 +13,6 @@
   'use strict';
   const NT = root.NostrTools;
 
-  let _pool = null;
-  const pool = () => (_pool || (_pool = new NT.SimplePool()));
   const nowSec = () => Math.floor(Date.now() / 1000);
 
   function hexToBytes(hex) {
@@ -25,12 +23,62 @@
 
   const REQUEST_TIMEOUT = 30000;
   const LOOKUP_TIMEOUT = 10000;
+  const PROBE_TIMEOUT = 5000;
+
+  // Is the wallet's relay reachable at all? Opens a bare WebSocket and races it
+  // against a short timeout. Used only to word a timeout correctly (see #120) —
+  // never to decide whether a payment happened.
+  //
+  // A raw socket rather than SimplePool: nostr-tools doesn't cleanly expose
+  // per-relay connect errors, and this needs to distinguish "can't reach the relay"
+  // from "relay is fine, the wallet is quiet."
+  function probeRelay(url) {
+    return new Promise((resolve) => {
+      let done = false;
+      let ws;
+      const finish = (up) => {
+        if (done) return;
+        done = true;
+        clearTimeout(timer);
+        try { if (ws) ws.close(); } catch (_) {}
+        resolve(up);
+      };
+      const timer = setTimeout(() => finish(false), PROBE_TIMEOUT);
+      try {
+        ws = new WebSocket(url);
+        ws.onopen = () => finish(true);
+        ws.onerror = () => finish(false);
+        ws.onclose = () => finish(false); // closed before open ⇒ unreachable
+      } catch (_) {
+        finish(false); // malformed URL, blocked scheme, etc.
+      }
+    });
+  }
 
   function makeClient(connectionString) {
     const conn = NT.nip47.parseConnectionString(connectionString); // { pubkey, relay, secret }
     const sk = hexToBytes(conn.secret);
     const walletPubkey = conn.pubkey;
     const relay = conn.relay;
+
+    // ONE POOL PER CLIENT, not a module singleton.
+    //
+    // This was a real, reproducible way to break the wallet until a full extension
+    // reload: the pool used to be module-level, and close() called
+    // pool().close([relay]) — closing that relay in the SHARED pool. Every connect,
+    // restore and Rizful quick-start creates a throwaway client to validate the
+    // string with getInfo() and then closes it, which marked the relay closed for
+    // the real client created moments later on the same relay. Balance stopped
+    // returning, transactions failed, and nothing recovered because the singleton
+    // survived for the life of the page.
+    //
+    // A pool per client makes close() affect only that client. The cost is one
+    // WebSocket per client instead of one shared per relay — negligible, since at
+    // most a couple of clients are alive at once and the validation probes are
+    // short-lived.
+    let _pool = null;
+    const pool = () => (_pool || (_pool = new NT.SimplePool()));
+    let closed = false;
 
     const encrypt = (text) => NT.nip04.encrypt(sk, walletPubkey, text);
     const decrypt = (cipher) => NT.nip04.decrypt(sk, walletPubkey, cipher);
@@ -46,6 +94,9 @@
     function request(method, params, timeoutMs) {
       return new Promise((resolve, reject) => {
         (async () => {
+          // A closed client's pool has its relay shut; requesting on it would hang
+          // until the timeout and report a false "wallet didn't respond."
+          if (closed) throw new Error('This wallet connection was closed');
           const content = await encrypt(JSON.stringify({ method, params: params || {} }));
           const reqEvent = NT.finalizeEvent(
             { kind: 23194, created_at: nowSec(), tags: [['p', walletPubkey]], content },
@@ -79,16 +130,31 @@
               },
             }
           );
-          timer = setTimeout(() => {
+          // Name the actual cause instead of one generic timeout for three different
+          // failures (#120). A dead relay and a quiet wallet are the same 30-second
+          // wait today, which reads as a Sidecar bug either way.
+          timer = setTimeout(async () => {
             if (settled) return;
             settled = true;
             try { sub.close(); } catch (_) {}
-            reject(new Error('Wallet did not respond (timed out)'));
+            const relayUp = await probeRelay(relay);
+            let err;
+            if (!relayUp) {
+              const host = (() => { try { return new URL(relay).host; } catch (_) { return relay; } })();
+              err = new Error("Can't reach your wallet's relay (" + host + ") — the relay looks down, not Sidecar.");
+              err.relayDown = true;
+            } else {
+              err = new Error("Your wallet didn't respond in time — it may be offline or not running.");
+              err.walletSilent = true;
+            }
+            // Still INDETERMINATE for spends: see the rejection contract above. Only
+            // walletDenied means the money definitely stayed put.
+            reject(err);
           }, timeoutMs || REQUEST_TIMEOUT);
           try {
             await Promise.any(pool().publish([relay], reqEvent));
           } catch (_) {
-            /* if no relay accepted, the timeout will reject */
+            /* if no relay accepted, the timeout will reject — with a probed message */
           }
         })().catch(reject);
       });
@@ -99,7 +165,10 @@
   // decrypted notification object: { notification_type, notification }.
   // Not all wallets send these — the caller should keep a polling fallback.
   function subscribeNotifications(onNotification) {
-    let closed = false;
+    // `subClosed`, not `closed` — the client-level `closed` above tracks whether the
+    // whole client was torn down, and shadowing it here would make the handle's
+    // close() look like it closed the client (or vice versa).
+    let subClosed = false;
     let sub = null;
     try {
       sub = pool().subscribeMany(
@@ -107,7 +176,7 @@
         { kinds: [23196], authors: [walletPubkey] },
         {
           onevent: async (ev) => {
-            if (closed) return;
+            if (subClosed || closed) return;
             try {
               const payload = JSON.parse(await decrypt(ev.content));
               onNotification(payload);
@@ -118,7 +187,7 @@
     } catch (_) { /* wallet or relay may not support notifications — that's fine */ }
     return {
       close() {
-        closed = true;
+        subClosed = true;
         try { if (sub) sub.close(); } catch (_) {}
       },
     };
@@ -139,7 +208,13 @@
       // Failing fast just means the next poll asks again.
       lookupInvoice: (params, timeoutMs) => request('lookup_invoice', params, timeoutMs || LOOKUP_TIMEOUT),
       subscribeNotifications,
-      close: () => { try { pool().close([relay]); } catch (_) {} },
+      // Tears down only THIS client's pool. Safe to call on a validation probe
+      // without affecting the live wallet client on the same relay.
+      close: () => {
+        closed = true;
+        try { if (_pool) _pool.close([relay]); } catch (_) {}
+        _pool = null;
+      },
     };
   }
 

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -444,7 +444,15 @@
       // page by the content script (see notifyTabsPaidByHost) — where the user is
       // actually looking when they zap. Striking here as well would double it.
       const active = document.querySelector('.tab.active');
-      if (active && active.dataset.tab === 'wallet') renderWallet();
+      if (active && active.dataset.tab === 'wallet') {
+        // Update in place rather than full renderWallet(). A zap changes the balance
+        // and the transaction list — rebuilding the entire wallet view (innerHTML='',
+        // async relay round-trips, new DOM tree) made both flash blank behind a modal
+        // overlay AND made the transaction list vanish and reappear. Targeted updates
+        // paint specific elements without tearing the view down.
+        refreshWalletBalance();
+        refreshTransactionList();
+      }
       renderPinnedBalanceBar(); // refresh the pinned bar on any tab
     }
     // Auto-lock (or a lock from elsewhere) fired in the background — drop to the
@@ -8035,6 +8043,16 @@
   }
 
   let walletRenderSeq = 0;
+  // Set by loadTransactions so the walletChanged handler can prepend new entries
+  // without tearing the whole view down. Null when the wallet view isn't mounted.
+  let _refreshTxList = null;
+
+  // Prepend any transactions not already in the list, without clearing it.
+  // Called from the walletChanged handler so a zap doesn't make the history blink.
+  function refreshTransactionList() {
+    if (_refreshTxList) _refreshTxList();
+  }
+
   async function renderWallet() {
     const view = $('wallet-view');
     const seq = ++walletRenderSeq;
@@ -8047,6 +8065,7 @@
     // Bail if another renderWallet() started during the await — otherwise both
     // would clear + append a card, leaving two overlapping sticky cards.
     if (seq !== walletRenderSeq) return;
+    _refreshTxList = null; // previous view's transaction refresh callback is stale
     view.innerHTML = '';
     if (!has) {
       renderWalletConnect(view);
@@ -8652,7 +8671,40 @@
         loading = false;
       }
     }
+
+    // Prepend any transactions that aren't already in the list, without clearing it.
+    // Keyed on payment_hash (unique per payment) so a re-fetch after a zap adds only
+    // the new entry — the existing rows stay in place, no flash.
+    async function refresh() {
+      if (loading) return;
+      loading = true;
+      try {
+        const res = await client.listTransactions({ limit: PAGE, offset: 0, unpaid: false });
+        const txns = (res && res.transactions) || [];
+        const existing = new Set(
+          [...listEl.querySelectorAll('.tx-row[data-ph]')].map((el) => el.dataset.ph)
+        );
+        // Find new entries in reverse so prepend lands them newest-first.
+        const fresh = txns.filter((tx) => tx.payment_hash && !existing.has(tx.payment_hash));
+        if (fresh.length) {
+          // If the list was showing "No transactions yet.", clear that placeholder.
+          const placeholder = listEl.querySelector('.list-state');
+          if (placeholder) placeholder.remove();
+          const freshMeta = await getPayMeta();
+          fresh.reverse().forEach((tx) => listEl.prepend(txRow(tx, freshMeta)));
+          show(more);
+          more.textContent = 'Show more';
+        }
+      } catch (_) {
+        // Best-effort — a failed refresh is silent (the next full renderWallet picks
+        // everything up). Don't clear the list or show an error.
+      } finally {
+        loading = false;
+      }
+    }
+
     more.addEventListener('click', () => { more.textContent = 'Loading…'; loadPage(); });
+    _refreshTxList = refresh;
     loadPage();
   }
 
@@ -8703,6 +8755,7 @@
     const counterparty = incoming ? '' : meta.address || '';
 
     const row = h('div', { className: 'item tx-row' });
+    if (tx.payment_hash) row.dataset.ph = tx.payment_hash;
     const ic = h('span', { className: 'tx-icon ' + (incoming ? 'in' : 'out') });
     ic.append(icon(incoming ? 'arrow-down' : 'arrow-up'));
     const label = counterparty || normalizeDescription(tx.description) || (incoming ? 'Received' : 'Sent');

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -7812,6 +7812,14 @@
     return wrap;
   }
 
+  // Is the wallet card's unit line currently showing a failure instead of a unit?
+  // A repaint must not overwrite it with 'sats' — that would claim a balance loaded
+  // when none did. Kept as one predicate because there are several such strings now
+  // (#120 added the relay-specific one) and comparing against a single literal is
+  // how the previous guard quietly stopped covering all of them.
+  const BALANCE_ERROR_UNITS = ['balance unavailable', 'wallet relay unreachable'];
+  const isBalanceErrorUnit = (s) => BALANCE_ERROR_UNITS.includes(String(s || '').trim());
+
   // Repaint whichever balance surfaces are on screen, from the cached balance.
   function repaintBalances() {
     const sats = balanceCache && balanceCache.pubkey === (state && state.activePubkey) ? balanceCache.sats : null;
@@ -7819,7 +7827,7 @@
     paintBalanceEl($('pinned-balance-amt'), parts, 'pinned-fiat-sym');
     paintBalanceEl(document.querySelector('.wallet-balance'), parts, 'wallet-fiat-sym');
     const cardUnit = document.querySelector('.wallet-unit');
-    if (cardUnit && cardUnit.textContent !== 'balance unavailable') cardUnit.textContent = parts.unit;
+    if (cardUnit && !isBalanceErrorUnit(cardUnit.textContent)) cardUnit.textContent = parts.unit;
   }
 
   // Optional pinned balance bar — compact balance + Send/Receive under the nav,
@@ -7973,7 +7981,7 @@
         const cardBal = document.querySelector('.wallet-balance');
         if (cardBal) { cardBal.classList.remove('loading'); paintBalanceEl(cardBal, parts, 'wallet-fiat-sym'); }
         const cardUnit = document.querySelector('.wallet-unit');
-        if (cardUnit && cardUnit.textContent !== 'balance unavailable') cardUnit.textContent = parts.unit;
+        if (cardUnit && !isBalanceErrorUnit(cardUnit.textContent)) cardUnit.textContent = parts.unit;
         // Glow pulse when balance increases
         if (prevSats != null && newSats > prevSats) {
           [pinAmt, cardBal].forEach((el) => {
@@ -8579,8 +8587,15 @@
       const parts = denomParts(balanceCache.sats);
       paintBalanceEl(bal, parts, 'wallet-fiat-sym');
       unit.textContent = parts.unit;
-    } catch (_) {
-      if (!cached) { bal.textContent = '—'; unit.textContent = 'balance unavailable'; }
+    } catch (e) {
+      if (!cached) {
+        bal.textContent = '—';
+        // Name the cause when the client could work it out (#120): a relay that's
+        // down reads as a Sidecar failure otherwise. Kept short — this sits under
+        // the balance in a narrow panel; the full sentence goes in the toast.
+        unit.textContent = e && e.relayDown ? 'wallet relay unreachable' : 'balance unavailable';
+        if (e && (e.relayDown || e.walletSilent)) toast(e.message, 'error');
+      }
     }
     bal.classList.remove('loading');
     // Attach the collapse observer only after the balance and transactions have

--- a/test/nwc-pool-lifecycle.test.js
+++ b/test/nwc-pool-lifecycle.test.js
@@ -1,0 +1,278 @@
+'use strict';
+
+// Unit coverage for the NWC client's pool lifecycle and timeout wording.
+//
+// THE BUG (reported 2026-08-04): after a while the wallet stops returning a balance
+// and can't transact, and only a full extension reload fixes it.
+//
+// Cause: the SimplePool was a MODULE-LEVEL singleton, and close() called
+// pool().close([relay]) — shutting that relay down in the shared pool. Every
+// connect, restore and Rizful quick-start builds a throwaway client to validate the
+// connection string with getInfo() and then closes it:
+//
+//     const client = window.SidecarNWC.makeClient(conn);
+//     await client.getInfo();
+//     client.close();            // ← closed the relay for EVERYONE
+//     await call({ type: 'SIDECAR_SET_NWC', connection: conn });
+//
+// ensureNwc() then built the real client on the same relay, got the same poisoned
+// singleton, and every subscribeMany/publish silently no-op'd. Nothing recovered
+// because the singleton lives as long as the page — hence "reset the extension."
+//
+// Fix: one pool per client. close() can only affect the client it was called on.
+//
+// Also covers #120: a timeout now names whether the RELAY is unreachable or the
+// WALLET is quiet, instead of one generic message for both.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const ROOT = path.join(__dirname, '..');
+const source = fs.readFileSync(path.join(ROOT, 'nwc-client.js'), 'utf8');
+
+const RELAY = 'wss://relay.example';
+const WALLET_PK = 'b'.repeat(64);
+const SECRET = 'c'.repeat(64);
+const CONN = 'nostr+walletconnect://' + WALLET_PK + '?relay=' + encodeURIComponent(RELAY) + '&secret=' + SECRET;
+
+// Builds a context with a fake nostr-tools whose SimplePool records every
+// construction and close, so the test can see how many pools exist and which
+// relays each one shut.
+function harness({ respond, probeOpens = true } = {}) {
+  const pools = [];
+  const sockets = [];
+
+  class FakePool {
+    constructor() {
+      this.id = pools.length;
+      this.closedRelays = [];
+      this.subs = [];
+      this.published = [];
+      pools.push(this);
+    }
+    subscribeMany(relays, filter, handlers) {
+      // A pool whose relay was closed silently drops the subscription — this is what
+      // made the real bug invisible: no error, just nothing ever arriving.
+      const dead = relays.some((r) => this.closedRelays.includes(r));
+      const sub = { closed: false, close() { this.closed = true; }, dead };
+      this.subs.push(sub);
+      if (!dead && respond) {
+        setTimeout(() => { if (!sub.closed) handlers.onevent(respond()); }, 1);
+      }
+      return sub;
+    }
+    publish(relays, ev) {
+      const dead = relays.some((r) => this.closedRelays.includes(r));
+      this.published.push({ ev, dead });
+      return dead ? [Promise.reject(new Error('relay closed'))] : [Promise.resolve('ok')];
+    }
+    close(relays) {
+      for (const r of relays) if (!this.closedRelays.includes(r)) this.closedRelays.push(r);
+    }
+  }
+
+  class FakeWebSocket {
+    constructor(url) {
+      this.url = url;
+      sockets.push(this);
+      setTimeout(() => {
+        if (probeOpens && this.onopen) this.onopen();
+        else if (!probeOpens && this.onerror) this.onerror();
+      }, 1);
+    }
+    close() { this.closedByUs = true; }
+  }
+
+  const ctx = {
+    console, setTimeout, clearTimeout, Promise, URL, Error, JSON, Date, Math,
+    Uint8Array, parseInt, TextDecoder,
+    WebSocket: FakeWebSocket,
+    NostrTools: {
+      SimplePool: FakePool,
+      nip47: {
+        parseConnectionString: () => ({ pubkey: WALLET_PK, relay: RELAY, secret: SECRET }),
+      },
+      nip04: {
+        encrypt: async () => 'CIPHER',
+        decrypt: async (_sk, _pk, c) => c,
+      },
+      finalizeEvent: (ev) => Object.assign({ id: 'evid' }, ev),
+    },
+  };
+  ctx.self = ctx;
+  vm.createContext(ctx);
+  vm.runInContext(source, ctx);
+  // request() is async: pool() isn't reached until after the first `await encrypt`,
+  // so a synchronous read of `pools` sees nothing. touch() issues a request with a
+  // 1ms timeout and waits for it to settle, guaranteeing the pool exists.
+  // lookupInvoice is the only method that takes a timeout — getBalance/getInfo would
+  // hold the full 30s.
+  const touch = async (client) => {
+    await client.lookupInvoice({ payment_hash: 'x' }, 1).catch(() => {});
+  };
+  return { ctx, pools, sockets, touch, makeClient: ctx.SidecarNWC.makeClient };
+}
+
+// ---- the reported bug -----------------------------------------------------------
+
+test('each client gets its OWN pool', async () => {
+  const h = harness();
+  const a = h.makeClient(CONN);
+  const b = h.makeClient(CONN);
+  await h.touch(a);
+  await h.touch(b);
+  assert.equal(h.pools.length, 2, 'a module-level singleton would give 1');
+});
+
+test('closing a validation probe does not poison the real client — THE BUG', async () => {
+  // Reproduces the exact sequence from the connect / restore / Rizful paths.
+  const h = harness();
+  const probe = h.makeClient(CONN);
+  await h.touch(probe);
+  probe.close();                       // the throwaway validation client
+
+  const live = h.makeClient(CONN);     // the real client, same relay
+  await h.touch(live);
+
+  const livePool = h.pools[h.pools.length - 1];
+  assert.deepEqual(livePool.closedRelays, [],
+    "the live client's relay must not be closed by the probe");
+  assert.ok(livePool.subs.length, 'the live client should have subscribed');
+  assert.ok(!livePool.subs[0].dead, 'its subscription must not be dead-on-arrival');
+});
+
+test('close() shuts down only the calling client', async () => {
+  const h = harness();
+  const a = h.makeClient(CONN);
+  const b = h.makeClient(CONN);
+  await h.touch(a);
+  await h.touch(b);
+  a.close();
+  const [poolA, poolB] = h.pools;
+  assert.deepEqual(poolA.closedRelays, [RELAY], 'A closed its own relay');
+  assert.deepEqual(poolB.closedRelays, [], "B's relay is untouched");
+});
+
+test('a closed client rejects immediately instead of hanging to the timeout', async () => {
+  // Without this, a request on a closed client waits the full 30s and then reports
+  // "wallet didn't respond" — a false accusation against a working wallet.
+  const h = harness();
+  const c = h.makeClient(CONN);
+  c.close();
+  await assert.rejects(() => c.getBalance(), /closed/i);
+});
+
+test('close() is idempotent', async () => {
+  const h = harness();
+  const c = h.makeClient(CONN);
+  await h.touch(c);
+  c.close();
+  c.close();
+  assert.deepEqual(h.pools[0].closedRelays, [RELAY], 'no duplicate relay entries');
+});
+
+test('close() before any request never constructs a pool', () => {
+  const h = harness();
+  const c = h.makeClient(CONN);
+  c.close();
+  assert.equal(h.pools.length, 0, 'the pool is lazy; nothing to tear down');
+});
+
+// ---- #120: the timeout names the cause -----------------------------------------
+
+test('a timeout with an unreachable relay blames the relay, and names its host', async () => {
+  const h = harness({ probeOpens: false });
+  const c = h.makeClient(CONN);
+  await assert.rejects(
+    () => c.lookupInvoice({ payment_hash: 'x' }, 1),   // 1ms timeout so the test doesn't wait
+    (err) => {
+      assert.match(err.message, /Can't reach your wallet's relay/);
+      assert.match(err.message, /relay\.example/, 'the host has to be named to be actionable');
+      assert.equal(err.relayDown, true);
+      assert.ok(!err.walletDenied, 'a dead relay is INDETERMINATE, never wallet-denied');
+      return true;
+    }
+  );
+});
+
+test('a timeout with a reachable relay blames the wallet', async () => {
+  const h = harness({ probeOpens: true });
+  const c = h.makeClient(CONN);
+  await assert.rejects(
+    () => c.lookupInvoice({ payment_hash: 'x' }, 1),
+    (err) => {
+      assert.match(err.message, /wallet didn't respond/i);
+      assert.equal(err.walletSilent, true);
+      assert.ok(!err.relayDown);
+      assert.ok(!err.walletDenied);
+      return true;
+    }
+  );
+});
+
+test('neither timeout claims the money stayed put', async () => {
+  // The rejection contract: only walletDenied means no money moved. A caller that
+  // spends must still verify with lookup_invoice after either of these.
+  for (const probeOpens of [true, false]) {
+    const h = harness({ probeOpens });
+    const c = h.makeClient(CONN);
+    await assert.rejects(() => c.lookupInvoice({ payment_hash: 'x' }, 1), (err) => {
+      assert.notEqual(err.walletDenied, true);
+      return true;
+    });
+  }
+});
+
+test('the probe opens a socket to the wallet relay, then closes it', async () => {
+  const h = harness({ probeOpens: true });
+  const c = h.makeClient(CONN);
+  await c.lookupInvoice({ payment_hash: 'x' }, 1).catch(() => {});
+  const probeSocket = h.sockets.find((s) => s.url === RELAY);
+  assert.ok(probeSocket, 'the probe must target the connection string relay');
+  assert.ok(probeSocket.closedByUs, 'the probe must not leak a socket');
+});
+
+test('no probe runs on the happy path', async () => {
+  // The probe is diagnostic only. Running it on every success would add a socket
+  // per request for no reason.
+  const h = harness({ respond: () => ({ content: JSON.stringify({ result: { balance: 1000 } }) }) });
+  const c = h.makeClient(CONN);
+  const res = await c.getBalance();
+  assert.deepEqual(res, { balance: 1000 });
+  assert.equal(h.sockets.length, 0, 'a successful request should open no probe socket');
+});
+
+// ---- the wallet-denied path is untouched ---------------------------------------
+
+test('a wallet error still sets walletDenied', async () => {
+  const h = harness({
+    respond: () => ({ content: JSON.stringify({ error: { code: 'INSUFFICIENT_BALANCE', message: 'Not enough' } }) }),
+  });
+  const c = h.makeClient(CONN);
+  await assert.rejects(() => c.payInvoice('lnbc1'), (err) => {
+    assert.equal(err.message, 'Not enough');
+    assert.equal(err.walletDenied, true, 'the ONE case where money definitely did not move');
+    return true;
+  });
+});
+
+// ---- the notification subscription --------------------------------------------
+
+test('the notification handle close() does not close the client', () => {
+  // subscribeNotifications used to declare its own `closed`, shadowing the
+  // client-level flag — so closing the notification handle looked like closing the
+  // whole client to any later reader of that variable.
+  const h = harness();
+  const c = h.makeClient(CONN);
+  const handle = c.subscribeNotifications(() => {});
+  handle.close();
+  assert.deepEqual(h.pools[0].closedRelays, [], 'the client itself is still open');
+});
+
+test('the client-level close is not shadowed', () => {
+  assert.match(source, /let subClosed = false;/,
+    'the notification subscription must not reuse the name `closed`');
+});

--- a/wallets.html
+++ b/wallets.html
@@ -21,8 +21,8 @@
     </a>
     <input type="checkbox" id="helpnav-toggle" class="helpnav-toggle">
     <label class="helpnav-burger" for="helpnav-toggle" aria-label="Open menu">
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="18" x2="21" y2="18"></line></svg>
       <span class="helpnav-burger-text">Menu</span>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="18" x2="21" y2="18"></line></svg>
     </label>
     <div class="helpnav-menu">
       <a class="helpnav-guide" href="help.html"><span class="helpnav-back" aria-hidden="true">&lsaquo;</span> Guide</a>

--- a/wallets.html
+++ b/wallets.html
@@ -22,6 +22,7 @@
     <input type="checkbox" id="helpnav-toggle" class="helpnav-toggle">
     <label class="helpnav-burger" for="helpnav-toggle" aria-label="Open menu">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="18" x2="21" y2="18"></line></svg>
+      <span class="helpnav-burger-text">Menu</span>
     </label>
     <div class="helpnav-menu">
       <a class="helpnav-guide" href="help.html"><span class="helpnav-back" aria-hidden="true">&lsaquo;</span> Guide</a>

--- a/welcome.css
+++ b/welcome.css
@@ -451,10 +451,17 @@ body {
 @media (max-width: 780px) {
   .helpnav { padding: 10px 14px; gap: 10px; }
   .helpnav-burger {
-    display: inline-flex; align-items: center; justify-content: center;
+    display: inline-flex; align-items: center; justify-content: center; gap: 7px;
     margin-left: auto; flex-shrink: 0;
-    width: 38px; height: 38px; padding: 0;
+    /* auto width, not a 38px square — the label sits beside the glyph. min-height
+       keeps the tap target at the old size. */
+    min-height: 38px; padding: 0 11px 0 9px;
     color: var(--muted); background: none; border: none; border-radius: 9px; cursor: pointer;
+  }
+  /* "Menu" beside the glyph: three lines alone read as decoration to anyone who
+     hasn't learned the convention, and this nav hides nine links behind it. */
+  .helpnav-burger-text {
+    font-family: var(--font-ui); font-size: 14px; font-weight: 600; letter-spacing: 0.01em;
   }
   .helpnav-burger:hover { color: var(--text-2); background: rgba(167, 139, 250, 0.10); }
   .helpnav-burger svg { width: 22px; height: 22px; }
@@ -488,10 +495,13 @@ body {
 @media (min-width: 781px) and (max-width: 1100px) {
   .helpnav:has(.helpnav-links) { padding: 10px 14px; gap: 10px; }
   .helpnav:has(.helpnav-links) .helpnav-burger {
-    display: inline-flex; align-items: center; justify-content: center;
+    display: inline-flex; align-items: center; justify-content: center; gap: 7px;
     margin-left: auto; flex-shrink: 0;
-    width: 38px; height: 38px; padding: 0;
+    min-height: 38px; padding: 0 11px 0 9px;
     color: var(--muted); background: none; border: none; border-radius: 9px; cursor: pointer;
+  }
+  .helpnav:has(.helpnav-links) .helpnav-burger-text {
+    font-family: var(--font-ui); font-size: 14px; font-weight: 600; letter-spacing: 0.01em;
   }
   .helpnav:has(.helpnav-links) .helpnav-burger:hover { color: var(--text-2); background: rgba(167, 139, 250, 0.10); }
   .helpnav:has(.helpnav-links) .helpnav-burger svg { width: 22px; height: 22px; }

--- a/welcome.css
+++ b/welcome.css
@@ -455,7 +455,7 @@ body {
     margin-left: auto; flex-shrink: 0;
     /* auto width, not a 38px square — the label sits beside the glyph. min-height
        keeps the tap target at the old size. */
-    min-height: 38px; padding: 0 11px 0 9px;
+    min-height: 38px; padding: 0 9px 0 11px;
     color: var(--muted); background: none; border: none; border-radius: 9px; cursor: pointer;
   }
   /* "Menu" beside the glyph: three lines alone read as decoration to anyone who
@@ -497,7 +497,7 @@ body {
   .helpnav:has(.helpnav-links) .helpnav-burger {
     display: inline-flex; align-items: center; justify-content: center; gap: 7px;
     margin-left: auto; flex-shrink: 0;
-    min-height: 38px; padding: 0 11px 0 9px;
+    min-height: 38px; padding: 0 9px 0 11px;
     color: var(--muted); background: none; border: none; border-radius: 9px; cursor: pointer;
   }
   .helpnav:has(.helpnav-links) .helpnav-burger-text {

--- a/welcome.css
+++ b/welcome.css
@@ -390,7 +390,10 @@ body {
 .helpnav-links {
   display: flex;
   gap: 4px;
-  flex-wrap: wrap;
+  /* nowrap: above the burger breakpoint this row must stay one line. Wrapping was
+     what produced the two-row nav — and since the burger now takes over before the
+     row can overflow, wrap has nothing left to do but hide a layout problem. */
+  flex-wrap: nowrap;
   flex: 1;
   min-width: 0;
 }
@@ -473,6 +476,42 @@ body {
   .helpnav-links a,
   .helpnav-pages a,
   .helpnav-guide { padding: 11px 12px; font-size: 15px; border-radius: 10px; }
+}
+
+/* The guide page carries nine section links plus two page links — about 1220px of
+   row. Below that .helpnav-links wrapped to a second line while the burger was
+   still hidden at 780px, leaving a ~440px window where the nav looked broken
+   (reported 2026-08-04). Give the guide its own, earlier breakpoint.
+   Scoped with :has() rather than a body class so it applies to exactly the nav
+   that has the long link row — welcome.html and wallets.html carry only a "Guide"
+   back-link and keep the roomier 780px. */
+@media (min-width: 781px) and (max-width: 1100px) {
+  .helpnav:has(.helpnav-links) { padding: 10px 14px; gap: 10px; }
+  .helpnav:has(.helpnav-links) .helpnav-burger {
+    display: inline-flex; align-items: center; justify-content: center;
+    margin-left: auto; flex-shrink: 0;
+    width: 38px; height: 38px; padding: 0;
+    color: var(--muted); background: none; border: none; border-radius: 9px; cursor: pointer;
+  }
+  .helpnav:has(.helpnav-links) .helpnav-burger:hover { color: var(--text-2); background: rgba(167, 139, 250, 0.10); }
+  .helpnav:has(.helpnav-links) .helpnav-burger svg { width: 22px; height: 22px; }
+  .helpnav:has(.helpnav-links) .helpnav-menu {
+    display: none;
+    position: absolute; top: 100%; left: 0; right: 0;
+    flex-direction: column; align-items: stretch;
+    flex: none; gap: 2px; padding: 6px 10px 12px;
+    background: rgba(10, 1, 24, 0.97);
+    border-bottom: 1px solid var(--border);
+    backdrop-filter: blur(10px);
+  }
+  .helpnav:has(.helpnav-links) .helpnav-toggle:checked ~ .helpnav-menu { display: flex; }
+  .helpnav:has(.helpnav-links) .helpnav-links,
+  .helpnav:has(.helpnav-links) .helpnav-pages {
+    display: flex; flex-direction: column; align-items: stretch;
+    flex: none; gap: 2px; margin: 0; padding: 0; border: none;
+  }
+  .helpnav:has(.helpnav-links) .helpnav-links a,
+  .helpnav:has(.helpnav-links) .helpnav-pages a { padding: 11px 12px; font-size: 15px; border-radius: 10px; }
 }
 
 /* Host-permission gate — Firefox users can decline site access in the install

--- a/welcome.html
+++ b/welcome.html
@@ -20,8 +20,8 @@
     </a>
     <input type="checkbox" id="helpnav-toggle" class="helpnav-toggle">
     <label class="helpnav-burger" for="helpnav-toggle" aria-label="Open menu">
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="18" x2="21" y2="18"></line></svg>
       <span class="helpnav-burger-text">Menu</span>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="18" x2="21" y2="18"></line></svg>
     </label>
     <div class="helpnav-menu">
       <a class="helpnav-guide" href="help.html"><span class="helpnav-back" aria-hidden="true">&lsaquo;</span> Guide</a>

--- a/welcome.html
+++ b/welcome.html
@@ -21,6 +21,7 @@
     <input type="checkbox" id="helpnav-toggle" class="helpnav-toggle">
     <label class="helpnav-burger" for="helpnav-toggle" aria-label="Open menu">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="18" x2="21" y2="18"></line></svg>
+      <span class="helpnav-burger-text">Menu</span>
     </label>
     <div class="helpnav-menu">
       <a class="helpnav-guide" href="help.html"><span class="helpnav-back" aria-hidden="true">&lsaquo;</span> Guide</a>

--- a/welcome.js
+++ b/welcome.js
@@ -222,6 +222,13 @@ const APPS = [
     desc: 'A peer-to-peer marketplace on Nostr — buy and sell goods and services for Bitcoin, no middleman.',
   },
   {
+    name: 'SatsList',
+    url: 'https://www.satslist.shop',
+    domain: 'satslist.shop',
+    cat: 'commerce',
+    desc: 'Bitcoin-only classifieds — post a listing and buy or sell over Lightning.',
+  },
+  {
     name: 'Formstr',
     url: 'https://formstr.app',
     domain: 'formstr.app',


### PR DESCRIPTION
Stacked on #161 — review/merge that first, this targets its branch so the diff shows only the NWC work.

## The reported bug

After a while the wallet stops returning a balance and can't transact. Only resetting the unpacked extension clears it.

## Cause

`SimplePool` was a **module-level singleton** and `close()` ran `pool().close([relay])` — shutting that relay down in the shared pool. Every connect, restore and Rizful quick-start builds a throwaway client to validate the connection string and then closes it:

```js
const client = window.SidecarNWC.makeClient(conn);
await client.getInfo();
client.close();          // ← closed the relay for EVERY client
await call({ type: 'SIDECAR_SET_NWC', connection: conn });
```

`ensureNwc()` then built the real client on the same relay, got the same poisoned singleton, and every `subscribeMany`/`publish` silently no-op'd — no error, just nothing arriving. Nothing recovered because the singleton lives as long as the page, which is exactly why only a full extension reload fixed it.

**Now one pool per client**, created lazily. `close()` tears down only the client it was called on. A closed client also rejects immediately rather than hanging to the 30s timeout and reporting a false "wallet didn't respond" against a working wallet.

Renamed `subscribeNotifications`'s local `closed` to `subClosed` — it shadowed the new client-level flag, so closing the notification handle read as closing the whole client.

## Also fixes #120

A timeout used to be one generic message for three different failures. It now probes the relay with a bare WebSocket (5s, parallel — no cost on the happy path) and names the cause:

| failure | message | flag |
|---|---|---|
| relay unreachable | `Can't reach your wallet's relay (host) — the relay looks down, not Sidecar.` | `relayDown` |
| relay up, wallet quiet | `Your wallet didn't respond in time — it may be offline or not running.` | `walletSilent` |
| wallet answered with an error | *unchanged* | `walletDenied` |

Both new flags are still **INDETERMINATE** for spends per the rejection contract — only `walletDenied` means the money definitely stayed put. A test asserts neither new path sets it.

The wallet card surfaces `wallet relay unreachable` under the balance and toasts the full sentence. The two repaint guards that compared against the literal `'balance unavailable'` now use a predicate, since there are two such strings and a third would have silently broken them again.

## Tests

14 new (255 total). **Mutation-tested against a faithful revert** of the original code — module-level singleton plus the old `close()` — which fails 5 of 14, including the headline "closing a validation probe does not poison the real client." My first mutation attempt only reverted the declaration and left the new `close()`, which didn't reproduce the bug; worth noting because a partial revert made the test look weaker than it is.

## Still needs live QA

Per #120: test against 2-3 wallet providers (Alby Hub, Zeus, one other) in three states — healthy, relay down, and relay-up-but-wallet-offline — to confirm the messages land correctly and the probe doesn't interfere with normal operation.

🍷 Decanted with [Claude Code](https://claude.com/claude-code)
