### PR TITLE
security: clear copied secrets from the clipboard after 60s

### DIFF
--- a/sidepanel.js
+++ b/sidepanel.js
@@ -354,6 +354,49 @@
     true
   );
 
+  // ---- timed clipboard clear for copied secrets ----
+  // The reveal UI auto-hides a secret after 30s, but a COPY of it outlives the
+  // modal: OS clipboard history and cross-device clipboard sync (Windows
+  // clipboard history, Universal Clipboard) can hold an nsec or wallet
+  // connection string indefinitely. So a secret copy schedules a clear of the
+  // clipboard CLIPBOARD_CLEAR_S later. Best-effort on two counts: reading the
+  // clipboard first (to avoid wiping something the user copied elsewhere in
+  // the meantime) needs the clipboardRead permission, which Sidecar
+  // deliberately doesn't request — so when the read fails the clear happens
+  // blind. That blind clear is why every OTHER copy the panel makes goes
+  // through copyPlain(), which cancels a pending clear: the public value has
+  // replaced the secret on the clipboard, so there is nothing left to protect
+  // and the timer would only destroy the user's copy. And writing needs a
+  // focused document, so the clear can no-op if the panel has lost focus or
+  // closed — same "reduce the window, don't promise to close it" stance as
+  // wipe() in the keystore. The copy toast announces the countdown so a
+  // clipboard entry vanishing a minute later is expected, not spooky.
+  const CLIPBOARD_CLEAR_S = 60;
+  let clipClearTimer = null;
+  function cancelClipboardClear() {
+    if (clipClearTimer) { clearTimeout(clipClearTimer); clipClearTimer = null; }
+  }
+  async function copyPlain(text) {
+    cancelClipboardClear();
+    await navigator.clipboard.writeText(text);
+  }
+  async function copySecret(secret) {
+    await navigator.clipboard.writeText(secret);
+    cancelClipboardClear();
+    clipClearTimer = setTimeout(async () => {
+      clipClearTimer = null;
+      try {
+        // If the clipboard is readable and no longer holds the secret, leave it.
+        if ((await navigator.clipboard.readText()) !== secret) return;
+      } catch (_) { /* no clipboardRead — proceed with the blind clear */ }
+      try { await navigator.clipboard.writeText(''); } catch (_) { /* unfocused/closed */ }
+    }, CLIPBOARD_CLEAR_S * 1000);
+  }
+  // A manual selection-copy (Ctrl+C) inside the panel also replaces the
+  // clipboard; writeText() never fires this event, so a secret copy can't
+  // cancel its own timer.
+  document.addEventListener('copy', cancelClipboardClear, true);
+
   let state = null;
   let hideBalances = false;
   let pinBalanceBar = false;
