### PR TITLE
fix: retry a signing request the sleeping service worker never received

### DIFF
--- a/content.js
+++ b/content.js
@@ -59,27 +59,82 @@
       180000
     );
 
-    try {
-      chrome.runtime.sendMessage(
-        { type, scope: d.scope, method: d.method, params: d.params, host },
-        function (response) {
-          let err;
-          try { err = chrome.runtime.lastError; } catch (_) {
-            return reply({ ok: false, error: 'Sidecar was updated — reload this page to reconnect.' });
+    // MV3 evicts the service worker after ~30s idle. If that happens between the
+    // page's call and our response, the request is lost: the page waits out its own
+    // timeout and reports a failure for something Sidecar never even asked about.
+    // Reported as "had to reload the extension to get Jumble to send the draft".
+    //
+    // Chrome distinguishes the two failure shapes through lastError.message, and only
+    // ONE of them is safe to retry:
+    //
+    //   "Could not establish connection. Receiving end does not exist."
+    //       The worker wasn't running and couldn't be woken; the message was NEVER
+    //       delivered. Nothing was prompted, nothing signed. Retrying is safe.
+    //
+    //   "The message port closed before a response was received."
+    //       The listener DID get it — the channel died before sendResponse. The user
+    //       may already have approved, and the signature may exist. Retrying could
+    //       prompt a second time and produce a SECOND signed event, which for a note
+    //       means a duplicate post and for a payment means paying twice. Never retry.
+    //
+    // So the retry is deliberately narrow. Sending the same event twice is worse than
+    // one clear failure, and the background has no request-level dedupe to fall back on.
+    const RETRYABLE = /receiving end does not exist|could not establish connection/i;
+    let attempted = 0;
+
+    function dispatch() {
+      attempted++;
+      try {
+        chrome.runtime.sendMessage(
+          { type, scope: d.scope, method: d.method, params: d.params, host },
+          function (response) {
+            let err;
+            try { err = chrome.runtime.lastError; } catch (_) {
+              return reply({ ok: false, error: 'Sidecar was updated — reload this page to reconnect.' });
+            }
+            // Undelivered, and we haven't retried yet: wake the worker and try once
+            // more. A short delay gives Chrome time to actually start it — an
+            // immediate re-send usually races the same cold start and fails again.
+            if (err && attempted === 1 && RETRYABLE.test(err.message || '')) {
+              setTimeout(dispatch, 150);
+              return;
+            }
+            // A successful nostr call means the page is signed in — unlock the pay
+            // card and re-scan in case an invoice is already on screen.
+            if (!err && d.scope === 'nostr' && response && response.ok && !connectedToSite) {
+              connectedToSite = true;
+              scheduleScan();
+            }
+            reply(err ? { ok: false, error: friendlyError(err.message) } : response);
           }
-          // A successful nostr call means the page is signed in — unlock the pay
-          // card and re-scan in case an invoice is already on screen.
-          if (!err && d.scope === 'nostr' && response && response.ok && !connectedToSite) {
-            connectedToSite = true;
-            scheduleScan();
-          }
-          reply(err ? { ok: false, error: err.message } : response);
-        }
-      );
-    } catch (e) {
-      reply({ ok: false, error: 'Sidecar was updated — reload this page to reconnect.' });
+        );
+      } catch (e) {
+        reply({ ok: false, error: 'Sidecar was updated — reload this page to reconnect.' });
+      }
     }
+    dispatch();
   });
+
+  // Turn Chrome's internal messaging errors into something a user can act on. The raw
+  // strings name Chrome's plumbing ("the message port closed before a response was
+  // received"), which reads as a Sidecar crash rather than the recoverable hiccup it is.
+  function friendlyError(msg) {
+    const m = String(msg || '');
+    if (/message port closed/i.test(m)) {
+      // The request reached Sidecar but the answer didn't come back. Deliberately does
+      // NOT say "try again" without qualification: if the user already approved, the
+      // event may have been signed and re-sending would duplicate it.
+      return 'Sidecar lost the connection while handling this. Check whether it went through before retrying.';
+    }
+    if (/receiving end does not exist|could not establish connection/i.test(m)) {
+      // Survived a retry, so Sidecar genuinely isn't reachable.
+      return "Sidecar didn't respond. Make sure it's enabled, then try again.";
+    }
+    if (/context invalidated/i.test(m)) {
+      return 'Sidecar was updated — reload this page to reconnect.';
+    }
+    return m || 'Sidecar request failed.';
+  }
 
   // ===== "Pay with Sidecar" confirmation card =====
   // When the page shows a Lightning invoice (a lightning: link, an input/QR value,