@@ -2951,7 +2994,7 @@
       catch (e) { if (e && e.name === 'AbortError') return; } // dismissed → done; else fall through to copy
     }
     try {
-      await navigator.clipboard.writeText(message);
+      await copyPlain(message);
       toast('Message copied — share it with a friend', 'success');
     } catch (_) {
       toast('Could not share', 'error');
@@ -3183,7 +3226,7 @@
       };
       const list = h('div', { className: 'menu-list' }, [
         menuItem('Copy npub', 'copy', () => {
-          navigator.clipboard.writeText(a.npub);
+          copyPlain(a.npub);
           toast('npub copied', 'success');
           closeModal();
         }),
@@ -3327,8 +3370,8 @@
     const copy = h('button', { className: 'secondary', textContent: 'Copy ' + noun });
     copy.addEventListener('click', async () => {
       try {
-        await navigator.clipboard.writeText(secret);
-        toast(noun + ' copied', 'success');
+        await copySecret(secret);
+        toast(noun + ' copied — clipboard clears in ' + CLIPBOARD_CLEAR_S + 's', 'success');
       } catch (_) {}
     });
 
@@ -4539,7 +4582,7 @@
     el.append(icon('copy'), h('span', { textContent: shortNpub(npub) }));
     el.addEventListener('click', async () => {
       try {
-        await navigator.clipboard.writeText(npub);
+        await copyPlain(npub);
         const span = el.querySelector('span');
         const prev = span.textContent;
         span.textContent = 'Copied ✓';
@@ -8504,7 +8547,7 @@
       ]);
       addr.addEventListener('click', async () => {
         try {
-          await navigator.clipboard.writeText(lud16);
+          await copyPlain(lud16);
           const s = addr.querySelector('span');
           const prev = s.textContent;
           s.textContent = 'Copied ✓';
@@ -8734,7 +8777,7 @@
       val.addEventListener('click', async (e) => {
         e.stopPropagation();
         try {
-          await navigator.clipboard.writeText(String(copyValue));
+          await copyPlain(String(copyValue));
           const old = val.textContent;
           val.textContent = 'Copied';
           val.classList.add('copied');
@@ -9303,7 +9346,7 @@
         copy.append(addrText);
         copy.addEventListener('click', async () => {
           try {
-            await navigator.clipboard.writeText(lud16);
+            await copyPlain(lud16);
             addrText.textContent = 'Copied ✓';
             setTimeout(() => (addrText.textContent = lud16), 1200);
           } catch (_) {}
@@ -9362,7 +9405,7 @@
     const copy = h('button', { className: 'secondary recv-copy', textContent: 'Copy invoice' });
     copy.addEventListener('click', async () => {
       try {
-        await navigator.clipboard.writeText(invoice);
+        await copyPlain(invoice);
         copy.textContent = 'Copied ✓';
         setTimeout(() => (copy.textContent = 'Copy invoice'), 1200);
       } catch (_) {}
@@ -9503,7 +9546,7 @@
       const copy = h('button', { className: 'secondary', textContent: CREATOR_LN });
       copy.addEventListener('click', async () => {
         try {
-          await navigator.clipboard.writeText(CREATOR_LN);
+          await copyPlain(CREATOR_LN);
           copy.textContent = 'Copied ✓';
           setTimeout(() => (copy.textContent = CREATOR_LN), 1200);
         } catch (_) {}
@@ -10649,7 +10692,7 @@
       const copyBtn = h('button', { className: 'secondary', textContent: 'Copy' });
       copyBtn.addEventListener('click', async () => {
         try {
-          await navigator.clipboard.writeText(debugLogText(entries) || '(empty)');
+          await copyPlain(debugLogText(entries) || '(empty)');
           copyBtn.textContent = 'Copied ✓';
           setTimeout(() => (copyBtn.textContent = 'Copy'), 1200);
         } catch (_) {}

--- a/test/clipboard-clear.test.js
+++ b/test/clipboard-clear.test.js
@@ -1,0 +1,146 @@
+'use strict';
+
+// Unit coverage for the timed clipboard clear in sidepanel.js (copySecret /
+// copyPlain / cancelClipboardClear).
+//
+// The exposure this pins shut: the reveal modal auto-hides a secret after 30s,
+// but a COPY of it used to live on the clipboard forever — OS clipboard history
+// and cross-device sync retain it indefinitely. copySecret() schedules a clear;
+// what these tests really guard is the clear's aim. Wiping the secret is the
+// easy part — the dangerous failure is wiping something ELSE: a value the user
+// copied after the secret. So every assertion is one of two claims: the secret
+// is cleared when it's still the thing on the clipboard, and nothing is cleared
+// when it isn't (a later copyPlain, a manual Ctrl+C-style cancel, a readable
+// clipboard holding different content).
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const ROOT = path.join(__dirname, '..');
+const source = fs.readFileSync(path.join(ROOT, 'sidepanel.js'), 'utf8');
+
+function lift(pattern, label) {
+  const m = source.match(pattern);
+  if (!m) throw new Error('Could not find ' + label + ' in sidepanel.js');
+  return m[0];
+}
+
+const SECRET = 'nsec1testsecretvalue000000000000000000000000';
+
+// Builds a context with a scripted clipboard and hand-cranked timers, so the
+// scheduling is exercised without a DOM or real time.
+//   readText: undefined → readText rejects (the no-clipboardRead reality);
+//             a function → resolves with its return value.
+function harness({ readText } = {}) {
+  const writes = [];
+  const timers = new Map();
+  let nextTimerId = 1;
+  const ctx = {
+    console,
+    navigator: {
+      clipboard: {
+        writeText: async (text) => { writes.push(text); },
+        readText: async () => {
+          if (!readText) throw new Error('clipboardRead not granted');
+          return readText();
+        },
+      },
+    },
+    setTimeout: (fn, ms) => {
+      const id = nextTimerId++;
+      timers.set(id, { fn, ms });
+      return id;
+    },
+    clearTimeout: (id) => { timers.delete(id); },
+  };
+  vm.createContext(ctx);
+  vm.runInContext(
+    lift(/const CLIPBOARD_CLEAR_S = \d+;/, 'CLIPBOARD_CLEAR_S') + '\n' +
+    lift(/let clipClearTimer = null;/, 'clipClearTimer') + '\n' +
+    lift(/function cancelClipboardClear\(\)[\s\S]*?\n  \}/, 'cancelClipboardClear') + '\n' +
+    lift(/async function copyPlain\([\s\S]*?\n  \}/, 'copyPlain') + '\n' +
+    lift(/async function copySecret\([\s\S]*?\n  \}/, 'copySecret') + '\n' +
+    'globalThis.copyPlain = copyPlain;' +
+    'globalThis.copySecret = copySecret;' +
+    'globalThis.cancelClipboardClear = cancelClipboardClear;' +
+    'globalThis.CLIPBOARD_CLEAR_S = CLIPBOARD_CLEAR_S;',
+    ctx
+  );
+  // Run every armed timer callback (insertion order) and settle its promise.
+  async function fireTimers() {
+    const due = [...timers.values()];
+    timers.clear();
+    for (const t of due) await t.fn();
+  }
+  return { ctx, writes, timers, fireTimers };
+}
+
+// ---- the clear fires when the secret is still on the clipboard -----------------
+
+test('copySecret writes the secret and schedules one clear at the announced delay', async () => {
+  const { ctx, writes, timers } = harness();
+  await ctx.copySecret(SECRET);
+  assert.deepEqual(writes, [SECRET]);
+  assert.equal(timers.size, 1);
+  assert.equal([...timers.values()][0].ms, ctx.CLIPBOARD_CLEAR_S * 1000);
+});
+
+test('unreadable clipboard (no clipboardRead) → the clear happens blind', async () => {
+  const { ctx, writes, fireTimers } = harness();
+  await ctx.copySecret(SECRET);
+  await fireTimers();
+  assert.deepEqual(writes, [SECRET, '']);
+});
+
+test('readable clipboard still holding the secret → cleared', async () => {
+  const { ctx, writes, fireTimers } = harness({ readText: () => SECRET });
+  await ctx.copySecret(SECRET);
+  await fireTimers();
+  assert.deepEqual(writes, [SECRET, '']);
+});
+
+test('a failed clear write (panel unfocused/closed) is swallowed', async () => {
+  const { ctx, fireTimers } = harness();
+  await ctx.copySecret(SECRET);
+  ctx.navigator.clipboard.writeText = async () => { throw new Error('Document is not focused'); };
+  await fireTimers(); // must not reject
+});
+
+// ---- nothing is cleared when the secret is no longer the thing there -----------
+
+test('readable clipboard holding something else → left alone', async () => {
+  const { ctx, writes, fireTimers } = harness({ readText: () => 'lnbc1invoicecopiedelsewhere' });
+  await ctx.copySecret(SECRET);
+  await fireTimers();
+  assert.deepEqual(writes, [SECRET]); // no '' write
+});
+
+test('a later copyPlain cancels the pending clear (the public value replaced the secret)', async () => {
+  const { ctx, writes, timers, fireTimers } = harness();
+  await ctx.copySecret(SECRET);
+  await ctx.copyPlain('npub1publicvalue');
+  assert.equal(timers.size, 0);
+  await fireTimers();
+  assert.deepEqual(writes, [SECRET, 'npub1publicvalue']);
+});
+
+test('cancelClipboardClear (the manual-copy listener) disarms the timer', async () => {
+  const { ctx, writes, timers, fireTimers } = harness();
+  await ctx.copySecret(SECRET);
+  ctx.cancelClipboardClear();
+  assert.equal(timers.size, 0);
+  await fireTimers();
+  assert.deepEqual(writes, [SECRET]);
+});
+
+test('a second copySecret replaces the first timer — one pending clear, for the new secret', async () => {
+  const { ctx, writes, timers, fireTimers } = harness();
+  await ctx.copySecret(SECRET);
+  await ctx.copySecret('nsec1secondsecret0000000000000000000000000');
+  assert.equal(timers.size, 1);
+  await fireTimers(); // blind clear — aimed at the latest copy
+  assert.deepEqual(writes, [SECRET, 'nsec1secondsecret0000000000000000000000000', '']);
+});


### PR DESCRIPTION
## Context: repo-wide secrets-handling review

This PR is the outcome of a security review of the repo focused on leak paths for private keys, wallet connection strings, and the PIN. The review covered the crypto/keystore layer, the page ↔ content-script ↔ service-worker boundaries, reveal/export/backup flows, logging, storage, CI, packaging, and the full git history.

### What the review verified is sound

- **No committed secrets.** All commits' added files are clean; `*.pem`/`*.zip`/`*.crx`/`dist/` are gitignored; test fixtures use obvious dummy values; CI uses no repository secrets.
- **Keys at rest.** nsecs and NWC strings are AES-GCM encrypted under a PBKDF2-derived key (600k iterations, per-store salt, fresh IV per encryption) in `chrome.storage.local` — never plaintext on disk. No `localStorage`/`sessionStorage` anywhere.
- **Trust boundary.** The message router hard-requires an extension-page sender for everything outside a small content-script allowlist, so a content-script bug can't pivot into key reveal, unlock, decryption, or prompt settlement. The permission `host` is taken from `location` in the content script, never from the page. Secrets never transit `postMessage` toward the page.
- **Reveal flows.** nsec/NWC reveals always require a PIN step-up that shares the unlock throttle/self-wipe accounting (no brute-force oracle); revealed text and QRs auto-hide on a countdown.
- **Backups.** Vault export is encrypted client-side with a fresh user-chosen password before download; relay backups (profile/follows/NWC) are NIP-44 encrypted to the user's own key before publishing.
- **Logging.** The debug log is dev-build-only and records only type/method/host/timing/error; no `console.*` call logs key material. Prompt-queue data mirrored to `storage.session` is sanitized to metadata.
- **PIN hygiene.** All PIN/password inputs are `type="password"` with autocomplete disabled; the PIN is never persisted.
- **External calls.** The Rizful code exchange POSTs over HTTPS with `credentials: 'omit'` and validates the response; NWC traffic is encrypted to the wallet's pubkey; nothing sensitive rides in URL query strings.

### Findings noted, no change needed

1. `SIDECAR_GET_NWC` returns the decrypted connection string without PIN step-up while unlocked. Extension-page-gated and needed by the panel (backup-state comparison, NWC client) — not a vulnerability, but it means the PIN on "Export connection" is a UX control, not a security boundary.
2. The derived AES key is exported (extractable) into `chrome.storage.session` to survive service-worker eviction. Memory-only, cleared on browser exit, and at the default `TRUSTED_CONTEXTS` access level — a documented, reasonable tradeoff. Future changes should avoid calling `setAccessLevel` or moving this to `storage.local`.
3. The nsec paste guard matches `nsec1…` only, not 64-hex private keys — likely deliberate (hex pubkeys/event ids would false-positive).
4. Large follow-list backups fall back to NIP-04 (still encrypted to self, recorded in a tag) — acceptable and documented.
5. In-memory wiping is best-effort: `wipe()` zeroes byte arrays, but secrets held as JS strings can't be zeroed — inherent to JavaScript.

### The improvement made (this PR)

The one actionable gap: the reveal UI auto-hides a secret after 30s, but a **copy** of it stayed on the clipboard indefinitely — where Windows clipboard history, macOS/iCloud Universal Clipboard, and clipboard managers can retain and sync it.

- Every secret copy (nsec, ncryptsec, NWC connection string — all via `renderSecretReveal`) now goes through `copySecret()`, which schedules a best-effort clipboard clear 60 seconds later. The copy toast announces the countdown.
- At clear time the clipboard is checked first where readable; since Sidecar deliberately does not request `clipboardRead`, the clear is usually blind — so every **other** panel copy (npub, lightning address, invoice, tx details, share text, debug log) routes through `copyPlain()`, which cancels a pending clear rather than letting it wipe the public value that replaced the secret. A manual selection-copy inside the panel cancels via the `copy` event.
- The clear is best-effort by design: writing needs a focused document, so it can no-op if the panel loses focus or closes — same "reduce the window, don't promise to close it" stance as `wipe()` in the keystore. No new manifest permissions.

### Tests

`test/clipboard-clear.test.js` (8 tests, in the repo's lift-and-run style): the clear fires at the announced delay, blind when the clipboard is unreadable, and conditionally when readable; nothing is cleared after a later `copyPlain`, a manual cancel, or when the clipboard holds different content; a second secret copy replaces the first timer; a failed clear write is swallowed.

Full suite: **249 pass, 0 fail** (the two suites requiring the npm `nostr-tools` package need it installed locally; unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)