--- a/test/sw-death-retry.test.js
+++ b/test/sw-death-retry.test.js
@@ -1,0 +1,137 @@
+'use strict';
+
+// Unit coverage for the content script's retry when the MV3 service worker was
+// asleep and the message never landed.
+//
+// THE REPORT (2026-08-09): posting from Jumble failed, and reloading the whole
+// extension was the only way to get the failed draft to send.
+//
+// Sidecar does not publish notes for a client — Jumble signs via window.nostr and
+// publishes itself, and background.js has no relay pool at all. So the failure was
+// in the SIGNING hop: the worker is evicted after ~30s idle, the message goes
+// nowhere, Jumble waits out its own 30s timeout (signer-approval.ts) and reports
+// "Failed to post". Reloading the extension gave a fresh worker, so the retry landed.
+//
+// The fix retries ONCE, and only for the failure that proves nothing was delivered.
+// The distinction matters more than the retry: re-sending a request the background
+// already processed would prompt a second time and produce a SECOND signature —
+// a duplicate note, or a payment made twice.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.join(__dirname, '..');
+const source = fs.readFileSync(path.join(ROOT, 'content.js'), 'utf8');
+
+// The retry predicate, lifted verbatim so the test exercises the shipped regex.
+const RETRYABLE = (() => {
+  const m = source.match(/const RETRYABLE = (\/.*?\/i);/);
+  if (!m) throw new Error('RETRYABLE not found in content.js');
+  // eslint-disable-next-line no-eval
+  return eval(m[1]);
+})();
+
+// ---- which failures may be retried ----------------------------------------------
+
+test('an undelivered message IS retryable', () => {
+  // Chrome's wording when the worker was not running and could not be woken. Nothing
+  // reached the background: no prompt, no signature.
+  for (const msg of [
+    'Could not establish connection. Receiving end does not exist.',
+    'Receiving end does not exist.',
+  ]) {
+    assert.equal(RETRYABLE.test(msg), true, msg);
+  }
+});
+
+test('a closed message port is NOT retryable — the dangerous case', () => {
+  // The listener DID receive it; only the response was lost. The user may already
+  // have approved, so the event may be signed. Retrying would sign it twice: a
+  // duplicate note, or a double payment.
+  assert.equal(
+    RETRYABLE.test('The message port closed before a response was received.'),
+    false,
+    'retrying this could produce a second signature'
+  );
+});
+
+test('an invalidated extension context is NOT retryable', () => {
+  // The extension was reloaded under the content script. The page has to reload;
+  // retrying into a dead context accomplishes nothing.
+  assert.equal(RETRYABLE.test('Extension context invalidated.'), false);
+});
+
+test('an unknown error is NOT retryable', () => {
+  // Default closed. An error we do not recognise might mean the request was
+  // processed, and the cost of guessing wrong is a duplicate signature.
+  for (const msg of ['', 'Some unexpected failure', 'Native host has exited.']) {
+    assert.equal(RETRYABLE.test(msg), false, JSON.stringify(msg));
+  }
+});
+
+// ---- the retry is bounded --------------------------------------------------------
+
+test('it retries at most once', () => {
+  // A worker that cannot start would otherwise be re-sent forever, and each attempt
+  // could eventually wake it and prompt.
+  assert.match(source, /if \(err && attempted === 1 && RETRYABLE\.test/,
+    'the guard must pin the attempt number, not just the error');
+});
+
+test('the retry is delayed, not immediate', () => {
+  // An immediate re-send races the same cold start and usually fails identically.
+  assert.match(source, /setTimeout\(dispatch, \d+\)/);
+  const delay = Number(source.match(/setTimeout\(dispatch, (\d+)\)/)[1]);
+  assert.ok(delay >= 100 && delay <= 1000,
+    `${delay}ms — too short to let Chrome start the worker, or long enough to be felt`);
+});
+
+test('the page is still answered exactly once', () => {
+  // reply() guards on `replied`, which is what stops a retry from settling the page's
+  // promise twice. Losing that would surface as a duplicate response to window.nostr.
+  assert.match(source, /function reply\(response\) \{\s*\n\s*if \(replied\) return;/);
+});
+
+// ---- the messages a user actually sees -------------------------------------------
+
+test('a lost-response error does not tell the user to just try again', () => {
+  // The one case where blind retrying is unsafe. The copy has to leave room for
+  // "it may already have worked" rather than implying nothing happened.
+  const fn = source.match(/function friendlyError\(msg\) \{[\s\S]*?\n  \}/)[0];
+  const m = fn.match(/message port closed[\s\S]*?return '([^']*)'/);
+  assert.ok(m, 'no message for the port-closed case');
+  assert.match(m[1], /went through/i, 'must hint the action may have completed');
+});
+
+test('raw Chrome plumbing never reaches the user', () => {
+  const fn = source.match(/function friendlyError\(msg\) \{[\s\S]*?\n  \}/)[0];
+  for (const phrase of ['message port closed', 'Receiving end does not exist']) {
+    // The phrases appear as regex TESTS, but must not be what gets returned.
+    const returned = [...fn.matchAll(/return '([^']*)'/g)].map((x) => x[1]);
+    assert.ok(!returned.some((r) => r.includes(phrase)),
+      `"${phrase}" is Chrome's internal wording, not a user message`);
+  }
+});
+
+test('every branch returns something non-empty', () => {
+  const fn = source.match(/function friendlyError\(msg\) \{[\s\S]*?\n  \}/)[0];
+  const returns = [...fn.matchAll(/return ([^;]+);/g)].map((m) => m[1].trim());
+  assert.ok(returns.length >= 4, 'expected a branch per known error plus a fallback');
+  // The fallback must not be able to produce an empty toast.
+  assert.match(fn, /return m \|\| '[^']+'/, 'the fallback needs a default string');
+});
+
+// ---- the timeout was deliberately left alone ------------------------------------
+
+test('the 180s page timeout is unchanged', () => {
+  // Tempting to shorten this to match Jumble's 30s, but the window exists so a user
+  // can READ an approval prompt and decide. background.js's REQUEST_TTL (175s) is set
+  // just under it on purpose. Shortening it would abandon prompts mid-decision —
+  // trading a rare lost request for a common one.
+  assert.match(source, /180000/, 'the read-and-decide window must stay');
+  const bg = fs.readFileSync(path.join(ROOT, 'background.js'), 'utf8');
+  const ttl = Number(bg.match(/const REQUEST_TTL = (\d+);/)[1]);
+  assert.ok(ttl < 180000, `REQUEST_TTL ${ttl} must stay under the content-script timeout`);
+});


### PR DESCRIPTION
Reported: posting from Jumble failed, and reloading the whole extension was the only way to get the failed draft to send.

## This was never the relay bug

Sidecar doesn't publish notes for a client. Jumble signs via `window.nostr` and publishes itself — and `background.js` has no relay pool at all. So `publishToRelays` (and #166) isn't in this code path. The earlier eight-relay error came from the *Sidecar composer*, a different flow entirely.

The failure was the **signing hop**:

```
Jumble -> window.nostr.signEvent -> content.js -> sendMessage -> background.js
                                                     |
                              SW evicted at ~30s idle; message goes nowhere
                                                     |
                     Jumble's own 30s timeout fires -> "Failed to post"
```

`content.js` sent once and never retried, so a request lost to a sleeping worker was gone. Reloading the extension gave a fresh worker, which is why that worked.

## The retry is deliberately narrow

Chrome distinguishes two failure shapes via `lastError.message`, and only one is safe:

| message | meaning | retry? |
|---|---|---|
| `Receiving end does not exist` | worker wasn't running, message **never delivered** — nothing prompted, nothing signed | **yes** |
| `The message port closed before a response was received` | listener **did** get it; only the response was lost. May already be approved and signed | **no** |
| `Extension context invalidated` | extension reloaded under the page; must reload | no |
| anything else | unknown | no |

Retrying the second case would prompt again and produce a **second signature** — a duplicate note, or a payment made twice. The background has no request-level dedupe to fall back on, so unknown errors default to not-retryable too.

Bounded to one attempt, delayed 150ms: an immediate re-send races the same cold start and fails identically.

## Error copy

Chrome's raw text reads as a Sidecar crash. The port-closed case now says to check whether it went through, rather than implying nothing happened — the one case where "just try again" is actively bad advice.

## What I deliberately did NOT change

The 180-second page timeout, and there's a test pinning it. Shortening it to match Jumble's 30s is tempting, but that window exists so a user can *read* an approval prompt and decide, and `background.js`'s `REQUEST_TTL` (175s) is set just under it on purpose. Cutting it would abandon prompts mid-decision — trading a rare lost request for a common one. Jumble's 30s is its own choice, in its `signer-approval.ts`.

## Tests

11 new (295 total). Mutation-tested the safety boundary specifically: widening the retry to cover port-closed, dropping the attempt cap, and retrying without a delay each fail.

🍸 Stirred with [Claude Code](https://claude.com/claude-code)
