### PR TITLE
feat: a way out when the signer names the wrong account, and four theme-contrast fixes

### DIFF
--- a/background.js
+++ b/background.js
@@ -1086,6 +1086,24 @@ async function handleNostrRpc(method, params, host, sendResponse, originWindowId
         // what's about to be lost, and "trust this site to stop asking" is the last
         // advice it should be carrying.
         nudgeTrust: !destructive && (await shouldNudgeTrust(host, activePubkey)),
+        // The "wrong account" escape: offer the account list on any content sign where
+        // the user holds more than one account and no switcher is already on screen.
+        //
+        // Deliberately NOT gated on detecting that the account is "pinned" (a binding,
+        // or a client-stamped author). The first cut tried that and it was wrong twice
+        // over. Pin detection can only ever REMOVE a working way out, and it misses the
+        // case that matters most: a client showing account A while Sidecar's active
+        // account is B, with nothing pinned and nothing stamped. Sidecar cannot see the
+        // client's UI, so it cannot detect that at all — only the user can, and this is
+        // the control they need in order to say so.
+        //
+        // The cost of being generous is one muted collapsed line on prompts that did not
+        // need it. The cost of being clever was no route out at all.
+        //
+        // isContentSign already excludes relay auth (see its definition), so there is no
+        // separate !isRelayAuth term. sharedIdentity means the real switcher is already
+        // showing, and two account pickers on one signing screen is worse than none.
+        wrongAccountEscape: isContentSign && !sharedIdentity && st.accounts.length > 1,
         // The popup window loads every theme stylesheet but has no settings access of
         // its own, so without this it renders whatever the default is — Speakeasy
         // purple over someone's Brownstone panel. Carried on the payload rather than

--- a/background.js
+++ b/background.js
@@ -1060,18 +1060,31 @@ async function handleNostrRpc(method, params, host, sendResponse, originWindowId
               picture: a.picture || '',
             }))
         : null;
-      // Accounts offerable in the "wrong account" escape. Excludes the account the
-      // prompt is already showing (activePubkey — the resolved signer), since detaching
-      // to re-pick the same identity is a no-op with extra steps. NOT `otherAccounts`:
-      // that list is scoped to accounts authorized on this host, and the whole point
-      // here is that the one the user wants isn't in that set yet.
+      // Accounts offerable in the "wrong account" escape: exactly the ones the switcher
+      // above CANNOT offer. Two exclusions, for two different reasons.
+      //
+      // The resolved signer (activePubkey) — detaching to re-pick the identity already on
+      // screen is a no-op with extra steps.
+      //
+      // Anything already in `otherAccounts` — that's the switcher's own list, and those
+      // accounts can be picked up there without cancelling anything. Subtracting it keeps
+      // the two lists disjoint, so the prompt never shows the same account twice under two
+      // different actions. Derived from `otherAccounts` itself rather than re-deriving the
+      // condition, so the two stay complementary if that filter ever changes.
+      //
+      // This is what closes the gap that shipped first: on a SHARED host the switcher is
+      // scoped to accounts already authorized here (never silently introduce a new identity
+      // to a site), and the escape used to be suppressed on shared hosts because "the real
+      // switcher is already showing". Both guards are individually right, and together they
+      // left a user with three accounts and two signed in unable to reach the third at all.
       //
       // The GLOBALLY active account sorts first. On a host pinned to someone else it's
       // both the likeliest pick and the one the user already chose in Sidecar, so it
       // shouldn't be buried in an eight-row list.
       const globalActivePubkey = await KS.getActivePubkey();
+      const offeredInSwitcher = new Set((otherAccounts || []).map((a) => a.pubkey));
       const escapeAccounts = st.accounts
-        .filter((a) => a.pubkey !== activePubkey)
+        .filter((a) => a.pubkey !== activePubkey && !offeredInSwitcher.has(a.pubkey))
         .map((a) => ({
           pubkey: a.pubkey,
           npub: self.NostrTools.nip19.npubEncode(a.pubkey),
@@ -1124,7 +1137,11 @@ async function handleNostrRpc(method, params, host, sendResponse, originWindowId
         // isContentSign already excludes relay auth (see its definition), so there is no
         // separate !isRelayAuth term. sharedIdentity means the real switcher is already
         // showing, and two account pickers on one signing screen is worse than none.
-        wrongAccountEscape: isContentSign && !sharedIdentity && st.accounts.length > 1,
+        // No !sharedIdentity term and no account-count term: both are now implied by
+        // escapeAccounts being non-empty. When the switcher already covers every other
+        // account the subtraction empties this list on its own, so the escape disappears
+        // without needing to reason about shared hosts separately.
+        wrongAccountEscape: isContentSign && escapeAccounts.length > 0,
         allAccounts: escapeAccounts,
         // The popup window loads every theme stylesheet but has no settings access of
         // its own, so without this it renders whatever the default is — Speakeasy

--- a/background.js
+++ b/background.js
@@ -1060,6 +1060,27 @@ async function handleNostrRpc(method, params, host, sendResponse, originWindowId
               picture: a.picture || '',
             }))
         : null;
+      // Accounts offerable in the "wrong account" escape. Excludes the account the
+      // prompt is already showing (activePubkey — the resolved signer), since detaching
+      // to re-pick the same identity is a no-op with extra steps. NOT `otherAccounts`:
+      // that list is scoped to accounts authorized on this host, and the whole point
+      // here is that the one the user wants isn't in that set yet.
+      //
+      // The GLOBALLY active account sorts first. On a host pinned to someone else it's
+      // both the likeliest pick and the one the user already chose in Sidecar, so it
+      // shouldn't be buried in an eight-row list.
+      const globalActivePubkey = await KS.getActivePubkey();
+      const escapeAccounts = st.accounts
+        .filter((a) => a.pubkey !== activePubkey)
+        .map((a) => ({
+          pubkey: a.pubkey,
+          npub: self.NostrTools.nip19.npubEncode(a.pubkey),
+          name: a.name || '',
+          picture: a.picture || '',
+          active: a.pubkey === globalActivePubkey,
+        }));
+      escapeAccounts.sort((x, y) => (y.active ? 1 : 0) - (x.active ? 1 : 0));
+
       // For encrypt/decrypt, translate the counterparty's hex pubkey to an npub so
       // the prompt can show a recognizable identity instead of raw hex. Pure offline
       // encoding — no relay lookup. Falls back to the raw hex if it isn't valid.
@@ -1104,6 +1125,7 @@ async function handleNostrRpc(method, params, host, sendResponse, originWindowId
         // separate !isRelayAuth term. sharedIdentity means the real switcher is already
         // showing, and two account pickers on one signing screen is worse than none.
         wrongAccountEscape: isContentSign && !sharedIdentity && st.accounts.length > 1,
+        allAccounts: escapeAccounts,
         // The popup window loads every theme stylesheet but has no settings access of
         // its own, so without this it renders whatever the default is — Speakeasy
         // purple over someone's Brownstone panel. Carried on the payload rather than
@@ -1133,6 +1155,43 @@ async function handleNostrRpc(method, params, host, sendResponse, originWindowId
         if (switchedStatus === 'reject') throw new Error('This site is blocked in Sidecar for that account');
         activePubkey = decision.switchToPubkey;
         await KS.setActive(activePubkey);
+      }
+
+      // "Wrong account" escape: detach this host from the account it's pinned to, make
+      // the chosen account active, and REJECT this signature.
+      //
+      // DETACH (clear the binding), not rebind (write a new one). This is the same
+      // primitive behind Settings -> Sites -> "Use <account>" (switchSiteModal in
+      // sidepanel.js), so both routes leave identical state and there's one behavior to
+      // reason about rather than two. Clearing means the next getPublicKey re-pairs the
+      // host to whatever is active — which is why setActive below is the line that
+      // actually decides who the user comes back as, not the clear.
+      //
+      // Deliberately not "sign this one as them": the event the client built carries the
+      // pubkey the client still has cached, so signing it under another identity yields
+      // one correct event and then silent reverts on the next. Rejecting means the client
+      // re-asks after the user reconnects, at which point getPublicKey runs and both
+      // sides agree on the identity for real.
+      if (decision.action === 'detach') {
+        const target = decision.detachPubkey;
+        if (!target || !(await KS.hasAccount(target))) {
+          throw new Error('That account is no longer available');
+        }
+        if ((await PERMS.getPermissionStatus(target, host, method)) === 'reject') {
+          throw new Error('This site is blocked in Sidecar for that account');
+        }
+        await clearSiteAccount(host);
+        await KS.setActive(target);
+        // The relax window was earned by the identity we're leaving. Left standing it
+        // would auto-approve the next request for the one arriving — a grant the user
+        // never gave to that account.
+        await RELAX.revokeForHost(host);
+        syncRelaxBadge();
+        const tgt = st.accounts.find((a) => a.pubkey === target);
+        throw new Error(
+          'Detached ' + host + '. Sign out and back in as ' + ((tgt && tgt.name) || 'that account') +
+          ' — the site is still using the old identity.'
+        );
       }
 
       if (decision.action === 'block') {

--- a/prompt.html
+++ b/prompt.html
@@ -263,13 +263,23 @@
       text-align: center; margin: -8px 0 14px;
     }
     .wrong-acct strong { display: block; color: var(--text); font-weight: 600; }
-    /* Reads as a link, not a button — see .approval-wrong-acct-cancel in styles.css for
+    /* Reads as a link, not a button — see .approval-wrong-acct-toggle in styles.css for
        why this is --muted rather than the --lav accent. */
-    .wrong-acct-cancel {
+    .wrong-acct-toggle {
       background: none; border: none; padding: 2px 4px; cursor: pointer;
       font: inherit; color: var(--muted); text-decoration: underline;
     }
-    .wrong-acct-cancel:hover { color: var(--text); }
+    .wrong-acct-toggle:hover { color: var(--text); }
+    .wrong-acct-list {
+      text-align: left; margin: 8px 0 0; padding: 6px;
+      background: linear-gradient(180deg, var(--velvet-1), var(--velvet-2));
+      border: 1px solid var(--border-strong); border-radius: 14px; box-shadow: var(--sheen);
+    }
+    .wrong-acct-lede { margin: 2px 6px 8px; font-size: 12px; line-height: 1.45; color: var(--muted); }
+    .wrong-acct-tag {
+      margin-left: auto; font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase;
+      color: var(--muted); white-space: nowrap;
+    }
     .switch-row {
       display: flex; align-items: center; gap: 10px; width: 100%; text-align: left;
       background: transparent; border: none; cursor: pointer; color: var(--text);
@@ -374,7 +384,8 @@
          hidden. Copy must stay in step with the panel's. -->
     <div class="wrong-acct hidden" id="wrong-acct">
       <strong>Not the right account?</strong>
-      <button class="wrong-acct-cancel" id="wrong-acct-cancel">Cancel and login with another identity.</button>
+      <button class="wrong-acct-toggle" id="wrong-acct-toggle" aria-expanded="false">Detach and use another identity.</button>
+      <div class="wrong-acct-list hidden" id="wrong-acct-list"></div>
     </div>
 
     <div id="preview" class="card hidden"></div>

--- a/prompt.html
+++ b/prompt.html
@@ -379,9 +379,9 @@
     <div class="account" id="account"></div>
     <button class="switch-toggle hidden" id="switch-toggle">Sign in with a different account</button>
     <div class="switch-menu hidden" id="switch-menu"></div>
-    <!-- "Wrong account?" hint — mirrors #approval-wrong-acct in sidepanel.html. Shown
-         on a content sign when the user holds 2+ accounts and the switcher above is
-         hidden. Copy must stay in step with the panel's. -->
+    <!-- "Wrong account?" escape — mirrors #approval-wrong-acct in sidepanel.html. Shown
+         on a content sign whenever an account exists that the switcher above can't offer.
+         Copy must stay in step with the panel's. -->
     <div class="wrong-acct hidden" id="wrong-acct">
       <strong>Not the right account?</strong>
       <button class="wrong-acct-toggle" id="wrong-acct-toggle" aria-expanded="false">Detach and use another identity.</button>

--- a/prompt.html
+++ b/prompt.html
@@ -255,6 +255,21 @@
       border: 1px solid var(--border-strong); border-radius: 14px;
       padding: 6px; margin: -6px 0 14px; box-shadow: var(--sheen);
     }
+    /* "Wrong account?" hint — mirrors .approval-wrong-acct in styles.css. Same muted
+       weight as .trust-nudge, which is the other advisory line on this screen; it must
+       not compete with the destructive banner or read as something being wrong. */
+    .wrong-acct {
+      font-size: 12.5px; line-height: 1.45; color: var(--muted);
+      text-align: center; margin: -8px 0 14px;
+    }
+    .wrong-acct strong { display: block; color: var(--text); font-weight: 600; }
+    /* Reads as a link, not a button — see .approval-wrong-acct-cancel in styles.css for
+       why this is --muted rather than the --lav accent. */
+    .wrong-acct-cancel {
+      background: none; border: none; padding: 2px 4px; cursor: pointer;
+      font: inherit; color: var(--muted); text-decoration: underline;
+    }
+    .wrong-acct-cancel:hover { color: var(--text); }
     .switch-row {
       display: flex; align-items: center; gap: 10px; width: 100%; text-align: left;
       background: transparent; border: none; cursor: pointer; color: var(--text);
@@ -354,6 +369,13 @@
     <div class="account" id="account"></div>
     <button class="switch-toggle hidden" id="switch-toggle">Sign in with a different account</button>
     <div class="switch-menu hidden" id="switch-menu"></div>
+    <!-- "Wrong account?" hint — mirrors #approval-wrong-acct in sidepanel.html. Shown
+         on a content sign when the user holds 2+ accounts and the switcher above is
+         hidden. Copy must stay in step with the panel's. -->
+    <div class="wrong-acct hidden" id="wrong-acct">
+      <strong>Not the right account?</strong>
+      <button class="wrong-acct-cancel" id="wrong-acct-cancel">Cancel and login with another identity.</button>
+    </div>
 
     <div id="preview" class="card hidden"></div>
 

--- a/prompt.html
+++ b/prompt.html
@@ -335,9 +335,15 @@
       box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35), 0 8px 22px var(--btn-shadow, rgba(234, 119, 47, 0.28));
     }
     .primary:hover { filter: brightness(1.06); transform: translateY(-1px); }
+    /* Mirrors .lav-btn in styles.css — see there for why the stops and label are
+       variables, and why the ring is an inset shadow rather than a border. */
     .lav-btn {
-      background: linear-gradient(180deg, #cebfff, var(--lav) 58%, var(--purple)); color: #190a33;
-      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 8px 22px rgba(var(--border-rgb), 0.24);
+      background: linear-gradient(180deg, var(--btn-lav-top, #cebfff), var(--btn-lav-mid, var(--lav)) 58%, var(--btn-lav-bot, var(--purple)));
+      color: var(--btn-lav-text, #190a33);
+      box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.4),
+        inset 0 0 0 1px var(--btn-lav-ring, transparent),
+        0 8px 22px var(--btn-lav-shadow, rgba(var(--border-rgb), 0.24));
     }
     .lav-btn:hover { filter: brightness(1.05); transform: translateY(-1px); }
     .secondary {

--- a/prompt.html
+++ b/prompt.html
@@ -346,9 +346,10 @@
         0 8px 22px var(--btn-lav-shadow, rgba(var(--border-rgb), 0.24));
     }
     .lav-btn:hover { filter: brightness(1.05); transform: translateY(-1px); }
+    /* Mirrors .secondary in styles.css — see there for why these are separate hooks. */
     .secondary {
-      background: linear-gradient(180deg, var(--velvet-1), var(--velvet-2));
-      color: var(--text); border: 1px solid var(--border); box-shadow: var(--sheen);
+      background: linear-gradient(180deg, var(--btn-secondary-top, var(--velvet-1)), var(--btn-secondary-bot, var(--velvet-2)));
+      color: var(--btn-secondary-text, var(--text)); border: 1px solid var(--border); box-shadow: var(--sheen);
     }
     .secondary:hover { border-color: var(--gold-soft); }
     .ghost { background: transparent; color: var(--muted); }

--- a/prompt.js
+++ b/prompt.js
@@ -647,8 +647,10 @@
     els.wrongAcctList.innerHTML = '';
     const lede = document.createElement('p');
     lede.className = 'wrong-acct-lede';
-    lede.textContent =
-      'Picks who this site uses next, everywhere in Sidecar. Cancels this request — sign out and back in on ' + (data.host || 'the site') + '.';
+    // Copy asserted identical to the panel's — see buildWrongAcctList in sidepanel.js for
+    // why the reconnect instruction isn't here. This window closes on the decision, so it
+    // has no toast of its own; the client's error is the only channel either way.
+    lede.textContent = 'Cancels this request and makes that account active.';
     els.wrongAcctList.append(lede);
     accts.forEach((a) => {
       const row = document.createElement('button');

--- a/prompt.js
+++ b/prompt.js
@@ -16,6 +16,8 @@
     account: $('account'),
     switchToggle: $('switch-toggle'),
     switchMenu: $('switch-menu'),
+    wrongAcct: $('wrong-acct'),
+    wrongAcctCancel: $('wrong-acct-cancel'),
     unlock: $('unlock'),
     pin: $('pin'),
     error: $('error'),
@@ -383,6 +385,7 @@
     const verb = isPayment ? 'wants to send a Lightning payment' : 'wants to ' + (METHOD_LABELS[data.method] || data.method);
     els.ask.textContent = verb;
     buildAccountCapsule();
+    buildWrongAcct();
     renderPreview();
 
     // Decrypt-burst note: a client loading a DM inbox fires many decrypt requests
@@ -618,6 +621,13 @@
     });
   }
 
+  // "Wrong account?" hint — the popup half of renderWrongAcctEscape in sidepanel.js.
+  // Copy lives in prompt.html; keep it in step with sidepanel.html's.
+  function buildWrongAcct() {
+    if (!els.wrongAcct) return;
+    els.wrongAcct.classList.toggle('hidden', !data.wrongAccountEscape);
+  }
+
   // Disable Allow once + Trust this site while a destructive overwrite is
   // unacknowledged. Reject is never gated — the safe way out must stay reachable.
   function setLocked(locked) {
@@ -690,6 +700,10 @@
   els.allow.addEventListener('click', () => decide('once'));
   els.trust.addEventListener('click', () => decide('trust'));
   els.reject.addEventListener('click', () => decide('reject'));
+  // The "wrong account?" hint's cancel line — same decision as Reject. Bound directly
+  // rather than forwarded to els.reject, which init() swaps for a plain Close button on
+  // an expired request.
+  els.wrongAcctCancel.addEventListener('click', () => decide('reject'));
   els.pin &&
     els.pin.addEventListener('keydown', (e) => {
       // Respect the destructive lock — Enter bypasses the disabled Allow button

--- a/prompt.js
+++ b/prompt.js
@@ -623,7 +623,9 @@
   }
 
   // "Wrong account?" escape — the popup half of renderWrongAcctEscape in sidepanel.js.
-  // Keep the two in step; the lede copy is asserted identical in both by the tests.
+  // Offers the accounts the switcher above can't reach; the two lists are disjoint by
+  // construction in background.js. Keep the two surfaces in step; the lede copy is
+  // asserted identical in both by the tests.
   function buildWrongAcct() {
     if (!els.wrongAcct || !els.wrongAcctToggle || !els.wrongAcctList) return;
     els.wrongAcctList.innerHTML = '';

--- a/prompt.js
+++ b/prompt.js
@@ -17,7 +17,8 @@
     switchToggle: $('switch-toggle'),
     switchMenu: $('switch-menu'),
     wrongAcct: $('wrong-acct'),
-    wrongAcctCancel: $('wrong-acct-cancel'),
+    wrongAcctToggle: $('wrong-acct-toggle'),
+    wrongAcctList: $('wrong-acct-list'),
     unlock: $('unlock'),
     pin: $('pin'),
     error: $('error'),
@@ -621,11 +622,61 @@
     });
   }
 
-  // "Wrong account?" hint — the popup half of renderWrongAcctEscape in sidepanel.js.
-  // Copy lives in prompt.html; keep it in step with sidepanel.html's.
+  // "Wrong account?" escape — the popup half of renderWrongAcctEscape in sidepanel.js.
+  // Keep the two in step; the lede copy is asserted identical in both by the tests.
   function buildWrongAcct() {
-    if (!els.wrongAcct) return;
-    els.wrongAcct.classList.toggle('hidden', !data.wrongAccountEscape);
+    if (!els.wrongAcct || !els.wrongAcctToggle || !els.wrongAcctList) return;
+    els.wrongAcctList.innerHTML = '';
+    els.wrongAcctList.classList.add('hidden');
+    els.wrongAcctToggle.setAttribute('aria-expanded', 'false');
+    const accts = Array.isArray(data.allAccounts) ? data.allAccounts : [];
+    els.wrongAcct.classList.toggle('hidden', !data.wrongAccountEscape || !accts.length);
+    els.wrongAcctToggle.onclick = () => {
+      if (els.wrongAcctList.classList.contains('hidden')) {
+        buildWrongAcctList(accts);
+        els.wrongAcctList.classList.remove('hidden');
+        els.wrongAcctToggle.setAttribute('aria-expanded', 'true');
+      } else {
+        els.wrongAcctList.classList.add('hidden');
+        els.wrongAcctToggle.setAttribute('aria-expanded', 'false');
+      }
+    };
+  }
+
+  function buildWrongAcctList(accts) {
+    els.wrongAcctList.innerHTML = '';
+    const lede = document.createElement('p');
+    lede.className = 'wrong-acct-lede';
+    lede.textContent =
+      'Picks who this site uses next, everywhere in Sidecar. Cancels this request — sign out and back in on ' + (data.host || 'the site') + '.';
+    els.wrongAcctList.append(lede);
+    accts.forEach((a) => {
+      const row = document.createElement('button');
+      row.className = 'switch-row';
+      const av = document.createElement('img');
+      av.className = 'switch-row-av';
+      av.referrerPolicy = 'no-referrer';
+      av.onerror = () => { av.onerror = null; av.src = 'icons/avatar-default.svg'; };
+      av.src = a.picture || 'icons/avatar-default.svg';
+      const info = document.createElement('div');
+      info.className = 'switch-row-info';
+      const name = document.createElement('div');
+      name.className = 'switch-row-name';
+      name.textContent = a.name || shortNpub(a.npub);
+      const np = document.createElement('div');
+      np.className = 'switch-row-npub';
+      np.textContent = shortNpub(a.npub);
+      info.append(name, np);
+      row.append(av, info);
+      if (a.active) {
+        const tag = document.createElement('span');
+        tag.className = 'wrong-acct-tag';
+        tag.textContent = 'Active';
+        row.append(tag);
+      }
+      row.addEventListener('click', () => decide('detach', { detachPubkey: a.pubkey }));
+      els.wrongAcctList.append(row);
+    });
   }
 
   // Disable Allow once + Trust this site while a destructive overwrite is
@@ -640,8 +691,9 @@
   async function decide(action, opts) {
     els.error.textContent = '';
     els.pinError.textContent = '';
-    // Unlock first if needed (Allow once / Trust / Relax / Pay only).
-    if (data.needUnlock && (action === 'once' || action === 'trust' || action === 'relax')) {
+    // Unlock first if needed. 'detach' is included even though it never signs — see
+    // decideApproval in sidepanel.js. Reject stays ungated.
+    if (data.needUnlock && (action === 'once' || action === 'trust' || action === 'relax' || action === 'detach')) {
       const pin = els.pin.value;
       if (!pin) {
         els.pinError.textContent = 'Enter your PIN.';
@@ -680,6 +732,11 @@
     if (data.offerAutoZap > 0 && els.autozapOfferBox.checked) {
       extra = Object.assign({}, extra, { enableAutoZap: true });
     }
+    // "Wrong account" escape: carry the account to make active. The background detaches
+    // and then throws, so this never signs.
+    if (action === 'detach') {
+      extra = Object.assign({}, extra, { detachPubkey: (opts && opts.detachPubkey) || '' });
+    }
     // Timed auto-sign window chosen via the relax chips.
     if (action === 'relax') {
       extra = Object.assign({}, extra, { relaxMs: (opts && opts.relaxMs) || 15 * 60000 });
@@ -700,10 +757,6 @@
   els.allow.addEventListener('click', () => decide('once'));
   els.trust.addEventListener('click', () => decide('trust'));
   els.reject.addEventListener('click', () => decide('reject'));
-  // The "wrong account?" hint's cancel line — same decision as Reject. Bound directly
-  // rather than forwarded to els.reject, which init() swaps for a plain Close button on
-  // an expired request.
-  els.wrongAcctCancel.addEventListener('click', () => decide('reject'));
   els.pin &&
     els.pin.addEventListener('keydown', (e) => {
       // Respect the destructive lock — Enter bypasses the disabled Allow button

--- a/prompt.js
+++ b/prompt.js
@@ -650,7 +650,7 @@
     // Copy asserted identical to the panel's — see buildWrongAcctList in sidepanel.js for
     // why the reconnect instruction isn't here. This window closes on the decision, so it
     // has no toast of its own; the client's error is the only channel either way.
-    lede.textContent = 'Cancels this request and makes that account active.';
+    lede.textContent = 'Cancels this request and makes the selected account active.';
     els.wrongAcctList.append(lede);
     accts.forEach((a) => {
       const row = document.createElement('button');

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -457,10 +457,10 @@
       <button class="approval-switch-toggle hidden" id="approval-switch-toggle">Sign in with a different account</button>
       <div class="approval-switch-menu hidden" id="approval-switch-menu"></div>
 
-      <!-- "Wrong account?" hint. Shown on a content sign when the user holds more than
-           one account and the switcher above is hidden (only one account has logged in
-           here), so the prompt names an identity they may not have picked and has no
-           control to change it.
+      <!-- "Wrong account?" escape. Shown on a content sign whenever there is an account
+           the switcher above cannot offer — either because no switcher is showing, or
+           because it is scoped to the accounts already signed in on this host and the one
+           the user wants is not among them.
            Collapsed, because with eight accounts an always-open list buries the account
            capsule this screen exists to show.
            Picking a row DETACHES the host and makes that account active, then rejects —

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -457,6 +457,24 @@
       <button class="approval-switch-toggle hidden" id="approval-switch-toggle">Sign in with a different account</button>
       <div class="approval-switch-menu hidden" id="approval-switch-menu"></div>
 
+      <!-- "Wrong account?" hint. Shown on a content sign when the user holds more than
+           one account and the switcher above is hidden (only one account has logged in
+           here), so the prompt names an identity they may not have picked and has no
+           control to change it.
+           A hint plus one action, not a picker. An earlier cut listed every account and
+           let the user choose one — but the only thing Sidecar can honestly do is cancel,
+           because the event the client built carries the pubkey the client still has
+           cached. Signing it as someone else yields one correct event and then silent
+           reverts. Since the user has to cancel and reconnect on the site either way, the
+           list was a choice with no outcome; the line below IS that cancel.
+           It rejects — same as the Reject button, and like Reject it is never gated behind
+           the PIN or the destructive lock, because the safe way out must always be one
+           tap away. -->
+      <div class="approval-wrong-acct hidden" id="approval-wrong-acct">
+        <strong>Not the right account?</strong>
+        <button class="approval-wrong-acct-cancel" id="approval-wrong-acct-cancel">Cancel and login with another identity.</button>
+      </div>
+
       <div id="approval-preview" class="card hidden"></div>
 
       <div id="approval-unlock" class="hidden stack">

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -461,18 +461,16 @@
            one account and the switcher above is hidden (only one account has logged in
            here), so the prompt names an identity they may not have picked and has no
            control to change it.
-           A hint plus one action, not a picker. An earlier cut listed every account and
-           let the user choose one — but the only thing Sidecar can honestly do is cancel,
-           because the event the client built carries the pubkey the client still has
-           cached. Signing it as someone else yields one correct event and then silent
-           reverts. Since the user has to cancel and reconnect on the site either way, the
-           list was a choice with no outcome; the line below IS that cancel.
-           It rejects — same as the Reject button, and like Reject it is never gated behind
-           the PIN or the destructive lock, because the safe way out must always be one
-           tap away. -->
+           Collapsed, because with eight accounts an always-open list buries the account
+           capsule this screen exists to show.
+           Picking a row DETACHES the host and makes that account active, then rejects —
+           the same primitive as Settings -> Sites -> "Use <account>", so both routes leave
+           identical state. See the 'detach' branch in background.js for why signing this
+           request as a different account would be worse than failing it. -->
       <div class="approval-wrong-acct hidden" id="approval-wrong-acct">
         <strong>Not the right account?</strong>
-        <button class="approval-wrong-acct-cancel" id="approval-wrong-acct-cancel">Cancel and login with another identity.</button>
+        <button class="approval-wrong-acct-toggle" id="approval-wrong-acct-toggle" aria-expanded="false">Detach and use another identity.</button>
+        <div class="approval-wrong-acct-list hidden" id="approval-wrong-acct-list"></div>
       </div>
 
       <div id="approval-preview" class="card hidden"></div>

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -10515,16 +10515,13 @@
   function buildWrongAcctList(data, accts) {
     const list = $('approval-wrong-acct-list');
     list.innerHTML = '';
-    // Says "everywhere in Sidecar" because detach + setActive moves the GLOBAL active
-    // account, not just this site's. That's the coherent thing to do — it's the two steps
-    // the user would take by hand — but a silent global state change from a signing prompt
-    // is how you get a confused bug report a month later.
-    list.append(
-      h('p', {
-        className: 'wrong-acct-lede',
-        textContent: 'Picks who this site uses next, everywhere in Sidecar. Cancels this request — sign out and back in on ' + (data.host || 'the site') + '.',
-      })
-    );
+    // Only the two things the user can't learn afterwards: that this cancels, and that the
+    // switch is app-wide rather than just this site. "Makes that account active" carries
+    // the second one in Sidecar's own vocabulary, tying to the ACTIVE tag on the row below.
+    // The reconnect instruction is deliberately NOT here — it lands as a toast the moment
+    // the detach settles, with the account name filled in, which this can't do. Three lines
+    // of lede in a sidebar to pre-announce it was too much.
+    list.append(h('p', { className: 'wrong-acct-lede', textContent: 'Cancels this request and makes that account active.' }));
     accts.forEach((a) => {
       const row = h('button', { className: 'acct-row' });
       const av = document.createElement('span');
@@ -10781,6 +10778,18 @@
       await bg({ type: 'SIDECAR_PROMPT_RESULT_BATCH', ids: groupIds, action, extra });
     } else {
       await bg({ type: 'SIDECAR_PROMPT_RESULT', id, action, extra });
+    }
+    // Detach settled: say what to do next, in Sidecar. The background throws the same
+    // instruction as the signing error, but that goes to the CLIENT — a client that
+    // swallows signing errors would leave the user with no next step at all. Same string
+    // as switchSiteModal's, so the Settings route and this one read identically.
+    if (action === 'detach') {
+      const picked = (data.allAccounts || []).find((a) => a.pubkey === (opts && opts.detachPubkey));
+      toast(
+        'Detached. Sign out of ' + data.host + ' and back in as ' +
+          ((picked && picked.name) || 'that account') + '.',
+        'success'
+      );
     }
     $('approval-pin').value = '';
     // Leave pendingApproval set so refreshApproval() knows an approval was up:

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -10516,12 +10516,13 @@
     const list = $('approval-wrong-acct-list');
     list.innerHTML = '';
     // Only the two things the user can't learn afterwards: that this cancels, and that the
-    // switch is app-wide rather than just this site. "Makes that account active" carries
-    // the second one in Sidecar's own vocabulary, tying to the ACTIVE tag on the row below.
+    // switch is app-wide rather than just this site. "Makes the selected account active"
+    // carries the second in Sidecar's own vocabulary, tying to the ACTIVE tag on the row
+    // below.
     // The reconnect instruction is deliberately NOT here — it lands as a toast the moment
     // the detach settles, with the account name filled in, which this can't do. Three lines
     // of lede in a sidebar to pre-announce it was too much.
-    list.append(h('p', { className: 'wrong-acct-lede', textContent: 'Cancels this request and makes that account active.' }));
+    list.append(h('p', { className: 'wrong-acct-lede', textContent: 'Cancels this request and makes the selected account active.' }));
     accts.forEach((a) => {
       const row = h('button', { className: 'acct-row' });
       const av = document.createElement('span');

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -10472,6 +10472,26 @@
     });
   }
 
+  // "Wrong account?" hint. The switcher above only appears when 2+ accounts have logged
+  // in on this host, so on a single-login host a user looking at the wrong identity has
+  // no control at all. This tells them what to do about it.
+  //
+  // Static copy, deliberately. An earlier cut listed every account and rebound the host
+  // on a pick — but the only honest outcome was still "canceled, now reconnect on the
+  // site", because the event the client built carries the pubkey it still has cached.
+  // With eight accounts on screen that was a long list offering a choice that changed
+  // nothing. The Reject button already cancels; this just says so.
+  //
+  // Shown generously (see the gate in background.js — any content sign with 2+
+  // accounts). Sidecar can't see the client's UI, so it can't tell a correct prompt from
+  // a wrong one; only the user can.
+  function renderWrongAcctEscape(data) {
+    const hint = $('approval-wrong-acct');
+    if (!hint) return;
+    if (data.wrongAccountEscape) show(hint);
+    else hide(hint);
+  }
+
   function showApproval() {
     if (!pendingApproval) return;
     const data = pendingApproval.data;
@@ -10504,6 +10524,7 @@
       : 'wants to ' + (APPROVAL_METHOD_LABELS[data.method] || data.method);
 
     renderApprovalAccountCapsule(data);
+    renderWrongAcctEscape(data);
 
     // Shared-identity confirm: host signed in with 2+ of your accounts. Make the
     // "who's posting" choice explicit; relabel the switcher for signing context.
@@ -10715,6 +10736,10 @@
   $('approval-allow').addEventListener('click', () => decideApproval('once'));
   $('approval-trust').addEventListener('click', () => decideApproval('trust'));
   $('approval-reject').addEventListener('click', () => decideApproval('reject'));
+  // The "wrong account?" hint's cancel line. Same decision as Reject — including the
+  // batch behavior in decideApproval, so a grouped burst is dismissed in one go rather
+  // than re-prompting for each sibling under the same wrong identity.
+  $('approval-wrong-acct-cancel').addEventListener('click', () => decideApproval('reject'));
   // Escape hatch: reject the whole backlog at once (this request + all waiting).
   $('approval-reject-all').addEventListener('click', async () => {
     pendingApproval = null;

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -10472,9 +10472,11 @@
     });
   }
 
-  // "Wrong account?" escape. The switcher above only appears when 2+ accounts have logged
-  // in on this host, so on a single-login host a user looking at the wrong identity has no
-  // control at all. This is that control.
+  // "Wrong account?" escape. Offers exactly the accounts the switcher above cannot: it
+  // appears only once 2+ accounts have logged in on this host, and even then it is scoped
+  // to those accounts, so a user whose intended identity is a third one has no control at
+  // all. This is that control. See the gate in background.js — the two lists are disjoint
+  // by construction, so this never repeats a row the switcher already offers.
   //
   // Picking a row detaches the host and makes that account active — the same primitive as
   // Settings -> Sites -> "Use <account>", reachable from the moment the problem is

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -10472,24 +10472,75 @@
     });
   }
 
-  // "Wrong account?" hint. The switcher above only appears when 2+ accounts have logged
-  // in on this host, so on a single-login host a user looking at the wrong identity has
-  // no control at all. This tells them what to do about it.
+  // "Wrong account?" escape. The switcher above only appears when 2+ accounts have logged
+  // in on this host, so on a single-login host a user looking at the wrong identity has no
+  // control at all. This is that control.
   //
-  // Static copy, deliberately. An earlier cut listed every account and rebound the host
-  // on a pick — but the only honest outcome was still "canceled, now reconnect on the
-  // site", because the event the client built carries the pubkey it still has cached.
-  // With eight accounts on screen that was a long list offering a choice that changed
-  // nothing. The Reject button already cancels; this just says so.
+  // Picking a row detaches the host and makes that account active — the same primitive as
+  // Settings -> Sites -> "Use <account>", reachable from the moment the problem is
+  // actually discovered instead of three levels into Settings.
   //
-  // Shown generously (see the gate in background.js — any content sign with 2+
-  // accounts). Sidecar can't see the client's UI, so it can't tell a correct prompt from
-  // a wrong one; only the user can.
+  // Shown generously (see the gate in background.js — any content sign with 2+ accounts).
+  // Sidecar can't see the client's UI, so it can't tell a correct prompt from a wrong one;
+  // only the user can.
   function renderWrongAcctEscape(data) {
     const hint = $('approval-wrong-acct');
-    if (!hint) return;
-    if (data.wrongAccountEscape) show(hint);
-    else hide(hint);
+    const toggle = $('approval-wrong-acct-toggle');
+    const list = $('approval-wrong-acct-list');
+    if (!hint || !toggle || !list) return;
+    // Collapse on every render, not just the first: the panel re-shows the approval on
+    // queue advance and unlock, and an expanded list left over from the previous request
+    // would be offering to detach a different host.
+    list.innerHTML = '';
+    hide(list);
+    toggle.setAttribute('aria-expanded', 'false');
+    const accts = Array.isArray(data.allAccounts) ? data.allAccounts : [];
+    if (!data.wrongAccountEscape || !accts.length) {
+      hide(hint);
+      return;
+    }
+    show(hint);
+    toggle.onclick = () => {
+      if (list.classList.contains('hidden')) {
+        buildWrongAcctList(data, accts);
+        show(list);
+        toggle.setAttribute('aria-expanded', 'true');
+      } else {
+        hide(list);
+        toggle.setAttribute('aria-expanded', 'false');
+      }
+    };
+  }
+
+  function buildWrongAcctList(data, accts) {
+    const list = $('approval-wrong-acct-list');
+    list.innerHTML = '';
+    // Says "everywhere in Sidecar" because detach + setActive moves the GLOBAL active
+    // account, not just this site's. That's the coherent thing to do — it's the two steps
+    // the user would take by hand — but a silent global state change from a signing prompt
+    // is how you get a confused bug report a month later.
+    list.append(
+      h('p', {
+        className: 'wrong-acct-lede',
+        textContent: 'Picks who this site uses next, everywhere in Sidecar. Cancels this request — sign out and back in on ' + (data.host || 'the site') + '.',
+      })
+    );
+    accts.forEach((a) => {
+      const row = h('button', { className: 'acct-row' });
+      const av = document.createElement('span');
+      av.className = 'acct-row-av';
+      applyAvatar(av, a);
+      row.append(
+        av,
+        h('div', { className: 'acct-row-info' }, [
+          h('div', { className: 'acct-row-name', textContent: a.name || shortNpub(a.npub) }),
+          h('div', { className: 'acct-row-npub', textContent: shortNpub(a.npub) }),
+        ])
+      );
+      if (a.active) row.append(h('span', { className: 'wrong-acct-tag', textContent: 'Active' }));
+      row.addEventListener('click', () => decideApproval('detach', { detachPubkey: a.pubkey }));
+      list.append(row);
+    });
   }
 
   function showApproval() {
@@ -10666,8 +10717,12 @@
     const pinErr = $('approval-pin-error');
     err.textContent = '';
     pinErr.textContent = '';
-    // Unlock first if needed (Allow once / Trust / Relax only).
-    if (data.needUnlock && (action === 'once' || action === 'trust' || action === 'relax')) {
+    // Unlock first if needed. 'detach' is in here even though it never signs: it clears
+    // the site binding and moves the GLOBAL active account, and without it a locked prompt
+    // would be the one surface that can change persistent state with no authentication —
+    // reachable by anyone at an unattended browser who can make a site ask for a
+    // signature. Reject stays ungated; the safe way out must never need a PIN.
+    if (data.needUnlock && (action === 'once' || action === 'trust' || action === 'relax' || action === 'detach')) {
       const pin = $('approval-pin').value;
       if (!pin) {
         pinErr.textContent = 'Enter your PIN.';
@@ -10698,6 +10753,11 @@
       action = 'budget';
       // Merge, don't assign — other flags share this object (see prompt.js).
       extra = Object.assign({}, extra, { budgetSats, perPaymentSats: 0 });
+    }
+    // "Wrong account" escape: carry the account to make active. The background detaches
+    // and then throws, so this never signs.
+    if (action === 'detach') {
+      extra = Object.assign({}, extra, { detachPubkey: (opts && opts.detachPubkey) || '' });
     }
     // Timed auto-sign window chosen via the relax chips.
     if (action === 'relax') {
@@ -10736,10 +10796,6 @@
   $('approval-allow').addEventListener('click', () => decideApproval('once'));
   $('approval-trust').addEventListener('click', () => decideApproval('trust'));
   $('approval-reject').addEventListener('click', () => decideApproval('reject'));
-  // The "wrong account?" hint's cancel line. Same decision as Reject — including the
-  // batch behavior in decideApproval, so a grouped burst is dismissed in one go rather
-  // than re-prompting for each sibling under the same wrong identity.
-  $('approval-wrong-acct-cancel').addEventListener('click', () => decideApproval('reject'));
   // Escape hatch: reject the whole backlog at once (this request + all waiting).
   $('approval-reject-all').addEventListener('click', async () => {
     pendingApproval = null;

--- a/styles.css
+++ b/styles.css
@@ -38,6 +38,10 @@
   --orange: #ea772f;
   --amber: #f4a64b;
   --gold: #cba14e;
+  /* Channel triple behind every translucent accent wash (row highlights, hover fills,
+     tip cards). It used to be the literal 203, 161, 78 in 15 places, which meant a theme
+     could restyle --gold and still show Speakeasy's gold everywhere a wash appeared. */
+  --accent-rgb: 203, 161, 78;
   --gold-soft: rgba(203, 161, 78, 0.5);
   --purple: #a78bfa;
   --lav: #bda1ff;
@@ -441,7 +445,7 @@ button { cursor: pointer; }
   border: 1px solid var(--border);
   box-shadow: var(--sheen);
 }
-.secondary:hover { border-color: var(--gold-soft); box-shadow: var(--sheen), 0 0 0 3px rgba(203, 161, 78, 0.1); }
+.secondary:hover { border-color: var(--gold-soft); box-shadow: var(--sheen), 0 0 0 3px rgba(var(--accent-rgb), 0.1); }
 .secondary.chosen { border-color: var(--orange); color: var(--orange); }
 .ghost { background: transparent; color: var(--muted); }
 .ghost:hover { color: var(--text); }
@@ -455,7 +459,7 @@ button { cursor: pointer; }
 .setting.danger-zone { margin-top: 30px; padding-top: 22px; border-top: 1px solid rgba(240, 86, 107, 0.3); }
 .setting.danger-zone h3 { color: var(--red); }
 .setting.danger-zone .danger { margin-top: 8px; }
-button:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(203, 161, 78, 0.4); }
+button:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(var(--accent-rgb), 0.4); }
 
 .icon-btn {
   background: transparent;
@@ -560,8 +564,8 @@ button:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(203, 161, 78, 0
   padding: 9px 10px; border-radius: 10px;
 }
 .acct-row:hover { background: var(--hover-medium); }
-.acct-row.active { background: rgba(203, 161, 78, 0.08); }
-.acct-row-pending { background: rgba(203, 161, 78, 0.12) !important; border-left: 2px solid var(--gold); }
+.acct-row.active { background: rgba(var(--accent-rgb), 0.08); }
+.acct-row-pending { background: rgba(var(--accent-rgb), 0.12) !important; border-left: 2px solid var(--gold); }
 /* Pending confirm ("Set as active?" / "Tap again to confirm").
    The sub-label used --gold-soft, which is a 50%-ALPHA token meant for borders. As a text
    color it blends toward whatever is behind it, so it can't be reasoned about from the
@@ -729,7 +733,7 @@ button:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(203, 161, 78, 0
 .welcome-mark { position: relative; width: 76px; height: 76px; margin: 6px auto 16px; display: flex; align-items: center; justify-content: center; }
 .welcome-mark::before {
   content: ''; position: absolute; inset: -18px; border-radius: 50%;
-  background: radial-gradient(circle, rgba(203, 161, 78, 0.32), transparent 66%);
+  background: radial-gradient(circle, rgba(var(--accent-rgb), 0.32), transparent 66%);
 }
 .welcome-mark img { position: relative; width: 58px; height: auto; display: block; filter: drop-shadow(0 8px 20px rgba(0, 0, 0, 0.55)); }
 .welcome-title { font-family: var(--font-display); font-weight: 700; font-size: 27px; margin: 0 0 8px; color: var(--text); }
@@ -739,7 +743,7 @@ button:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(203, 161, 78, 0
   display: flex; align-items: center; gap: 9px; text-align: left;
   max-width: 300px; margin: 18px auto 0; padding: 10px 13px;
   border: 1px solid var(--gold-soft); border-radius: 12px;
-  background: rgba(203, 161, 78, 0.08);
+  background: rgba(var(--accent-rgb), 0.08);
   color: var(--text-2); font-size: 12px; line-height: 1.45; text-wrap: pretty;
 }
 .welcome-tip svg { width: 16px; height: 16px; flex-shrink: 0; color: var(--gold); }
@@ -751,7 +755,7 @@ button:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(203, 161, 78, 0
   text-align: left;
   margin: 10px 14px 0; padding: 11px 30px 12px 13px;
   border: 1px solid var(--gold-soft); border-radius: 12px;
-  background: rgba(203, 161, 78, 0.08);
+  background: rgba(var(--accent-rgb), 0.08);
   text-wrap: pretty;
 }
 .switch-tip-title {
@@ -1104,7 +1108,7 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
 .recovery-badges { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 5px; }
 .recovery-badge { font-size: 10.5px; font-weight: 600; letter-spacing: 0.03em; text-transform: uppercase; padding: 2px 7px; border-radius: 999px; }
 .recovery-badge.cur { background: rgba(96, 165, 250, 0.16); color: #7cb0ff; }
-.recovery-badge.rec { background: rgba(203, 161, 78, 0.16); color: var(--gold); }
+.recovery-badge.rec { background: rgba(var(--accent-rgb), 0.16); color: var(--gold); }
 .recovery-confirm { background: var(--velvet-1); border: 1px solid var(--border); border-radius: 12px; padding: 14px; margin-top: 4px; }
 .restore-list { margin: 4px 0 10px; padding-left: 20px; color: var(--text); }
 .restore-list li { margin: 3px 0; }
@@ -1655,7 +1659,7 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
   width: 30px; height: 30px; padding: 0; display: flex; align-items: center; justify-content: center;
   background: none; border: none; border-radius: 8px; color: var(--muted); cursor: pointer;
 }
-.wallet-refresh:hover { color: var(--gold); background: rgba(203, 161, 78, 0.12); }
+.wallet-refresh:hover { color: var(--gold); background: rgba(var(--accent-rgb), 0.12); }
 .wallet-refresh:active svg { transform: rotate(-180deg); }
 .wallet-refresh svg { width: 16px; height: 16px; transition: transform 0.3s ease; }
 .wallet-eye {
@@ -1663,7 +1667,7 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
   width: 30px; height: 30px; padding: 0; display: flex; align-items: center; justify-content: center;
   background: none; border: none; border-radius: 8px; color: var(--muted); cursor: pointer;
 }
-.wallet-eye:hover { color: var(--gold); background: rgba(203, 161, 78, 0.12); }
+.wallet-eye:hover { color: var(--gold); background: rgba(var(--accent-rgb), 0.12); }
 .wallet-eye svg { width: 16px; height: 16px; }
 .wallet-bal-label { font-size: 11px; letter-spacing: 0.05em; text-transform: uppercase; color: var(--muted); }
 .wallet-balance {
@@ -1901,7 +1905,7 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
 .post-banner {
   display: flex; align-items: center; gap: 10px;
   margin: 10px 16px 0; padding: 10px 12px; border-radius: 10px;
-  background: linear-gradient(180deg, rgba(203, 161, 78, 0.16), rgba(203, 161, 78, 0.08));
+  background: linear-gradient(180deg, rgba(var(--accent-rgb), 0.16), rgba(var(--accent-rgb), 0.08));
   border: 1px solid var(--gold-soft);
 }
 .post-banner-msg { font-size: 13px; color: var(--text); }
@@ -1932,9 +1936,9 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
   flex: 1; justify-content: center;
   display: inline-flex; align-items: center; gap: 6px;
   padding: 10px 18px; border-radius: 10px; border: none; cursor: pointer;
-  background: linear-gradient(180deg, #e2b968, var(--gold) 60%, #b7863a);
-  color: #1c1206; font-weight: 600; font-size: 13px; white-space: nowrap;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.3), 0 4px 12px rgba(203, 161, 78, 0.22);
+  background: linear-gradient(180deg, var(--btn-accent-top, #e2b968), var(--btn-accent-mid, var(--gold)) 60%, var(--btn-accent-bot, #b7863a));
+  color: var(--btn-accent-text, #1c1206); font-weight: 600; font-size: 13px; white-space: nowrap;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.3), 0 4px 12px rgba(var(--accent-rgb), 0.22);
   transition: filter 0.15s, transform 0.12s;
 }
 .reload-banner-btn:hover { filter: brightness(1.06); transform: translateY(-1px); }
@@ -1966,8 +1970,8 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
 .host-perm-grant-btn {
   flex-shrink: 0; margin-left: auto; cursor: pointer; white-space: nowrap;
   padding: 6px 12px; border-radius: 8px; border: none;
-  background: linear-gradient(180deg, #e2b968, var(--gold) 60%, #b7863a);
-  color: #1c1206; font-weight: 600; font-size: 12.5px;
+  background: linear-gradient(180deg, var(--btn-accent-top, #e2b968), var(--btn-accent-mid, var(--gold)) 60%, var(--btn-accent-bot, #b7863a));
+  color: var(--btn-accent-text, #1c1206); font-weight: 600; font-size: 12.5px;
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.3);
   transition: filter 0.15s;
 }
@@ -2332,13 +2336,13 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
 .pin-reminder-warn { color: var(--gold); font-weight: 600; }
 .shared-note {
   margin: 2px 0 14px; padding: 9px 11px; border-radius: 9px;
-  background: rgba(203, 161, 78, 0.1); border: 1px solid var(--gold-soft);
+  background: rgba(var(--accent-rgb), 0.1); border: 1px solid var(--gold-soft);
   color: var(--text-2); font-size: 12px; line-height: 1.45; text-align: left;
 }
 /* one-time explainer for multi-account (shared-identity) signing */
 .shared-headsup {
   margin: 2px 0 14px; padding: 11px 12px; border-radius: 10px;
-  background: rgba(203, 161, 78, 0.1); border: 1px solid var(--gold-soft); text-align: left;
+  background: rgba(var(--accent-rgb), 0.1); border: 1px solid var(--gold-soft); text-align: left;
 }
 .shared-headsup-title {
   display: flex; align-items: center; gap: 7px;
@@ -2348,7 +2352,7 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
 .shared-headsup-body { margin: 0 0 10px; color: var(--text-2); font-size: 12px; line-height: 1.45; }
 .shared-headsup-btn {
   display: block; width: 100%; padding: 8px; border-radius: 8px; cursor: pointer;
-  background: rgba(203, 161, 78, 0.16); border: 1px solid var(--gold-soft);
+  background: rgba(var(--accent-rgb), 0.16); border: 1px solid var(--gold-soft);
   color: var(--gold); font-weight: 600; font-size: 12.5px;
 }
 .shared-headsup-btn:hover { filter: brightness(1.12); }
@@ -2468,7 +2472,10 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
   animation: relax-pulse 1.6s ease-out infinite;
 }
 .relax-status-dot.low {
-  background: var(--gold); --relax-glow: rgba(203, 161, 78, 0.5); /* amber — under a minute left */
+  /* --amber, NOT --gold: this is the amber half of a green -> amber countdown, so it has
+     to stay amber even in a theme whose --gold is cobalt. Reading --gold here turned the
+     "under a minute" warning blue and killed the traffic-light reading entirely. */
+  background: var(--amber); --relax-glow: rgba(203, 161, 78, 0.5);
 }
 .relax-status-x {
   width: 22px; height: 22px; flex-shrink: 0; padding: 0; border-radius: 50%; cursor: pointer;

--- a/styles.css
+++ b/styles.css
@@ -2346,6 +2346,25 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
   border: 1px solid var(--border-strong); border-radius: 14px;
   padding: 6px; margin: -6px 0 14px; box-shadow: var(--sheen);
 }
+/* "Wrong account?" hint (see renderWrongAcctEscape in sidepanel.js). Matches
+   .trust-nudge, the other advisory line on this screen — muted, so it doesn't compete
+   with the destructive banner or read as something being wrong. */
+.approval-wrong-acct {
+  font-size: 12.5px; line-height: 1.45; color: var(--muted);
+  text-align: center; margin: -6px 0 14px;
+}
+.approval-wrong-acct strong { display: block; color: var(--text); font-weight: 600; }
+/* Reads as a link, not a button — it sits above the real action row and must not look
+   like a fourth choice competing with Allow / Trust / Reject. Secondary color, not --lav:
+   at accent weight it pulled the eye away from the account capsule directly above, which
+   is the thing the user actually needs to read on this screen. The underline carries the
+   affordance on its own, and hover brings it up to full text color. */
+.approval-wrong-acct-cancel {
+  background: none; border: none; padding: 2px 4px; cursor: pointer;
+  font: inherit; color: var(--muted); text-decoration: underline;
+}
+.approval-wrong-acct-cancel:hover { color: var(--text); }
+
 .approval-as {
   font-size: 10.5px; color: var(--muted); margin-bottom: 8px;
   text-transform: uppercase; letter-spacing: 0.22em; text-align: center;

--- a/styles.css
+++ b/styles.css
@@ -405,11 +405,22 @@ button { cursor: pointer; }
   letter-spacing: 0.01em;
   transition: transform 0.12s, box-shadow 0.15s, filter 0.15s, border-color 0.15s;
 }
-/* filled secondary button — theme-adaptive (gold in dark themes, bronze in light) */
+/* "Trust this site" — the filled companion to .primary.
+   Themeable for the same reason .primary is: the fill is built from --lav / --purple,
+   which every theme overrides, while the label was a hardcoded near-black. Wherever a
+   theme lands those dark the label went dark-on-dark — illegible in Aegean (--lav
+   #1565C0 cobalt) and Art Deco (#7A5A18 bronze). Both light themes now supply a light
+   fill and keep the dark label.
+   The ring is an INSET SHADOW, not a border: the shared rule above sets border: none,
+   and a real border here would make this button 2px taller than the Allow button
+   directly above it. */
 .lav-btn {
-  background: linear-gradient(180deg, #cebfff, var(--lav) 58%, var(--purple));
-  color: #190a33;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 8px 22px rgba(167, 139, 250, 0.24);
+  background: linear-gradient(180deg, var(--btn-lav-top, #cebfff), var(--btn-lav-mid, var(--lav)) 58%, var(--btn-lav-bot, var(--purple)));
+  color: var(--btn-lav-text, #190a33);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.4),
+    inset 0 0 0 1px var(--btn-lav-ring, transparent),
+    0 8px 22px var(--btn-lav-shadow, rgba(167, 139, 250, 0.24));
 }
 .lav-btn:hover { filter: brightness(1.05); transform: translateY(-1px); }
 .lav-btn:active { transform: translateY(0); }

--- a/styles.css
+++ b/styles.css
@@ -2359,11 +2359,25 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
    at accent weight it pulled the eye away from the account capsule directly above, which
    is the thing the user actually needs to read on this screen. The underline carries the
    affordance on its own, and hover brings it up to full text color. */
-.approval-wrong-acct-cancel {
+.approval-wrong-acct-toggle {
   background: none; border: none; padding: 2px 4px; cursor: pointer;
   font: inherit; color: var(--muted); text-decoration: underline;
 }
-.approval-wrong-acct-cancel:hover { color: var(--text); }
+.approval-wrong-acct-toggle:hover { color: var(--text); }
+/* Borrows the switch-menu shell so the expanded list reads as the same kind of thing as
+   the account switcher above it. */
+.approval-wrong-acct-list {
+  text-align: left; margin: 8px 0 0; padding: 6px;
+  background: linear-gradient(180deg, var(--velvet-1), var(--velvet-2));
+  border: 1px solid var(--border-strong); border-radius: 14px; box-shadow: var(--sheen);
+}
+.wrong-acct-lede { margin: 2px 6px 8px; font-size: 12px; line-height: 1.45; color: var(--muted); }
+/* "Active" marker on the globally-active account, which sorts first. Without it the
+   top row looks arbitrary rather than like the obvious pick. */
+.wrong-acct-tag {
+  margin-left: auto; font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--muted); white-space: nowrap;
+}
 
 .approval-as {
   font-size: 10.5px; color: var(--muted); margin-bottom: 8px;

--- a/styles.css
+++ b/styles.css
@@ -432,9 +432,12 @@ button { cursor: pointer; }
 }
 .primary:hover { filter: brightness(1.06); transform: translateY(-1px); }
 .primary:active { transform: translateY(0); }
+/* Its own hooks rather than reading --velvet-* directly: a theme that wants its quiet
+   buttons tinted differently from its cards can say so without dragging every card, menu
+   and well along with it. Defaults are the old values, so the dark themes are unchanged. */
 .secondary {
-  background: linear-gradient(180deg, var(--velvet-1), var(--velvet-2));
-  color: var(--text);
+  background: linear-gradient(180deg, var(--btn-secondary-top, var(--velvet-1)), var(--btn-secondary-bot, var(--velvet-2)));
+  color: var(--btn-secondary-text, var(--text));
   border: 1px solid var(--border);
   box-shadow: var(--sheen);
 }

--- a/styles.css
+++ b/styles.css
@@ -562,8 +562,17 @@ button:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(203, 161, 78, 0
 .acct-row:hover { background: var(--hover-medium); }
 .acct-row.active { background: rgba(203, 161, 78, 0.08); }
 .acct-row-pending { background: rgba(203, 161, 78, 0.12) !important; border-left: 2px solid var(--gold); }
-.acct-row-pending .acct-row-name { color: var(--gold); }
-.acct-row-pending .acct-row-npub { color: var(--gold-soft); }
+/* Pending confirm ("Set as active?" / "Tap again to confirm").
+   The sub-label used --gold-soft, which is a 50%-ALPHA token meant for borders. As a text
+   color it blends toward whatever is behind it, so it can't be reasoned about from the
+   declaration: 1.30:1 on Art Deco's cream card (reported as unreadable, and it was) but
+   also only 2.49–3.07:1 in all three DARK themes, which is under AA everywhere. So the
+   default is --muted, the token that exists for secondary text, and the gold accent is
+   carried by the title alone — which also restores the hierarchy the two colors were
+   supposed to express. Themes with a --muted of their own that doesn't clear AA here
+   override --pending-sub. */
+.acct-row-pending .acct-row-name { color: var(--pending-text, var(--gold)); }
+.acct-row-pending .acct-row-npub { color: var(--pending-sub, var(--muted)); }
 .acct-row-av {
   width: 34px; height: 34px; border-radius: 50%; overflow: hidden; flex-shrink: 0;
   background: linear-gradient(180deg, var(--av-from), var(--av-to)); border: 1px solid var(--border);
@@ -958,7 +967,8 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
 }
 .item.item-pending { border-color: var(--gold-soft); box-shadow: var(--sheen), 0 0 0 1px var(--gold-soft); }
 .item.item-pending .item-label { color: var(--gold); }
-.item.item-pending .item-sub { color: var(--gold-soft); }
+/* Same pending sub-label, on the settings-style rows. See .acct-row-pending above. */
+.item.item-pending .item-sub { color: var(--pending-sub, var(--muted)); }
 /* budget rows: wrap the "X of Y sats left today" line at spaces, not mid-word */
 .wallet-budgets .item-sub { word-break: normal; overflow-wrap: anywhere; }
 

--- a/test/button-contrast.test.js
+++ b/test/button-contrast.test.js
@@ -1,0 +1,203 @@
+'use strict';
+
+// WCAG contrast for the two filled buttons on the approval prompt, in every theme.
+//
+// Why this exists: "Trust this site" (.lav-btn) hardcoded a near-black label over a
+// gradient whose mid and bottom stops come from --lav / --purple — variables every theme
+// overrides. In the two themes that land those dark (Aegean cobalt #1565C0, Art Deco
+// bronze #7A5A18) the label went dark-on-dark and was reported as illegible. The identical
+// bug had already been found and fixed for .primary next to it, whose comment still reads
+// "right on amber, unreadable on a cobalt fill" — so this is a mistake the codebase has now
+// made twice, in adjacent rules, which is exactly what a test is for.
+//
+// Asserting hex values would not have caught it: every individual value was reasonable.
+// The defect only exists in the COMBINATION of a theme's fill and the shared rule's label,
+// which is why this resolves the real var() chains out of styles.css and the theme files
+// and computes the ratio.
+//
+// Thresholds. The label is 14px/600 — not WCAG "large text" (that needs 18.66px bold or
+// 24px), so the bar is 4.5:1. But the fill is a vertical gradient and the label is
+// vertically centered, so it sits over the middle band, not the extremes:
+//
+//   mid stop  >= 4.5   the band the text actually sits on
+//   any stop  >= 3.0   nothing wildly illegible at the edges, where ascenders reach
+//
+// Checking every stop at 4.5 was tried and is too strict to be useful: Aegean's .primary
+// puts white on #2A7BD4 at the 0% stop for 4.33:1, which no eye reads as a defect because
+// no glyph sits up there. Both thresholds still catch the reported bug — the old Aegean
+// .lav-btn was 3.24:1 on its mid stop and 2.58:1 on its bottom.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.join(__dirname, '..');
+const css = fs.readFileSync(path.join(ROOT, 'styles.css'), 'utf8');
+const promptHtml = fs.readFileSync(path.join(ROOT, 'prompt.html'), 'utf8');
+
+// ---- CSS custom-property tables -------------------------------------------------------
+
+function varsIn(src, blockRe) {
+  const m = src.match(blockRe);
+  if (!m) throw new Error('block not found: ' + blockRe);
+  const out = {};
+  for (const d of m[0].matchAll(/(--[a-z0-9-]+)\s*:\s*([^;]+);/g)) out[d[1]] = d[2].trim();
+  return out;
+}
+
+const rootVars = varsIn(css, /:root\s*\{[\s\S]*?\n\}/);
+
+const THEMES = fs
+  .readdirSync(path.join(ROOT, 'themes'))
+  .filter((f) => f.endsWith('.css') && f !== 'patterns.css')
+  .map((f) => {
+    const src = fs.readFileSync(path.join(ROOT, 'themes', f), 'utf8');
+    return { name: f.replace('.css', ''), vars: varsIn(src, /\[data-theme=[^\]]+\]\s*\{[\s\S]*?\n\}/) };
+  });
+
+// ---- var() resolution ------------------------------------------------------------------
+//
+// Hand-rolled rather than regex: fallbacks nest (`var(--btn-lav-mid, var(--lav))`) and a
+// naive `[^)]*` stops at the inner paren, which silently resolves to the wrong color.
+
+function matchParen(s, open) {
+  let depth = 0;
+  for (let i = open; i < s.length; i++) {
+    if (s[i] === '(') depth++;
+    else if (s[i] === ')' && --depth === 0) return i;
+  }
+  throw new Error('unbalanced parens in: ' + s);
+}
+
+// Outermost var() expressions only — nested ones are skipped by resuming past the close.
+function outerVars(expr) {
+  const out = [];
+  let i = 0;
+  for (;;) {
+    const j = expr.indexOf('var(', i);
+    if (j === -1) return out;
+    const k = matchParen(expr, j + 3);
+    out.push(expr.slice(j, k + 1));
+    i = k + 1;
+  }
+}
+
+function splitVar(v) {
+  const inner = v.slice(4, -1);
+  let depth = 0;
+  for (let i = 0; i < inner.length; i++) {
+    if (inner[i] === '(') depth++;
+    else if (inner[i] === ')') depth--;
+    else if (inner[i] === ',' && depth === 0) return [inner.slice(0, i).trim(), inner.slice(i + 1).trim()];
+  }
+  return [inner.trim(), null];
+}
+
+function resolve(expr, themeVars) {
+  const e = String(expr).trim();
+  if (e.startsWith('var(')) {
+    const [name, fallback] = splitVar(e);
+    if (themeVars[name] != null) return resolve(themeVars[name], themeVars);
+    if (rootVars[name] != null) return resolve(rootVars[name], themeVars);
+    if (fallback != null) return resolve(fallback, themeVars);
+    return null;
+  }
+  return e.split(/\s+/)[0]; // drop a trailing gradient position like "58%"
+}
+
+// ---- contrast --------------------------------------------------------------------------
+
+function luminance(hex) {
+  const c = hex.replace('#', '');
+  const f = c.length === 3 ? c.split('').map((x) => x + x).join('') : c;
+  const ch = [0, 2, 4].map((i) => parseInt(f.slice(i, i + 2), 16) / 255);
+  const lin = (u) => (u <= 0.03928 ? u / 12.92 : Math.pow((u + 0.055) / 1.055, 2.4));
+  return 0.2126 * lin(ch[0]) + 0.7152 * lin(ch[1]) + 0.0722 * lin(ch[2]);
+}
+
+function contrast(a, b) {
+  const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+// ---- the rules under test --------------------------------------------------------------
+
+function rule(src, selector) {
+  const m = src.match(new RegExp('\\n\\s*\\' + selector + '\\s*\\{([\\s\\S]*?)\\n\\s*\\}'));
+  if (!m) throw new Error('rule not found: ' + selector);
+  return m[1];
+}
+
+function stopsAndLabel(body) {
+  const bg = body.match(/background:\s*linear-gradient\(([\s\S]*?)\);/);
+  const color = body.match(/color:\s*([^;]+);/);
+  if (!bg || !color) throw new Error('rule is missing background or color');
+  const stops = outerVars(bg[1]);
+  assert.equal(stops.length, 3, 'expected three themeable gradient stops, got ' + stops.length);
+  return { stops, label: color[1].trim() };
+}
+
+const BUTTONS = [
+  ['.lav-btn', 'Trust this site'],
+  ['.primary', 'Allow once'],
+];
+
+for (const [selector, label] of BUTTONS) {
+  for (const theme of THEMES) {
+    test(`${label} (${selector}) is legible in ${theme.name}`, () => {
+      const { stops, label: labelExpr } = stopsAndLabel(rule(css, selector));
+      const fg = resolve(labelExpr, theme.vars);
+      assert.ok(/^#[0-9a-f]{3,6}$/i.test(fg), `${theme.name}: label resolved to non-hex "${fg}"`);
+
+      const resolved = stops.map((s) => resolve(s, theme.vars));
+      for (const [i, bgc] of resolved.entries()) {
+        assert.ok(/^#[0-9a-f]{3,6}$/i.test(bgc), `${theme.name}: stop ${i} resolved to non-hex "${bgc}"`);
+        const r = contrast(fg, bgc);
+        assert.ok(
+          r >= 3.0,
+          `${theme.name} ${selector}: stop ${i} (${bgc}) vs label ${fg} is ${r.toFixed(2)}:1, needs >= 3.0`
+        );
+      }
+      const mid = contrast(fg, resolved[1]);
+      assert.ok(
+        mid >= 4.5,
+        `${theme.name} ${selector}: mid stop (${resolved[1]}) vs label ${fg} is ${mid.toFixed(2)}:1, needs >= 4.5`
+      );
+    });
+  }
+}
+
+// ---- the two surfaces must not drift ---------------------------------------------------
+
+test('prompt.html and styles.css declare the same themeable hooks', () => {
+  // The popup window has its own copy of these rules. A theme sets one set of variables, so
+  // if the two rules read different ones the same theme renders differently depending on
+  // whether the side panel happened to be open.
+  for (const selector of ['.lav-btn']) {
+    const a = new Set(outerVars(rule(css, selector)).map((v) => splitVar(v)[0]));
+    const b = new Set(outerVars(rule(promptHtml, selector)).map((v) => splitVar(v)[0]));
+    assert.deepEqual([...a].sort(), [...b].sort(), selector + ' hooks differ between surfaces');
+  }
+});
+
+test('the light themes supply their own Trust fill', () => {
+  // Aegean and Art Deco are the two whose --lav / --purple are dark enough to break the
+  // shared default. If either stops overriding, the contrast tests above go red — this just
+  // names them so the failure is obvious rather than arithmetic.
+  for (const name of ['aegean', 'art-deco']) {
+    const t = THEMES.find((x) => x.name === name);
+    assert.ok(t, 'missing theme ' + name);
+    for (const v of ['--btn-lav-top', '--btn-lav-mid', '--btn-lav-bot', '--btn-lav-text']) {
+      assert.ok(t.vars[v], name + ' should define ' + v);
+    }
+  }
+});
+
+test('the ring is an inset shadow, not a border', () => {
+  // The shared button rule sets border: none. A real border on .lav-btn alone would make it
+  // 2px taller than the Allow button directly above it.
+  const body = rule(css, '.lav-btn');
+  assert.ok(!/(^|[^-])border:/.test(body), '.lav-btn must not set a border');
+  assert.match(body, /inset 0 0 0 1px var\(--btn-lav-ring/);
+});

--- a/test/theme-contrast.test.js
+++ b/test/theme-contrast.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
-// WCAG contrast for the two filled buttons on the approval prompt, in every theme.
+// WCAG contrast for theme colors: the filled buttons on the approval prompt, and every ink
+// against every surface, in all five themes.
 //
 // Why this exists: "Trust this site" (.lav-btn) hardcoded a near-black label over a
 // gradient whose mid and bottom stops come from --lav / --purple — variables every theme
@@ -174,7 +175,7 @@ test('prompt.html and styles.css declare the same themeable hooks', () => {
   // The popup window has its own copy of these rules. A theme sets one set of variables, so
   // if the two rules read different ones the same theme renders differently depending on
   // whether the side panel happened to be open.
-  for (const selector of ['.lav-btn']) {
+  for (const selector of ['.lav-btn', '.secondary']) {
     const a = new Set(outerVars(rule(css, selector)).map((v) => splitVar(v)[0]));
     const b = new Set(outerVars(rule(promptHtml, selector)).map((v) => splitVar(v)[0]));
     assert.deepEqual([...a].sort(), [...b].sort(), selector + ' hooks differ between surfaces');
@@ -200,4 +201,96 @@ test('the ring is an inset shadow, not a border', () => {
   const body = rule(css, '.lav-btn');
   assert.ok(!/(^|[^-])border:/.test(body), '.lav-btn must not set a border');
   assert.match(body, /inset 0 0 0 1px var\(--btn-lav-ring/);
+});
+
+// ---------------------------------------------------------------------------
+// Ink against surfaces
+// ---------------------------------------------------------------------------
+//
+// Added when Aegean's card bottoms were tinted sea-light blue. The card top stays white,
+// so the tint made the bottom DARKER, and every ink sitting on a card lost a little
+// contrast. That is the same class of change as the .lav-btn bug — a fill moving out from
+// under a label that used to be fine — so it needs the same kind of guard.
+//
+// Two tiers, because the four ink tokens are not one thing:
+//
+//   --text / --text-2   body copy. Hard AA floor of 4.5:1, met in every theme with a wide
+//                       margin (worst is Art Deco --text-2 at 6.03:1).
+//
+//   --muted / --faint   recorded floors, NOT an AA assertion. Neither clears 4.5:1 in every
+//                       theme today: Art Deco --muted is 3.68:1, and --faint runs 2.28–3.53
+//                       across all five. Lifting every theme's ink is a design decision and
+//                       not a test's call to make, so these record where things stand and
+//                       fail on further slippage. The numbers being visible here is half the
+//                       point — see the note under FLOORS.
+
+const AA_NORMAL = 4.5;
+const INK = ['--text', '--text-2', '--muted', '--faint'];
+const SURFACES = ['--bg', '--bg-2', '--velvet-1', '--velvet-2'];
+
+// Worst-surface floors as measured. Raise these when a theme's ink improves; do not lower
+// one to make a change pass — that is the failure this file exists to make visible.
+//
+// KNOWN BELOW AA (pre-existing, not introduced by any change here):
+//   art-deco --muted 3.68:1  — secondary body text under the 4.5 floor
+//   --faint  in every theme  — 2.28 (film-noir) to 3.53 (brownstone)
+// --faint is used for the lowest-emphasis labels; if it ever carries something a user has
+// to read, it needs darkening first, per theme.
+const FLOORS = {
+  aegean: { '--muted': 4.55, '--faint': 2.85 },
+  'art-deco': { '--muted': 3.65, '--faint': 2.30 },
+  brownstone: { '--muted': 6.20, '--faint': 3.50 },
+  'film-noir': { '--muted': 4.45, '--faint': 2.25 },
+  speakeasy: { '--muted': 5.20, '--faint': 3.00 },
+};
+
+for (const theme of THEMES) {
+  test(`body ink clears AA on every surface in ${theme.name}`, () => {
+    for (const ink of ['--text', '--text-2']) {
+      const fg = resolve('var(' + ink + ')', theme.vars);
+      assert.ok(/^#[0-9a-f]{3,6}$/i.test(fg), `${theme.name}: ${ink} resolved to "${fg}"`);
+      for (const surface of SURFACES) {
+        const bg = resolve('var(' + surface + ')', theme.vars);
+        assert.ok(/^#[0-9a-f]{3,6}$/i.test(bg), `${theme.name}: ${surface} resolved to "${bg}"`);
+        const r = contrast(fg, bg);
+        assert.ok(
+          r >= AA_NORMAL,
+          `${theme.name}: ${ink} (${fg}) on ${surface} (${bg}) is ${r.toFixed(2)}:1, needs >= ${AA_NORMAL}`
+        );
+      }
+    }
+  });
+
+  test(`secondary ink has not slipped in ${theme.name}`, () => {
+    const floors = FLOORS[theme.name];
+    assert.ok(floors, 'no recorded floors for theme ' + theme.name + ' — add them');
+    for (const ink of ['--muted', '--faint']) {
+      const fg = resolve('var(' + ink + ')', theme.vars);
+      const worst = Math.min(
+        ...SURFACES.map((s) => contrast(fg, resolve('var(' + s + ')', theme.vars)))
+      );
+      assert.ok(
+        worst >= floors[ink] - 0.005,
+        `${theme.name}: ${ink} (${fg}) worst surface is ${worst.toFixed(2)}:1, floor is ${floors[ink]}`
+      );
+    }
+  });
+}
+
+test('every theme has recorded floors', () => {
+  // A new theme must be measured, not silently skipped.
+  for (const theme of THEMES) assert.ok(FLOORS[theme.name], 'missing floors for ' + theme.name);
+  for (const name of Object.keys(FLOORS)) {
+    assert.ok(THEMES.some((t) => t.name === name), 'floors recorded for missing theme ' + name);
+  }
+});
+
+test('INK and SURFACES name real tokens in every theme', () => {
+  // A typo would make the loops above assert nothing at all.
+  for (const theme of THEMES) {
+    for (const v of INK.concat(SURFACES)) {
+      const c = resolve('var(' + v + ')', theme.vars);
+      assert.ok(/^#[0-9a-f]{3,6}$/i.test(c), `${theme.name}: ${v} did not resolve to a hex color`);
+    }
+  }
 });

--- a/test/theme-contrast.test.js
+++ b/test/theme-contrast.test.js
@@ -95,6 +95,19 @@ function splitVar(v) {
   return [inner.trim(), null];
 }
 
+// Resolves var() chains WITHOUT the trailing-token trim resolve() does, so an
+// `rgba(203, 161, 78, 0.5)` or a bare `203, 161, 78` channel triple survives intact.
+function resolveRaw(expr, themeVars) {
+  const e = String(expr).trim();
+  if (e.startsWith('var(')) {
+    const [name, fallback] = splitVar(e);
+    if (themeVars[name] != null) return resolveRaw(themeVars[name], themeVars);
+    if (rootVars[name] != null) return resolveRaw(rootVars[name], themeVars);
+    return fallback != null ? resolveRaw(fallback, themeVars) : null;
+  }
+  return e;
+}
+
 function resolve(expr, themeVars) {
   const e = String(expr).trim();
   if (e.startsWith('var(')) {
@@ -120,6 +133,40 @@ function luminance(hex) {
 function contrast(a, b) {
   const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x);
   return (hi + 0.05) / (lo + 0.05);
+}
+
+function toRgb(hex) {
+  const c = hex.replace('#', '');
+  const f = c.length === 3 ? c.split('').map((x) => x + x).join('') : c;
+  return [0, 2, 4].map((i) => parseInt(f.slice(i, i + 2), 16));
+}
+
+const hex = (rgb) => '#' + rgb.map((v) => Math.round(v).toString(16).padStart(2, '0')).join('');
+
+// Composite an rgba() over an opaque backdrop. This exists because the bug it caught was
+// precisely an alpha token used where an opaque one belonged: --gold-soft is 50% alpha,
+// designed for borders, and as a TEXT color it blends toward the surface behind it. On a
+// dark card that still leaves usable contrast; on Art Deco's cream card it measured
+// 1.30:1. Comparing the raw rgba against the surface would have shown a healthy ratio and
+// missed it entirely — the blend is the whole defect.
+function flatten(expr, backdrop, themeVars) {
+  const v = resolveRaw(expr, themeVars);
+  const m = String(v).match(/^rgba?\(([^)]+)\)$/);
+  if (!m) return v;
+  const parts = m[1].split(',').map((x) => x.trim());
+  let rgb;
+  let alpha;
+  if (parts.length === 4 && !parts[0].startsWith('var(')) {
+    rgb = parts.slice(0, 3).map(Number);
+    alpha = Number(parts[3]);
+  } else {
+    // rgba(var(--x-rgb), a) — the channel triple lives in its own variable.
+    const triple = resolveRaw(parts[0], themeVars);
+    rgb = String(triple).split(',').map((x) => Number(x.trim()));
+    alpha = Number(parts[parts.length - 1]);
+  }
+  const bg = toRgb(backdrop);
+  return hex(rgb.map((c, i) => alpha * c + (1 - alpha) * bg[i]));
 }
 
 // ---- the rules under test --------------------------------------------------------------
@@ -293,4 +340,74 @@ test('INK and SURFACES name real tokens in every theme', () => {
       assert.ok(/^#[0-9a-f]{3,6}$/i.test(c), `${theme.name}: ${v} did not resolve to a hex color`);
     }
   }
+});
+
+// ---------------------------------------------------------------------------
+// Pending-confirm state
+// ---------------------------------------------------------------------------
+//
+// Reported as unreadable in Art Deco: "Set as active?" / "Tap again to confirm". Two
+// separate faults in one component, and neither is visible by reading the CSS.
+//
+//   .acct-row-pending .acct-row-name   --gold on a gold wash        1.68:1
+//   .acct-row-pending .acct-row-npub   --gold-soft, 50% ALPHA       1.30:1
+//
+// The row's own background is a hardcoded rgba(203, 161, 78, 0.12) — the same wash in
+// every theme, subtle over a dark card and subtle over cream, so it was never the problem
+// on its own. The problem is gold ink on it, and an alpha token used as ink.
+//
+// Both text colors are now themeable with the gold as fallback, so the dark themes are
+// unchanged and the two light themes supply their own. This checks the composited result,
+// which is the only way the alpha fault shows up at all.
+
+const PENDING_WASH = 'rgba(203, 161, 78, 0.12)';
+
+for (const theme of THEMES) {
+  test(`pending confirm is readable in ${theme.name}`, () => {
+    const card = resolve('var(--velvet-1)', theme.vars);
+    const wash = flatten(PENDING_WASH, card, theme.vars);
+
+    const title = flatten(rule(css, '.acct-row-pending .acct-row-name').match(/color:\s*([^;]+);/)[1], wash, theme.vars);
+    const sub = flatten(rule(css, '.acct-row-pending .acct-row-npub').match(/color:\s*([^;]+);/)[1], wash, theme.vars);
+
+    const tr = contrast(title, wash);
+    const sr = contrast(sub, wash);
+    assert.ok(tr >= AA_NORMAL, `${theme.name}: pending title (${title}) on ${wash} is ${tr.toFixed(2)}:1, needs >= ${AA_NORMAL}`);
+    assert.ok(sr >= AA_NORMAL, `${theme.name}: pending sub (${sub}) on ${wash} is ${sr.toFixed(2)}:1, needs >= ${AA_NORMAL}`);
+
+    // The sub-label must stay the quieter of the two, or the fix has flattened the
+    // hierarchy the color was carrying in the first place.
+    assert.ok(sr <= tr, `${theme.name}: pending sub (${sr.toFixed(2)}) should not out-contrast the title (${tr.toFixed(2)})`);
+  });
+
+  test(`the item-row pending sub-label is readable in ${theme.name}`, () => {
+    // Same label on the settings-style rows, which have no wash — it sits on the card.
+    const expr = rule(css, '.item.item-pending .item-sub').match(/color:\s*([^;]+);/)[1];
+    for (const surface of ['--velvet-1', '--velvet-2']) {
+      const bg = resolve('var(' + surface + ')', theme.vars);
+      const fg = flatten(expr, bg, theme.vars);
+      const r = contrast(fg, bg);
+      assert.ok(r >= AA_NORMAL, `${theme.name}: item pending sub (${fg}) on ${surface} (${bg}) is ${r.toFixed(2)}:1, needs >= ${AA_NORMAL}`);
+    }
+  });
+}
+
+test('no text color anywhere resolves to a translucent token', () => {
+  // The root cause, stated directly. --gold-soft and friends are border/shadow tokens; a
+  // `color:` that lands on one inherits the surface behind it and cannot be reasoned about
+  // from the declaration alone. Scanning all of styles.css rather than the two known rules,
+  // because the next one will be somewhere else.
+  const offenders = [];
+  for (const m of css.matchAll(/([^{}]+)\{([^}]*)\}/g)) {
+    const selector = m[1].trim().split('\n').pop().trim();
+    for (const d of m[2].matchAll(/(?:^|;)\s*color:\s*([^;]+)/g)) {
+      for (const theme of THEMES) {
+        const v = resolveRaw(d[1].trim(), theme.vars);
+        if (/^rgba\(/.test(String(v)) && !/,\s*1\s*\)$/.test(String(v))) {
+          offenders.push(`${selector} -> ${d[1].trim()} = ${v} (${theme.name})`);
+        }
+      }
+    }
+  }
+  assert.deepEqual(offenders, [], 'translucent text colors:\n  ' + offenders.join('\n  '));
 });

--- a/test/theme-contrast.test.js
+++ b/test/theme-contrast.test.js
@@ -150,24 +150,39 @@ const hex = (rgb) => '#' + rgb.map((v) => Math.round(v).toString(16).padStart(2,
 // 1.30:1. Comparing the raw rgba against the surface would have shown a healthy ratio and
 // missed it entirely — the blend is the whole defect.
 function flatten(expr, backdrop, themeVars) {
-  const v = resolveRaw(expr, themeVars);
-  const m = String(v).match(/^rgba?\(([^)]+)\)$/);
-  if (!m) return v;
-  const parts = m[1].split(',').map((x) => x.trim());
-  let rgb;
-  let alpha;
-  if (parts.length === 4 && !parts[0].startsWith('var(')) {
-    rgb = parts.slice(0, 3).map(Number);
-    alpha = Number(parts[3]);
-  } else {
-    // rgba(var(--x-rgb), a) — the channel triple lives in its own variable.
-    const triple = resolveRaw(parts[0], themeVars);
-    rgb = String(triple).split(',').map((x) => Number(x.trim()));
-    alpha = Number(parts[parts.length - 1]);
+  const v = String(resolveRaw(expr, themeVars)).trim();
+  if (!/^rgba?\(/.test(v)) return v;
+  // Paren-aware, not /\(([^)]+)\)/: the channel triple can itself be a var(), and
+  // `rgba(var(--accent-rgb), 0.12)` closed the naive match at var's own paren and
+  // silently produced NaN instead of failing loudly.
+  const open = v.indexOf('(');
+  const inner = v.slice(open + 1, matchParen(v, open));
+  const parts = [];
+  let depth = 0;
+  let cur = '';
+  for (const ch of inner) {
+    if (ch === '(') { depth++; cur += ch; }
+    else if (ch === ')') { depth--; cur += ch; }
+    else if (ch === ',' && depth === 0) { parts.push(cur.trim()); cur = ''; }
+    else cur += ch;
   }
+  parts.push(cur.trim());
+
+  let rgb;
+  if (parts.length >= 4) {
+    rgb = parts.slice(0, 3).map(Number);
+  } else {
+    rgb = String(resolveRaw(parts[0], themeVars)).split(',').map((x) => Number(x.trim()));
+  }
+  const alpha = Number(parts[parts.length - 1]);
+  assert.ok(
+    rgb.length === 3 && rgb.every((c) => Number.isFinite(c)) && Number.isFinite(alpha),
+    'could not parse color "' + v + '"'
+  );
   const bg = toRgb(backdrop);
-  return hex(rgb.map((c, i) => alpha * c + (1 - alpha) * bg[i]));
+  return hex(rgb.map((c, k) => alpha * c + (1 - alpha) * bg[k]));
 }
+
 
 // ---- the rules under test --------------------------------------------------------------
 
@@ -272,7 +287,7 @@ test('the ring is an inset shadow, not a border', () => {
 //                       point — see the note under FLOORS.
 
 const AA_NORMAL = 4.5;
-const INK = ['--text', '--text-2', '--muted', '--faint'];
+const INK = ['--text', '--text-2', '--muted', '--faint', '--gold'];
 const SURFACES = ['--bg', '--bg-2', '--velvet-1', '--velvet-2'];
 
 // Worst-surface floors as measured. Raise these when a theme's ink improves; do not lower
@@ -283,12 +298,16 @@ const SURFACES = ['--bg', '--bg-2', '--velvet-1', '--velvet-2'];
 //   --faint  in every theme  — 2.28 (film-noir) to 3.53 (brownstone)
 // --faint is used for the lowest-emphasis labels; if it ever carries something a user has
 // to read, it needs darkening first, per theme.
+//   art-deco --gold  1.67:1   — and --gold is a `color:` in 35 rules. Same class of defect
+//                              as the pending sub-label, theme-wide. Gold ink on a cream
+//                              card cannot be made to work by adjusting either one; it
+//                              needs a decision about what Art Deco's accent ink IS.
 const FLOORS = {
-  aegean: { '--muted': 4.55, '--faint': 2.85 },
-  'art-deco': { '--muted': 3.65, '--faint': 2.30 },
-  brownstone: { '--muted': 6.20, '--faint': 3.50 },
-  'film-noir': { '--muted': 4.45, '--faint': 2.25 },
-  speakeasy: { '--muted': 5.20, '--faint': 3.00 },
+  aegean: { '--muted': 4.55, '--faint': 2.85, '--gold': 6.00 },
+  'art-deco': { '--muted': 3.65, '--faint': 2.30, '--gold': 1.65 },
+  brownstone: { '--muted': 6.20, '--faint': 3.50, '--gold': 8.60 },
+  'film-noir': { '--muted': 4.45, '--faint': 2.25, '--gold': 7.85 },
+  speakeasy: { '--muted': 5.20, '--faint': 3.00, '--gold': 6.95 },
 };
 
 for (const theme of THEMES) {
@@ -311,7 +330,7 @@ for (const theme of THEMES) {
   test(`secondary ink has not slipped in ${theme.name}`, () => {
     const floors = FLOORS[theme.name];
     assert.ok(floors, 'no recorded floors for theme ' + theme.name + ' — add them');
-    for (const ink of ['--muted', '--faint']) {
+    for (const ink of ['--muted', '--faint', '--gold']) {
       const fg = resolve('var(' + ink + ')', theme.vars);
       const worst = Math.min(
         ...SURFACES.map((s) => contrast(fg, resolve('var(' + s + ')', theme.vars)))
@@ -360,7 +379,11 @@ test('INK and SURFACES name real tokens in every theme', () => {
 // unchanged and the two light themes supply their own. This checks the composited result,
 // which is the only way the alpha fault shows up at all.
 
-const PENDING_WASH = 'rgba(203, 161, 78, 0.12)';
+// Read out of the rule, not restated. It was a hardcoded rgba(203, 161, 78, 0.12) when
+// this test was written and is now rgba(var(--accent-rgb), 0.12) so themes can move it —
+// a literal here would have gone on cheerfully testing a gold backdrop that no theme
+// renders any more.
+const PENDING_WASH = rule(css, '.acct-row-pending').match(/background:\s*([^;]+?)(?:\s*!important)?;/)[1].trim();
 
 for (const theme of THEMES) {
   test(`pending confirm is readable in ${theme.name}`, () => {
@@ -410,4 +433,64 @@ test('no text color anywhere resolves to a translucent token', () => {
     }
   }
   assert.deepEqual(offenders, [], 'translucent text colors:\n  ' + offenders.join('\n  '));
+});
+
+// ---------------------------------------------------------------------------
+// Accent plumbing
+// ---------------------------------------------------------------------------
+
+test('Aegean drives its accent washes off its own palette, not the gold literal', () => {
+  // The two have to move together. Recoloring --gold alone gave the reported screenshot:
+  // a cobalt check mark sitting on a Speakeasy-gold row highlight, because the wash was a
+  // hardcoded literal that no theme could reach.
+  const t = THEMES.find((x) => x.name === 'aegean');
+  assert.ok(t, 'missing aegean');
+  const wash = String(resolveRaw('var(--accent-rgb)', t.vars)).replace(/\s/g, '');
+  const border = String(resolveRaw('var(--border-rgb)', t.vars)).replace(/\s/g, '');
+  assert.ok(t.vars['--accent-rgb'], 'aegean must set --accent-rgb or its washes stay gold');
+  assert.equal(wash, border, 'aegean --accent-rgb should follow its own cobalt --border-rgb');
+  assert.equal(
+    resolve('var(--gold)', t.vars),
+    resolve('var(--purple)', t.vars),
+    'aegean --gold should be its cobalt accent, not a metallic'
+  );
+});
+
+test('the relax countdown keeps amber, whatever a theme does to --gold', () => {
+  // Green -> amber is a traffic light. Aegean's --gold is cobalt now, and this rule read
+  // --gold, so the "under a minute left" warning turned blue and the progression stopped
+  // meaning anything. --amber is metallic in every theme; --gold is not.
+  const body = rule(css, '.relax-status-dot.low');
+  assert.match(body, /background: var\(--amber\)/, 'must read --amber');
+  assert.ok(!/var\(--gold\)/.test(body), 'must not read --gold');
+});
+
+test('accent pills survive a themed --gold', () => {
+  // Their gradient hardcodes gold at the first and last stop with --gold in the middle,
+  // so a theme that recolors --gold alone gets gold-cobalt-gold.
+  for (const selector of ['.reload-banner-btn', '.host-perm-grant-btn']) {
+    const body = rule(css, selector);
+    assert.match(body, /var\(--btn-accent-mid/, selector + ' mid stop must be themeable');
+    assert.match(body, /var\(--btn-accent-top/, selector + ' top stop must be themeable');
+    assert.match(body, /var\(--btn-accent-bot/, selector + ' bottom stop must be themeable');
+    assert.match(body, /color: var\(--btn-accent-text/, selector + ' label must be themeable');
+  }
+});
+
+test('no stray Speakeasy gold is baked into a themed value', () => {
+  // 15 rules hardcoded rgba(203, 161, 78, x) for accent washes, so a theme could recolor
+  // --gold and still show Speakeasy's gold everywhere a wash appeared — which is what the
+  // Aegean account list was doing. They read --accent-rgb now. What may still be literal:
+  //   - the :root defaults themselves
+  //   - a var(--x, <literal>) fallback, which a theme overrides by setting --x
+  //   - the relax-glow amber, which is semantic and must not follow the theme
+  const offenders = [];
+  css.split('\n').forEach((line, i) => {
+    if (!line.includes('rgba(203, 161, 78')) return;
+    if (/^\s*--[a-z-]+:/.test(line)) return;            // a :root default
+    if (/var\(--[a-z-]+,\s*rgba\(203/.test(line)) return; // themeable via its own token
+    if (line.includes('--relax-glow')) return;          // semantic amber
+    offenders.push(i + 1 + ': ' + line.trim());
+  });
+  assert.deepEqual(offenders, [], 'unthemeable gold literals:\n  ' + offenders.join('\n  '));
 });

--- a/test/wrong-account-escape.test.js
+++ b/test/wrong-account-escape.test.js
@@ -8,18 +8,25 @@
 // there's no control at all — and no indication that cancelling and reconnecting is the
 // way out. Users hit this and concluded Sidecar was stuck.
 //
-// The fix is a hint plus one action, not a picker:
+// The fix, on both approval surfaces:
 //
 //   Not the right account?
-//   Cancel and login with another identity.   <- clickable, rejects the request
+//   Detach and use another identity.          <- collapsed; expands to the account list
+//     Picks who this site uses next, everywhere in Sidecar. Cancels this request ...
+//     [ accounts, globally-active first and tagged, current signer excluded ]
 //
-// An earlier cut listed every account and rebound the host on a pick. It was dropped
-// because the only honest outcome was still "canceled — now reconnect on the site": the
-// event the client built carries the pubkey the client still has cached, so signing it as
-// someone else yields one correct event and then silent reverts. With eight accounts in
-// the keystore that was a long scroll offering a choice that changed nothing. So there is
-// no 'rebind' decision to test — only that the hint appears in the right places, on both
-// surfaces, with matching copy, and that its line actually rejects.
+// Picking a row DETACHES the host (clears its binding), makes that account active, and
+// rejects the request. That is the same primitive as Settings -> Sites -> "Use <account>"
+// (switchSiteModal in sidepanel.js) — the fix already existed, three levels into Settings,
+// and the prompt is where the problem is actually discovered.
+//
+// Detach, not rebind: clearing the binding means the next getPublicKey re-pairs the host to
+// whatever is active, so setActive is the line that decides who the user comes back as.
+// Writing a new binding instead would pin an identity the site hasn't approved.
+//
+// Never "sign this one as them": the event the client built carries the pubkey the client
+// still has cached, so signing it under another identity yields one correct event and then
+// silent reverts on the next. That reads as working and isn't.
 //
 // The gate is deliberately BROAD — any content sign, 2+ accounts, no switcher already
 // showing. Two earlier cuts tried to detect that the account was "pinned" (by a host
@@ -46,6 +53,7 @@ const css = fs.readFileSync(path.join(ROOT, 'styles.css'), 'utf8');
 
 const PK_A = 'a'.repeat(64);
 const PK_B = 'b'.repeat(64);
+const HOST = 'jumble.social';
 
 // ---------------------------------------------------------------------------
 // 1. The payload gate
@@ -123,34 +131,165 @@ test('relay auth is excluded via isContentSign, not a separate term', () => {
 // of dead code that gets mistaken for a working feature later ('block' in background.js
 // was already discovered to be dead this way).
 
-test("no 'rebind' decision exists in the background", () => {
-  assert.ok(!/decision\.action === 'rebind'/.test(background), 'rebind branch should be gone');
-  assert.ok(!/rebindPubkey/.test(background), 'rebindPubkey should be gone');
+test('the action detaches the binding, never writes a new one', () => {
+  // Rebinding would pin an identity the site hasn't approved, and would diverge from the
+  // Settings -> Sites route, leaving two behaviors to reason about instead of one.
+  const br = liftDetach();
+  assert.match(br, /clearSiteAccount\(host\)/, 'must clear the binding');
+  assert.ok(!/setSiteAccount/.test(br), 'must not write a new binding');
+  assert.ok(!/'rebind'/.test(background), 'the old rebind action should be gone');
 });
 
-test("no surface sends a 'rebind' decision", () => {
-  for (const [label, src] of [['sidepanel.js', sidepanelJs], ['prompt.js', promptJs]]) {
-    assert.ok(!/'rebind'/.test(src), label + ' should not reference a rebind action');
-    assert.ok(!/rebindPubkey/.test(src), label + ' should not send rebindPubkey');
+test('the offered list excludes the account already being shown', () => {
+  // Detaching to re-pick the same identity is a no-op with extra steps.
+  const m = background.match(/const escapeAccounts = st\.accounts\s*\n\s*\.filter\((.*)\)\n/);
+  assert.ok(m, 'escapeAccounts should filter st.accounts');
+  assert.match(m[1], /a\.pubkey !== activePubkey/);
+});
+
+test('the offered list is built from every account, not the authorized set', () => {
+  // The account the user wants is the one that ISN'T authorized on this host yet, so
+  // sourcing this from `otherAccounts` (host-scoped) would leave it empty in exactly the
+  // case that matters.
+  const m = background.match(/const escapeAccounts = (st\.accounts|otherAccounts)/);
+  assert.ok(m);
+  assert.equal(m[1], 'st.accounts');
+});
+
+test('the globally-active account sorts first and is flagged', () => {
+  // With eight accounts the likeliest pick must not be buried, and an unexplained top row
+  // reads as arbitrary — hence both the sort and the flag the UI tags.
+  assert.match(background, /active: a\.pubkey === globalActivePubkey/);
+  assert.match(background, /escapeAccounts\.sort\(\(x, y\) => \(y\.active \? 1 : 0\) - \(x\.active \? 1 : 0\)\)/);
+  assert.match(background, /const globalActivePubkey = await KS\.getActivePubkey\(\)/);
+});
+
+// ---------------------------------------------------------------------------
+// 2b. The detach decision branch
+// ---------------------------------------------------------------------------
+
+function liftDetach() {
+  const m = background.match(/ {6}if \(decision\.action === 'detach'\) \{[\s\S]*?\n {6}\}/);
+  if (!m) throw new Error("Could not find the detach branch in background.js");
+  return m[0];
+}
+
+async function runDetach({ target, accounts = [PK_A, PK_B], status = 'ask' }) {
+  const calls = [];
+  const ctx = {
+    decision: { action: 'detach', detachPubkey: target },
+    host: HOST,
+    method: 'signEvent',
+    st: { accounts: accounts.map((pk) => ({ pubkey: pk, name: 'Acct ' + pk[0] })) },
+    KS: {
+      hasAccount: async (pk) => accounts.includes(pk),
+      setActive: async (pk) => calls.push(['setActive', pk]),
+    },
+    PERMS: { getPermissionStatus: async () => status },
+    RELAX: { revokeForHost: async (h) => calls.push(['revokeForHost', h]) },
+    clearSiteAccount: async (h) => calls.push(['clearSiteAccount', h]),
+    syncRelaxBadge: () => calls.push(['syncRelaxBadge']),
+    Error,
+  };
+  vm.createContext(ctx);
+  let threw = null;
+  try {
+    await vm.runInContext('(async () => {\n' + liftDetach() + '\n})()', ctx);
+  } catch (e) {
+    threw = e;
+  }
+  return { calls, threw };
+}
+
+test('detach clears the host binding', async () => {
+  const { calls } = await runDetach({ target: PK_B });
+  assert.deepEqual(calls.filter((c) => c[0] === 'clearSiteAccount'), [['clearSiteAccount', HOST]]);
+});
+
+test('detach makes the chosen account active', async () => {
+  // This is the line that decides who the user comes back as — clearing alone would let
+  // the reconnect land on whatever happened to be active.
+  const { calls } = await runDetach({ target: PK_B });
+  assert.deepEqual(calls.filter((c) => c[0] === 'setActive'), [['setActive', PK_B]]);
+});
+
+test('detach revokes any relax window on the host', async () => {
+  // The auto-sign window was earned by the identity being left. Left standing it would
+  // auto-approve the next request for the one arriving.
+  const { calls } = await runDetach({ target: PK_B });
+  assert.deepEqual(calls.filter((c) => c[0] === 'revokeForHost'), [['revokeForHost', HOST]]);
+  assert.ok(calls.some((c) => c[0] === 'syncRelaxBadge'), 'badge should re-sync after the revoke');
+});
+
+test('detach always throws — it never returns to the signer', async () => {
+  const { threw } = await runDetach({ target: PK_B });
+  assert.ok(threw instanceof Error, 'detach must not fall through to signing');
+});
+
+test('the detach error names the host and the account to reconnect as', async () => {
+  const { threw } = await runDetach({ target: PK_B });
+  assert.match(threw.message, new RegExp(HOST));
+  assert.match(threw.message, /sign out and back in as/i);
+  assert.match(threw.message, /Acct b/);
+});
+
+test('detach to an account that no longer exists changes nothing', async () => {
+  const { calls, threw } = await runDetach({ target: 'c'.repeat(64) });
+  assert.ok(threw instanceof Error);
+  assert.match(threw.message, /no longer available/i);
+  assert.deepEqual(calls, [], 'a missing account must not touch the binding');
+});
+
+test('detach with a missing pubkey changes nothing', async () => {
+  const { calls, threw } = await runDetach({ target: '' });
+  assert.ok(threw instanceof Error);
+  assert.deepEqual(calls, []);
+});
+
+test('detach to an account blocked on this host changes nothing', async () => {
+  // The user blocked this site for that identity; honoring the pick would quietly undo it.
+  const { calls, threw } = await runDetach({ target: PK_B, status: 'reject' });
+  assert.ok(threw instanceof Error);
+  assert.match(threw.message, /blocked/i);
+  assert.deepEqual(calls, [], 'a blocked target must not touch the binding');
+});
+
+test('the detach branch runs before the block and trust branches', () => {
+  // All three throw or settle; whichever comes first wins.
+  const iDetach = background.indexOf("decision.action === 'detach'");
+  const iBlock = background.indexOf("decision.action === 'block'");
+  const iTrust = background.indexOf("decision.action === 'trust'");
+  assert.ok(iDetach > 0 && iBlock > 0 && iTrust > 0);
+  assert.ok(iDetach < iBlock, 'detach should precede block');
+  assert.ok(iDetach < iTrust, 'detach should precede trust');
+});
+
+test("'detach' is not treated as an approval by the decrypt coalescing", () => {
+  // settlePrompt grants a short decrypt window on 'once'/'trust'. detach is a refusal; if
+  // it matched there it would hand the site a decrypt grant on the way out.
+  const m = background.match(/if \(action === 'reject'\) \{[\s\S]*?grantDecrypt\(host, activePubkey\);/);
+  assert.ok(m, 'could not find the decrypt-coalescing branch');
+  assert.ok(!/detach/.test(m[0]), 'detach must not appear in the decrypt grant path');
+});
+
+test("'detach' is not batched across a grouped burst", () => {
+  // Allow all / Reject all fan one decision across a same-kind burst. Detaching is a
+  // per-site identity change, not something to apply N times.
+  for (const src of [sidepanelJs, promptJs]) {
+    const m = src.match(/groupIds\.length > 1 && \(([^)]*)\)/);
+    if (m) assert.ok(!/detach/.test(m[1]), 'detach must not be in the batch predicate');
   }
 });
 
-test('the payload no longer carries an account list for the hint', () => {
-  // allAccounts existed only to render the picker.
-  assert.ok(!/allAccounts/.test(background), 'allAccounts should be gone from the payload');
-  for (const [label, src] of [['sidepanel.js', sidepanelJs], ['prompt.js', promptJs]]) {
-    assert.ok(!/allAccounts/.test(src), label + ' should not read allAccounts');
-  }
-});
-
-test('the unlock gate is back to the three actions that sign', () => {
-  // rebind was gated on unlock because it mutated persistent state. With it gone the
-  // gate should cover exactly the signing actions again — and never reject.
+test('detach needs the PIN when the keystore is locked', () => {
+  // It signs nothing, but it clears the binding and moves the GLOBAL active account.
+  // Without this a locked prompt is the one surface that can change persistent state with
+  // no authentication, reachable by anyone who can make a site request a signature.
   for (const [label, src] of [['sidepanel.js', sidepanelJs], ['prompt.js', promptJs]]) {
     const m = src.match(/if \(data\.needUnlock && \(([^)]*)\)\)/);
     assert.ok(m, 'could not find the needUnlock gate in ' + label);
-    const actions = m[1].match(/'[a-z]+'/g).map((x) => x.slice(1, -1)).sort();
-    assert.deepEqual(actions, ['once', 'relax', 'trust'], label);
+    assert.match(m[1], /action === 'detach'/, label + ' should gate detach on unlock');
+    assert.ok(!/'reject'/.test(m[1]), label + ': reject must never need a PIN');
   }
 });
 
@@ -163,77 +302,84 @@ test('the unlock gate is back to the three actions that sign', () => {
 // before.
 
 const COPY_TITLE = 'Not the right account?';
-const COPY_BODY = 'Cancel and login with another identity.';
+const COPY_TOGGLE = 'Detach and use another identity.';
+const COPY_LEDE = 'Picks who this site uses next, everywhere in Sidecar. Cancels this request — sign out and back in on ';
 
-test('both surfaces carry the hint element', () => {
+test('both surfaces carry the hint, the toggle and the list', () => {
   assert.match(sidepanelHtml, /id="approval-wrong-acct"/);
+  assert.match(sidepanelHtml, /id="approval-wrong-acct-toggle"/);
+  assert.match(sidepanelHtml, /id="approval-wrong-acct-list"/);
   assert.match(promptHtml, /id="wrong-acct"/);
+  assert.match(promptHtml, /id="wrong-acct-toggle"/);
+  assert.match(promptHtml, /id="wrong-acct-list"/);
 });
 
-test('both surfaces start hidden', () => {
+test('both surfaces start hidden and collapsed', () => {
   assert.match(sidepanelHtml, /class="approval-wrong-acct hidden"/);
+  assert.match(sidepanelHtml, /class="approval-wrong-acct-list hidden"/);
   assert.match(promptHtml, /class="wrong-acct hidden"/);
+  assert.match(promptHtml, /class="wrong-acct-list hidden"/);
 });
 
-test('both surfaces use the same copy, word for word', () => {
-  // Two files, one sentence. Drift here means two different explanations of the same
-  // situation depending on whether the panel happened to be open.
+test('both surfaces use the same title and toggle copy, word for word', () => {
+  // Two files, one explanation. Drift means the same situation reads differently depending
+  // on whether the panel happened to be open.
   for (const [label, src] of [['sidepanel.html', sidepanelHtml], ['prompt.html', promptHtml]]) {
     assert.ok(src.includes('<strong>' + COPY_TITLE + '</strong>'), label + ' title');
-    assert.ok(src.includes('>' + COPY_BODY + '</button>'), label + ' body');
+    assert.ok(src.includes('>' + COPY_TOGGLE + '</button>'), label + ' toggle');
   }
 });
 
-test('the copy says cancel, not switch', () => {
-  // The hint must not imply Sidecar can sign this request as someone else — it can't,
-  // and promising it was the flaw in the picker.
-  for (const src of [sidepanelHtml, promptHtml]) {
-    assert.match(src, /Cancel and login with/);
-    assert.ok(!/Pick who this site should use/.test(src), 'leftover picker copy');
-  }
-});
-
-test('the cancel line is a button on both surfaces', () => {
-  // Plain text left the user reading advice with nothing to act on.
-  assert.match(sidepanelHtml, /<button class="approval-wrong-acct-cancel" id="approval-wrong-acct-cancel">/);
-  assert.match(promptHtml, /<button class="wrong-acct-cancel" id="wrong-acct-cancel">/);
-});
-
-test('the cancel line rejects, on both surfaces', () => {
-  assert.match(sidepanelJs, /\$\('approval-wrong-acct-cancel'\)\.addEventListener\('click', \(\) => decideApproval\('reject'\)\)/);
-  assert.match(promptJs, /els\.wrongAcctCancel\.addEventListener\('click', \(\) => decide\('reject'\)\)/);
-});
-
-test('the cancel line never signs', () => {
-  // One character away from being the worst bug in the extension: a control the user
-  // taps *because* the identity is wrong must not approve under that identity.
-  const BINDINGS = [
-    ['sidepanel.js', sidepanelJs, /\$\('approval-wrong-acct-cancel'\)\.addEventListener\([^;]*;/],
-    ['prompt.js', promptJs, /els\.wrongAcctCancel\.addEventListener\([^;]*;/],
-  ];
-  for (const [label, src, re] of BINDINGS) {
-    const m = src.match(re);
-    assert.ok(m, 'could not find the cancel binding in ' + label);
-    assert.match(m[0], /'reject'/, label + ': cancel must send reject');
-    assert.ok(!/'once'|'trust'|'relax'|'budget'/.test(m[0]), label + ': cancel must not approve');
-  }
-});
-
-test('the popup binds cancel directly, not via els.reject', () => {
-  // init() replaces els.reject with a plain Close button when the request has already
-  // expired. Forwarding through it would leave cancel wired to a stale node.
-  const m = promptJs.match(/els\.wrongAcctCancel\.addEventListener\([^)]*\)[^;]*;/);
-  assert.ok(m, 'could not find the popup cancel binding');
-  assert.ok(!/els\.reject/.test(m[0]), 'must not forward through els.reject');
-});
-
-test('the cancel line is not disabled by the destructive lock', () => {
-  // setApprovalLocked / setLocked gate Allow + Trust behind "I understand". The way out
-  // is never gated — same rule that keeps Reject enabled.
+test('both surfaces use the same lede copy, word for word', () => {
   for (const [label, src] of [['sidepanel.js', sidepanelJs], ['prompt.js', promptJs]]) {
-    const fn = src.match(/function set(?:Approval)?Locked\(locked\) \{[\s\S]*?\n {2}\}/);
-    assert.ok(fn, label);
-    assert.ok(!/wrongAcct|wrong-acct/.test(fn[0]), label + ': cancel must stay enabled');
+    assert.ok(src.includes(COPY_LEDE), label + ' lede');
+  }
+});
+
+test('the lede says the account change is global', () => {
+  // detach + setActive moves the GLOBAL active account, not just this site's. That is the
+  // coherent thing to do, but a silent global state change from a signing prompt is how you
+  // get a confused report a month later.
+  for (const src of [sidepanelJs, promptJs]) {
+    assert.match(src, /everywhere in Sidecar/);
+    assert.match(src, /Cancels this request/);
+  }
+});
+
+test('the copy never promises to sign as the other account', () => {
+  // The one thing Sidecar cannot honestly offer here.
+  for (const src of [sidepanelHtml, promptHtml, sidepanelJs, promptJs]) {
+    assert.ok(!/[Ss]ign (this|it) as/.test(src), 'must not offer to sign as another account');
+  }
+});
+
+test('the toggle is a button on both surfaces', () => {
+  assert.match(sidepanelHtml, /<button class="approval-wrong-acct-toggle" id="approval-wrong-acct-toggle"/);
+  assert.match(promptHtml, /<button class="wrong-acct-toggle" id="wrong-acct-toggle"/);
+});
+
+test('picking a row sends detach with that pubkey, on both surfaces', () => {
+  assert.match(sidepanelJs, /decideApproval\('detach', \{ detachPubkey: a\.pubkey \}\)/);
+  assert.match(promptJs, /decide\('detach', \{ detachPubkey: a\.pubkey \}\)/);
+});
+
+test('picking a row never approves', () => {
+  // One character away from the worst bug in the extension: a control tapped *because* the
+  // identity is wrong must not approve under that identity.
+  for (const [label, src] of [['sidepanel.js', sidepanelJs], ['prompt.js', promptJs]]) {
+    const fn = src.match(/function buildWrongAcctList\([\s\S]*?\n {2}\}/);
+    assert.ok(fn, 'could not find buildWrongAcctList in ' + label);
+    const m = fn[0].match(/row\.addEventListener\('click',[^;]*;/);
+    assert.ok(m, 'could not find the row binding in ' + label);
+    assert.match(m[0], /'detach'/, label + ': row must send detach');
+    assert.ok(!/'once'|'trust'|'relax'|'budget'|'reject'/.test(m[0]), label + ': row must not approve');
+  }
+});
+
+test('the active account is tagged on both surfaces', () => {
+  for (const [label, src] of [['sidepanel.js', sidepanelJs], ['prompt.js', promptJs]]) {
+    assert.match(src, /a\.active/, label + ' should read the active flag');
+    assert.match(src, /'Active'/, label + ' should render the tag');
   }
 });
 
@@ -242,38 +388,79 @@ test('both surfaces gate the hint on the payload flag', () => {
   assert.match(promptJs, /data\.wrongAccountEscape/);
 });
 
+test('both surfaces read the account list from allAccounts', () => {
+  assert.match(sidepanelJs, /Array\.isArray\(data\.allAccounts\)/);
+  assert.match(promptJs, /Array\.isArray\(data\.allAccounts\)/);
+});
+
+test('an empty account list hides the hint entirely', () => {
+  // The gate can be true while the list is empty (every other account deleted). A visible
+  // "Detach and use another identity" that expands to nothing is worse than no hint.
+  assert.match(sidepanelJs, /!data\.wrongAccountEscape \|\| !accts\.length/);
+  assert.match(promptJs, /!data\.wrongAccountEscape \|\| !accts\.length/);
+});
+
 test('the hint is re-evaluated every time an approval is shown', () => {
-  // Not once at load: the panel re-renders on queue advance and unlock, and a hint left
-  // standing from a previous request would advise cancelling a prompt that is fine.
+  // Not once at load: the panel re-shows the approval on queue advance and unlock.
   assert.match(sidepanelJs, /renderApprovalAccountCapsule\(data\);\s*\n\s*renderWrongAcctEscape\(data\);/);
   assert.match(promptJs, /buildAccountCapsule\(\);\s*\n\s*buildWrongAcct\(\);/);
 });
 
+test('the list re-collapses on every render', () => {
+  // An expanded list left over from the previous request would offer to detach a different
+  // host than the one now on screen.
+  const panel = sidepanelJs.match(/function renderWrongAcctEscape\(data\) \{[\s\S]*?\n {2}\}/)[0];
+  assert.match(panel, /list\.innerHTML = '';/);
+  assert.match(panel, /hide\(list\);/);
+  assert.match(panel, /setAttribute\('aria-expanded', 'false'\)/);
+  const popup = promptJs.match(/function buildWrongAcct\(\) \{[\s\S]*?\n {2}\}/)[0];
+  assert.match(popup, /innerHTML = '';/);
+  assert.match(popup, /classList\.add\('hidden'\)/);
+  assert.match(popup, /setAttribute\('aria-expanded', 'false'\)/);
+});
+
 test('the hint hides again when the flag is false', () => {
   // A show-only render leaks the hint onto the next request in the queue.
-  assert.match(sidepanelJs, /if \(data\.wrongAccountEscape\) show\(hint\);\s*\n\s*else hide\(hint\);/);
-  assert.match(promptJs, /classList\.toggle\('hidden', !data\.wrongAccountEscape\)/);
+  assert.match(sidepanelJs, /hide\(hint\);/);
+  assert.match(promptJs, /els\.wrongAcct\.classList\.toggle\('hidden', !data\.wrongAccountEscape/);
 });
 
-test('the hint has styles on both surfaces', () => {
-  assert.match(css, /\.approval-wrong-acct \{/);
-  assert.match(css, /\.approval-wrong-acct strong \{/);
-  assert.match(promptHtml, /\.wrong-acct \{/);
-  assert.match(promptHtml, /\.wrong-acct strong \{/);
+test('account names and the host are set as text, never as HTML', () => {
+  // Profile metadata and the host are both attacker-controlled.
+  for (const [label, src] of [['sidepanel.js', sidepanelJs], ['prompt.js', promptJs]]) {
+    const fn = src.match(/function buildWrongAcctList\([\s\S]*?\n {2}\}/);
+    assert.ok(fn, 'could not find buildWrongAcctList in ' + label);
+    assert.ok(!/innerHTML\s*=\s*[^']/.test(fn[0].replace(/innerHTML = '';/g, '')),
+      label + ' should not assign untrusted innerHTML');
+    assert.match(fn[0], /textContent/);
+  }
 });
 
-test('the cancel line is de-emphasized, not accented', () => {
+test('the toggle is de-emphasized, not accented', () => {
   // At --lav it competed with the account capsule directly above, which is the thing the
   // user actually needs to read on a signing screen. The underline carries the affordance.
   for (const [label, src, sel] of [
-    ['styles.css', css, '.approval-wrong-acct-cancel'],
-    ['prompt.html', promptHtml, '.wrong-acct-cancel'],
+    ['styles.css', css, '.approval-wrong-acct-toggle'],
+    ['prompt.html', promptHtml, '.wrong-acct-toggle'],
   ]) {
     const blk = src.match(new RegExp('\\' + sel + ' \\{[^}]*\\}'));
     assert.ok(blk, 'could not find ' + sel + ' in ' + label);
     assert.match(blk[0], /color: var\(--muted\)/, label + ': should use the secondary color');
     assert.ok(!/var\(--lav\)/.test(blk[0]), label + ': should not use the accent');
     assert.match(blk[0], /text-decoration: underline/, label + ': needs the link affordance');
+  }
+});
+
+test('the hint has styles on both surfaces', () => {
+  for (const sel of ['.approval-wrong-acct ', '.approval-wrong-acct-toggle ', '.approval-wrong-acct-list ']) {
+    assert.ok(css.includes(sel + '{'), 'styles.css missing ' + sel);
+  }
+  for (const sel of ['.wrong-acct ', '.wrong-acct-toggle ', '.wrong-acct-list ']) {
+    assert.ok(promptHtml.includes(sel + '{'), 'prompt.html missing ' + sel);
+  }
+  for (const src of [css, promptHtml]) {
+    assert.ok(src.includes('.wrong-acct-lede {'), 'missing the lede style');
+    assert.ok(src.includes('.wrong-acct-tag {'), 'missing the active-tag style');
   }
 });
 
@@ -287,7 +474,7 @@ test('the popup hint only uses CSS variables that exist', () => {
   );
   for (const src of files) for (const m of src.matchAll(/(--[a-z0-9-]+)\s*:/g)) defined.add(m[1]);
   for (const [label, src] of [['prompt.html', promptHtml], ['styles.css', css]]) {
-    for (const blk of src.matchAll(/\.(?:approval-)?wrong-acct[^{]*\{[^}]*\}/g)) {
+    for (const blk of src.matchAll(/\.(?:approval-)?wrong-acct[a-z-]*[^{]*\{[^}]*\}/g)) {
       for (const v of blk[0].matchAll(/var\((--[a-z0-9-]+)/g)) {
         assert.ok(defined.has(v[1]), label + ' uses undefined ' + v[1]);
       }

--- a/test/wrong-account-escape.test.js
+++ b/test/wrong-account-escape.test.js
@@ -303,7 +303,7 @@ test('detach needs the PIN when the keystore is locked', () => {
 
 const COPY_TITLE = 'Not the right account?';
 const COPY_TOGGLE = 'Detach and use another identity.';
-const COPY_LEDE = 'Picks who this site uses next, everywhere in Sidecar. Cancels this request — sign out and back in on ';
+const COPY_LEDE = 'Cancels this request and makes that account active.';
 
 test('both surfaces carry the hint, the toggle and the list', () => {
   assert.match(sidepanelHtml, /id="approval-wrong-acct"/);
@@ -331,19 +331,57 @@ test('both surfaces use the same title and toggle copy, word for word', () => {
 });
 
 test('both surfaces use the same lede copy, word for word', () => {
-  for (const [label, src] of [['sidepanel.js', sidepanelJs], ['prompt.js', promptJs]]) {
-    assert.ok(src.includes(COPY_LEDE), label + ' lede');
+  // Exact equality on the extracted literal, not `includes`. A substring check passed when
+  // one surface's lede grew an extra sentence, which is precisely the drift it was meant to
+  // catch — parity claims have to be pinned at both ends of the string.
+  const LEDE_RE = [
+    ['sidepanel.js', sidepanelJs, /className: 'wrong-acct-lede', textContent: '([^']*)'/],
+    ['prompt.js', promptJs, /lede\.textContent = '([^']*)';/],
+  ];
+  for (const [label, src, re] of LEDE_RE) {
+    const m = src.match(re);
+    assert.ok(m, 'could not extract the lede literal from ' + label);
+    assert.equal(m[1], COPY_LEDE, label + ' lede must match exactly');
   }
 });
 
-test('the lede says the account change is global', () => {
-  // detach + setActive moves the GLOBAL active account, not just this site's. That is the
-  // coherent thing to do, but a silent global state change from a signing prompt is how you
-  // get a confused report a month later.
+test('the lede carries both facts the user cannot learn afterwards', () => {
+  // That it cancels, and that the switch is app-wide rather than just this site. Everything
+  // else was cut — three lines of lede in a sidebar was too much.
   for (const src of [sidepanelJs, promptJs]) {
-    assert.match(src, /everywhere in Sidecar/);
     assert.match(src, /Cancels this request/);
+    assert.match(src, /makes that account active/);
   }
+});
+
+test('the lede does not pre-announce the reconnect instruction', () => {
+  // It arrives as a toast the moment detach settles, with the account name filled in —
+  // which the lede can't do. Saying it twice is what made this three lines deep.
+  for (const [label, src] of [['sidepanel.js', sidepanelJs], ['prompt.js', promptJs]]) {
+    const fn = src.match(/function buildWrongAcctList\([\s\S]*?\n {2}\}/)[0];
+    const lede = fn.match(/wrong-acct-lede[\s\S]*?;/)[0];
+    assert.ok(!/sign out/i.test(lede), label + ': reconnect instruction belongs in the toast');
+  }
+});
+
+test('a settled detach toasts the reconnect instruction in Sidecar', () => {
+  // The background throws the same instruction as the signing error, but that goes to the
+  // CLIENT. A client that swallows signing errors would leave the user with no next step.
+  const fn = sidepanelJs.match(/async function decideApproval\(action, opts\) \{[\s\S]*?\n {2}\}/)[0];
+  const blk = fn.match(/if \(action === 'detach'\) \{[\s\S]*?\n {4}\}/g) || [];
+  const toastBlk = blk.find((b) => /toast\(/.test(b));
+  assert.ok(toastBlk, 'decideApproval should toast after a detach');
+  assert.match(toastBlk, /Sign out of/);
+  assert.match(toastBlk, /back in as/);
+  assert.match(toastBlk, /detachPubkey/, 'should name the account that was picked');
+});
+
+test('the detach toast reads the same as the Settings route', () => {
+  // switchSiteModal already toasts this. Two wordings for one outcome is how the same fix
+  // starts looking like two different features.
+  const settings = sidepanelJs.match(/toast\('Detached\. Sign out of ' \+ host[^;]*;/);
+  assert.ok(settings, 'could not find switchSiteModal toast');
+  assert.match(sidepanelJs, /'Detached\. Sign out of ' \+ data\.host \+ ' and back in as ' \+/);
 });
 
 test('the copy never promises to sign as the other account', () => {

--- a/test/wrong-account-escape.test.js
+++ b/test/wrong-account-escape.test.js
@@ -1,0 +1,296 @@
+'use strict';
+
+// Coverage for the "wrong account" hint on the signing approval.
+//
+// The problem: a client and Sidecar can disagree about which account is signed in, and
+// the approval then names an identity the user didn't pick. The existing account switcher
+// only appears once 2+ accounts have logged in on that host, so on a single-login host
+// there's no control at all — and no indication that cancelling and reconnecting is the
+// way out. Users hit this and concluded Sidecar was stuck.
+//
+// The fix is a hint plus one action, not a picker:
+//
+//   Not the right account?
+//   Cancel and login with another identity.   <- clickable, rejects the request
+//
+// An earlier cut listed every account and rebound the host on a pick. It was dropped
+// because the only honest outcome was still "canceled — now reconnect on the site": the
+// event the client built carries the pubkey the client still has cached, so signing it as
+// someone else yields one correct event and then silent reverts. With eight accounts in
+// the keystore that was a long scroll offering a choice that changed nothing. So there is
+// no 'rebind' decision to test — only that the hint appears in the right places, on both
+// surfaces, with matching copy, and that its line actually rejects.
+//
+// The gate is deliberately BROAD — any content sign, 2+ accounts, no switcher already
+// showing. Two earlier cuts tried to detect that the account was "pinned" (by a host
+// binding, or by a client stamping the author pubkey on the template) and both were
+// wrong: pin detection can only ever remove a working hint, and the case that matters
+// most has no pin to detect. A client showing account A while Sidecar's active account is
+// B leaves nothing for Sidecar to observe — it cannot see the client's UI. Only the user
+// can, which is the whole reason the hint exists. The tests below pin that breadth down,
+// because it is the part most likely to get "tightened" back.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const ROOT = path.join(__dirname, '..');
+const background = fs.readFileSync(path.join(ROOT, 'background.js'), 'utf8');
+const sidepanelJs = fs.readFileSync(path.join(ROOT, 'sidepanel.js'), 'utf8');
+const sidepanelHtml = fs.readFileSync(path.join(ROOT, 'sidepanel.html'), 'utf8');
+const promptJs = fs.readFileSync(path.join(ROOT, 'prompt.js'), 'utf8');
+const promptHtml = fs.readFileSync(path.join(ROOT, 'prompt.html'), 'utf8');
+const css = fs.readFileSync(path.join(ROOT, 'styles.css'), 'utf8');
+
+const PK_A = 'a'.repeat(64);
+const PK_B = 'b'.repeat(64);
+
+// ---------------------------------------------------------------------------
+// 1. The payload gate
+// ---------------------------------------------------------------------------
+//
+// Lifted verbatim from background.js rather than restated, so a change to the real
+// condition either shows up here or breaks the lift.
+
+function liftGate() {
+  const m = background.match(/wrongAccountEscape: (.*),\n/);
+  if (!m) throw new Error('Could not find the wrongAccountEscape gate in background.js');
+  return m[1];
+}
+
+function gate({ isContentSign, sharedIdentity, accounts }) {
+  const ctx = { isContentSign, sharedIdentity, st: { accounts } };
+  vm.createContext(ctx);
+  return vm.runInContext('(' + liftGate() + ')', ctx);
+}
+
+const TWO = [{ pubkey: PK_A }, { pubkey: PK_B }];
+
+test('hint shows on a content sign with more than one account', () => {
+  assert.equal(gate({ isContentSign: true, sharedIdentity: false, accounts: TWO }), true);
+});
+
+test('the gate does not consult the binding or the author stamp', () => {
+  // This is the breadth guarantee, and it is the whole fix. Both pins were tried and
+  // both were wrong, because the case that matters most has NO pin to detect: the client
+  // is displaying account A, Sidecar's active account is B, there is no binding and no
+  // author stamp. None of that is observable from the extension — it cannot see the
+  // client's UI. The prompt simply names the wrong identity and the user is the only one
+  // who can tell.
+  //
+  // Asserted against the gate's source, not its result, because a value-level test can't
+  // distinguish "ignores the binding" from "the binding happened to be set".
+  const src = liftGate();
+  assert.ok(!/getSiteAccount/.test(src), 'gate must not depend on a host binding');
+  assert.ok(!/authorSwitched/.test(src), 'gate must not depend on a client author stamp');
+});
+
+test('hint is hidden with a single account in the keystore', () => {
+  // Nothing to log in as.
+  assert.equal(gate({ isContentSign: true, sharedIdentity: false, accounts: [{ pubkey: PK_A }] }), false);
+});
+
+test('hint is hidden on a shared-identity host', () => {
+  // 2+ accounts have logged in here, so the real switcher is already on screen and the
+  // user can just pick — telling them to cancel and reconnect would be worse advice.
+  assert.equal(gate({ isContentSign: true, sharedIdentity: true, accounts: TWO }), false);
+});
+
+test('hint is hidden when the request is not a content sign', () => {
+  // Payments and getPublicKey both land here. A payment names the wallet, not a signing
+  // identity, so "wrong account" has no meaning on that screen; getPublicKey already
+  // gets the real switcher.
+  assert.equal(gate({ isContentSign: false, sharedIdentity: false, accounts: TWO }), false);
+});
+
+test('relay auth is excluded via isContentSign, not a separate term', () => {
+  // isContentSign is (signEvent && !isRelayAuth) || encrypt, so a kind 22242 auth event
+  // can never reach the hint. Asserting that implication rather than passing the
+  // impossible isContentSign+isRelayAuth pair an earlier version of this test used.
+  const m = background.match(/const isContentSign =\n([\s\S]*?);\n/);
+  assert.ok(m, 'could not find isContentSign');
+  assert.match(m[1], /method === 'signEvent' && !isRelayAuth/);
+});
+
+// ---------------------------------------------------------------------------
+// 2. No rebind machinery survives
+// ---------------------------------------------------------------------------
+//
+// The picker was removed deliberately. These guard against half of it coming back — a
+// 'rebind' action no surface sends, or a payload field nothing reads, is exactly the kind
+// of dead code that gets mistaken for a working feature later ('block' in background.js
+// was already discovered to be dead this way).
+
+test("no 'rebind' decision exists in the background", () => {
+  assert.ok(!/decision\.action === 'rebind'/.test(background), 'rebind branch should be gone');
+  assert.ok(!/rebindPubkey/.test(background), 'rebindPubkey should be gone');
+});
+
+test("no surface sends a 'rebind' decision", () => {
+  for (const [label, src] of [['sidepanel.js', sidepanelJs], ['prompt.js', promptJs]]) {
+    assert.ok(!/'rebind'/.test(src), label + ' should not reference a rebind action');
+    assert.ok(!/rebindPubkey/.test(src), label + ' should not send rebindPubkey');
+  }
+});
+
+test('the payload no longer carries an account list for the hint', () => {
+  // allAccounts existed only to render the picker.
+  assert.ok(!/allAccounts/.test(background), 'allAccounts should be gone from the payload');
+  for (const [label, src] of [['sidepanel.js', sidepanelJs], ['prompt.js', promptJs]]) {
+    assert.ok(!/allAccounts/.test(src), label + ' should not read allAccounts');
+  }
+});
+
+test('the unlock gate is back to the three actions that sign', () => {
+  // rebind was gated on unlock because it mutated persistent state. With it gone the
+  // gate should cover exactly the signing actions again — and never reject.
+  for (const [label, src] of [['sidepanel.js', sidepanelJs], ['prompt.js', promptJs]]) {
+    const m = src.match(/if \(data\.needUnlock && \(([^)]*)\)\)/);
+    assert.ok(m, 'could not find the needUnlock gate in ' + label);
+    const actions = m[1].match(/'[a-z]+'/g).map((x) => x.slice(1, -1)).sort();
+    assert.deepEqual(actions, ['once', 'relax', 'trust'], label);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 3. Both surfaces
+// ---------------------------------------------------------------------------
+//
+// Approvals render in the side panel AND in the standalone popup window. These are
+// separate implementations of the same screen, and a change to one has shipped half-done
+// before.
+
+const COPY_TITLE = 'Not the right account?';
+const COPY_BODY = 'Cancel and login with another identity.';
+
+test('both surfaces carry the hint element', () => {
+  assert.match(sidepanelHtml, /id="approval-wrong-acct"/);
+  assert.match(promptHtml, /id="wrong-acct"/);
+});
+
+test('both surfaces start hidden', () => {
+  assert.match(sidepanelHtml, /class="approval-wrong-acct hidden"/);
+  assert.match(promptHtml, /class="wrong-acct hidden"/);
+});
+
+test('both surfaces use the same copy, word for word', () => {
+  // Two files, one sentence. Drift here means two different explanations of the same
+  // situation depending on whether the panel happened to be open.
+  for (const [label, src] of [['sidepanel.html', sidepanelHtml], ['prompt.html', promptHtml]]) {
+    assert.ok(src.includes('<strong>' + COPY_TITLE + '</strong>'), label + ' title');
+    assert.ok(src.includes('>' + COPY_BODY + '</button>'), label + ' body');
+  }
+});
+
+test('the copy says cancel, not switch', () => {
+  // The hint must not imply Sidecar can sign this request as someone else — it can't,
+  // and promising it was the flaw in the picker.
+  for (const src of [sidepanelHtml, promptHtml]) {
+    assert.match(src, /Cancel and login with/);
+    assert.ok(!/Pick who this site should use/.test(src), 'leftover picker copy');
+  }
+});
+
+test('the cancel line is a button on both surfaces', () => {
+  // Plain text left the user reading advice with nothing to act on.
+  assert.match(sidepanelHtml, /<button class="approval-wrong-acct-cancel" id="approval-wrong-acct-cancel">/);
+  assert.match(promptHtml, /<button class="wrong-acct-cancel" id="wrong-acct-cancel">/);
+});
+
+test('the cancel line rejects, on both surfaces', () => {
+  assert.match(sidepanelJs, /\$\('approval-wrong-acct-cancel'\)\.addEventListener\('click', \(\) => decideApproval\('reject'\)\)/);
+  assert.match(promptJs, /els\.wrongAcctCancel\.addEventListener\('click', \(\) => decide\('reject'\)\)/);
+});
+
+test('the cancel line never signs', () => {
+  // One character away from being the worst bug in the extension: a control the user
+  // taps *because* the identity is wrong must not approve under that identity.
+  const BINDINGS = [
+    ['sidepanel.js', sidepanelJs, /\$\('approval-wrong-acct-cancel'\)\.addEventListener\([^;]*;/],
+    ['prompt.js', promptJs, /els\.wrongAcctCancel\.addEventListener\([^;]*;/],
+  ];
+  for (const [label, src, re] of BINDINGS) {
+    const m = src.match(re);
+    assert.ok(m, 'could not find the cancel binding in ' + label);
+    assert.match(m[0], /'reject'/, label + ': cancel must send reject');
+    assert.ok(!/'once'|'trust'|'relax'|'budget'/.test(m[0]), label + ': cancel must not approve');
+  }
+});
+
+test('the popup binds cancel directly, not via els.reject', () => {
+  // init() replaces els.reject with a plain Close button when the request has already
+  // expired. Forwarding through it would leave cancel wired to a stale node.
+  const m = promptJs.match(/els\.wrongAcctCancel\.addEventListener\([^)]*\)[^;]*;/);
+  assert.ok(m, 'could not find the popup cancel binding');
+  assert.ok(!/els\.reject/.test(m[0]), 'must not forward through els.reject');
+});
+
+test('the cancel line is not disabled by the destructive lock', () => {
+  // setApprovalLocked / setLocked gate Allow + Trust behind "I understand". The way out
+  // is never gated — same rule that keeps Reject enabled.
+  for (const [label, src] of [['sidepanel.js', sidepanelJs], ['prompt.js', promptJs]]) {
+    const fn = src.match(/function set(?:Approval)?Locked\(locked\) \{[\s\S]*?\n {2}\}/);
+    assert.ok(fn, label);
+    assert.ok(!/wrongAcct|wrong-acct/.test(fn[0]), label + ': cancel must stay enabled');
+  }
+});
+
+test('both surfaces gate the hint on the payload flag', () => {
+  assert.match(sidepanelJs, /data\.wrongAccountEscape/);
+  assert.match(promptJs, /data\.wrongAccountEscape/);
+});
+
+test('the hint is re-evaluated every time an approval is shown', () => {
+  // Not once at load: the panel re-renders on queue advance and unlock, and a hint left
+  // standing from a previous request would advise cancelling a prompt that is fine.
+  assert.match(sidepanelJs, /renderApprovalAccountCapsule\(data\);\s*\n\s*renderWrongAcctEscape\(data\);/);
+  assert.match(promptJs, /buildAccountCapsule\(\);\s*\n\s*buildWrongAcct\(\);/);
+});
+
+test('the hint hides again when the flag is false', () => {
+  // A show-only render leaks the hint onto the next request in the queue.
+  assert.match(sidepanelJs, /if \(data\.wrongAccountEscape\) show\(hint\);\s*\n\s*else hide\(hint\);/);
+  assert.match(promptJs, /classList\.toggle\('hidden', !data\.wrongAccountEscape\)/);
+});
+
+test('the hint has styles on both surfaces', () => {
+  assert.match(css, /\.approval-wrong-acct \{/);
+  assert.match(css, /\.approval-wrong-acct strong \{/);
+  assert.match(promptHtml, /\.wrong-acct \{/);
+  assert.match(promptHtml, /\.wrong-acct strong \{/);
+});
+
+test('the cancel line is de-emphasized, not accented', () => {
+  // At --lav it competed with the account capsule directly above, which is the thing the
+  // user actually needs to read on a signing screen. The underline carries the affordance.
+  for (const [label, src, sel] of [
+    ['styles.css', css, '.approval-wrong-acct-cancel'],
+    ['prompt.html', promptHtml, '.wrong-acct-cancel'],
+  ]) {
+    const blk = src.match(new RegExp('\\' + sel + ' \\{[^}]*\\}'));
+    assert.ok(blk, 'could not find ' + sel + ' in ' + label);
+    assert.match(blk[0], /color: var\(--muted\)/, label + ': should use the secondary color');
+    assert.ok(!/var\(--lav\)/.test(blk[0]), label + ': should not use the accent');
+    assert.match(blk[0], /text-decoration: underline/, label + ': needs the link affordance');
+  }
+});
+
+test('the popup hint only uses CSS variables that exist', () => {
+  // prompt.html is a separate document with its own inline styles; --line, --panel and
+  // --panel-2 were used here once and are defined nowhere, which silently renders as no
+  // border on no background.
+  const defined = new Set();
+  const files = [promptHtml, css].concat(
+    fs.readdirSync(path.join(ROOT, 'themes')).map((f) => fs.readFileSync(path.join(ROOT, 'themes', f), 'utf8'))
+  );
+  for (const src of files) for (const m of src.matchAll(/(--[a-z0-9-]+)\s*:/g)) defined.add(m[1]);
+  for (const [label, src] of [['prompt.html', promptHtml], ['styles.css', css]]) {
+    for (const blk of src.matchAll(/\.(?:approval-)?wrong-acct[^{]*\{[^}]*\}/g)) {
+      for (const v of blk[0].matchAll(/var\((--[a-z0-9-]+)/g)) {
+        assert.ok(defined.has(v[1]), label + ' uses undefined ' + v[1]);
+      }
+    }
+  }
+});

--- a/test/wrong-account-escape.test.js
+++ b/test/wrong-account-escape.test.js
@@ -303,7 +303,7 @@ test('detach needs the PIN when the keystore is locked', () => {
 
 const COPY_TITLE = 'Not the right account?';
 const COPY_TOGGLE = 'Detach and use another identity.';
-const COPY_LEDE = 'Cancels this request and makes that account active.';
+const COPY_LEDE = 'Cancels this request and makes the selected account active.';
 
 test('both surfaces carry the hint, the toggle and the list', () => {
   assert.match(sidepanelHtml, /id="approval-wrong-acct"/);
@@ -350,7 +350,7 @@ test('the lede carries both facts the user cannot learn afterwards', () => {
   // else was cut — three lines of lede in a sidebar was too much.
   for (const src of [sidepanelJs, promptJs]) {
     assert.match(src, /Cancels this request/);
-    assert.match(src, /makes that account active/);
+    assert.match(src, /makes the selected account active/);
   }
 });
 

--- a/test/wrong-account-escape.test.js
+++ b/test/wrong-account-escape.test.js
@@ -2,11 +2,13 @@
 
 // Coverage for the "wrong account" hint on the signing approval.
 //
-// The problem: a client and Sidecar can disagree about which account is signed in, and
-// the approval then names an identity the user didn't pick. The existing account switcher
-// only appears once 2+ accounts have logged in on that host, so on a single-login host
-// there's no control at all — and no indication that cancelling and reconnecting is the
-// way out. Users hit this and concluded Sidecar was stuck.
+// The problem: a client and Sidecar can disagree about which account is signed in, and the
+// approval then names an identity the user didn't pick. The existing switcher can't always
+// fix it, for two different reasons:
+//   - on a single-login host it doesn't appear at all (it needs 2+ accounts signed in);
+//   - on a shared host it DOES appear but is scoped to the accounts already signed in
+//     there, so a user whose intended identity is a third one still can't reach it.
+// Both were reported as Sidecar being stuck.
 //
 // The fix, on both approval surfaces:
 //
@@ -28,14 +30,21 @@
 // still has cached, so signing it under another identity yields one correct event and then
 // silent reverts on the next. That reads as working and isn't.
 //
-// The gate is deliberately BROAD — any content sign, 2+ accounts, no switcher already
-// showing. Two earlier cuts tried to detect that the account was "pinned" (by a host
-// binding, or by a client stamping the author pubkey on the template) and both were
-// wrong: pin detection can only ever remove a working hint, and the case that matters
-// most has no pin to detect. A client showing account A while Sidecar's active account is
-// B leaves nothing for Sidecar to observe — it cannot see the client's UI. Only the user
-// can, which is the whole reason the hint exists. The tests below pin that breadth down,
-// because it is the part most likely to get "tightened" back.
+// The gate is deliberately BROAD: any content sign with at least one account the switcher
+// can't offer. Every attempt to narrow it has been a bug.
+//
+// Two cuts tried to detect that the account was "pinned" (by a host binding, then by a
+// client-stamped author pubkey). Both wrong — the case that matters most has no pin to
+// observe, since a client showing account A while Sidecar's active account is B leaves
+// nothing Sidecar can see. It cannot read the client's UI. Only the user can, which is the
+// whole reason the escape exists.
+//
+// A third cut excluded shared-identity hosts on the grounds that "the real switcher is
+// already showing". That produced the reported bug directly: the switcher on those hosts is
+// scoped to accounts already authorized there, so suppressing the escape made a third
+// account unreachable. The escape is now the COMPLEMENT of the switcher rather than an
+// alternative to it, and the tests below pin that down, because it is the part most likely
+// to get "tightened" back again.
 
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
@@ -68,25 +77,116 @@ function liftGate() {
   return m[1];
 }
 
-function gate({ isContentSign, sharedIdentity, accounts }) {
-  const ctx = { isContentSign, sharedIdentity, st: { accounts } };
-  vm.createContext(ctx);
-  return vm.runInContext('(' + liftGate() + ')', ctx);
+// Lifts the real list construction too, not just the gate. The two are one decision now —
+// the gate is `escapeAccounts.length > 0`, so testing it against a hand-made array would
+// prove nothing about which accounts actually reach the list.
+function liftList() {
+  const m = background.match(
+    /const globalActivePubkey = await KS[\s\S]*?escapeAccounts\.sort\([^;]*;/
+  );
+  if (!m) throw new Error('Could not find the escapeAccounts construction in background.js');
+  return m[0];
 }
 
-const TWO = [{ pubkey: PK_A }, { pubkey: PK_B }];
+// accounts: every pubkey in the keystore. signer: the account the prompt shows.
+// switcher: pubkeys the switcher above already offers. active: the globally-active account.
+function evaluate({ accounts, signer, switcher = [], active = null, isContentSign = true }) {
+  const ctx = {
+    st: { accounts: accounts.map((pk) => ({ pubkey: pk, name: 'Acct ' + pk[0] })) },
+    activePubkey: signer,
+    otherAccounts: switcher.map((pk) => ({ pubkey: pk })),
+    KS: { getActivePubkey: async () => active },
+    self: { NostrTools: { nip19: { npubEncode: (pk) => 'npub_' + pk[0] } } },
+    isContentSign,
+    Set,
+  };
+  vm.createContext(ctx);
+  return vm.runInContext(
+    '(async () => {\n' + liftList() + '\n' +
+    'return { show: ' + liftGate() + ', list: escapeAccounts };\n})()',
+    ctx
+  );
+}
 
-test('hint shows on a content sign with more than one account', () => {
-  assert.equal(gate({ isContentSign: true, sharedIdentity: false, accounts: TWO }), true);
+const A = 'a'.repeat(64), B = 'b'.repeat(64), C = 'c'.repeat(64);
+
+test('escape offers the other account on a single-login host', async () => {
+  const r = await evaluate({ accounts: [A, B], signer: A });
+  assert.equal(r.show, true);
+  assert.deepEqual(r.list.map((x) => x.pubkey), [B]);
+});
+
+test('escape is hidden with a single account in the keystore', async () => {
+  // Nothing to switch to.
+  const r = await evaluate({ accounts: [A], signer: A });
+  assert.equal(r.show, false);
+  assert.deepEqual(r.list, []);
+});
+
+test('escape is hidden when the switcher already offers every other account', async () => {
+  // Shared host, both accounts authorized. The switcher can reach B, so offering it again
+  // under a second action that also cancels the request would be strictly worse.
+  const r = await evaluate({ accounts: [A, B], signer: A, switcher: [B] });
+  assert.equal(r.show, false);
+  assert.deepEqual(r.list, []);
+});
+
+test('escape offers the THIRD account the switcher cannot reach', async () => {
+  // The reported bug. Three accounts, two signed in on the host, and the one the user wants
+  // is the third. The switcher is scoped to accounts already authorized here, so it only
+  // offers B — and the escape used to be suppressed entirely on shared hosts, leaving no
+  // path to C at all.
+  const r = await evaluate({ accounts: [A, B, C], signer: A, switcher: [B] });
+  assert.equal(r.show, true);
+  assert.deepEqual(r.list.map((x) => x.pubkey), [C], 'C must be reachable');
+});
+
+test('the two lists never overlap', async () => {
+  // One account offered twice under two different actions — one of which cancels the
+  // request and one of which does not — is a worse prompt than either alone.
+  const r = await evaluate({ accounts: [A, B, C], signer: A, switcher: [B] });
+  for (const acct of r.list) {
+    assert.ok(acct.pubkey !== B, 'switcher account leaked into the escape list');
+  }
+});
+
+test('the account being shown is never offered', async () => {
+  // Detaching to re-pick the identity already on screen is a no-op with extra steps.
+  const r = await evaluate({ accounts: [A, B, C], signer: A });
+  assert.ok(!r.list.some((x) => x.pubkey === A));
+  assert.deepEqual(r.list.map((x) => x.pubkey).sort(), [B, C].sort());
+});
+
+test('the globally-active account sorts first and is tagged', async () => {
+  // With eight accounts the likeliest pick must not be buried, and an unexplained top row
+  // reads as arbitrary — hence both the sort and the flag the UI renders.
+  const r = await evaluate({ accounts: [A, B, C], signer: A, active: C });
+  assert.equal(r.list[0].pubkey, C);
+  assert.equal(r.list[0].active, true);
+  assert.equal(r.list[1].active, false);
+});
+
+test('escape is hidden when the request is not a content sign', async () => {
+  // Payments and getPublicKey both land here. A payment names the wallet, not a signing
+  // identity, so "wrong account" has no meaning there; getPublicKey gets the real switcher.
+  const r = await evaluate({ accounts: [A, B], signer: A, isContentSign: false });
+  assert.equal(r.show, false);
+});
+
+test('the gate carries no shared-host or account-count term of its own', async () => {
+  // Both are implied by the list being non-empty. Re-adding !sharedIdentity is what caused
+  // the reported bug: it suppressed the escape on exactly the hosts whose switcher is
+  // scoped, so a third account became unreachable.
+  const src = liftGate();
+  assert.ok(!/sharedIdentity/.test(src), 'gate must not re-exclude shared hosts');
+  assert.ok(!/accounts\.length/.test(src), 'account count is implied by the list');
+  assert.match(src, /escapeAccounts\.length > 0/);
 });
 
 test('the gate does not consult the binding or the author stamp', () => {
-  // This is the breadth guarantee, and it is the whole fix. Both pins were tried and
-  // both were wrong, because the case that matters most has NO pin to detect: the client
-  // is displaying account A, Sidecar's active account is B, there is no binding and no
-  // author stamp. None of that is observable from the extension — it cannot see the
-  // client's UI. The prompt simply names the wrong identity and the user is the only one
-  // who can tell.
+  // Two earlier cuts tried to detect that the account was "pinned" and both were wrong,
+  // because the case that matters most has NO pin to observe: the client shows account A
+  // while Sidecar's active account is B. Sidecar cannot see the client's UI.
   //
   // Asserted against the gate's source, not its result, because a value-level test can't
   // distinguish "ignores the binding" from "the binding happened to be set".
@@ -95,31 +195,25 @@ test('the gate does not consult the binding or the author stamp', () => {
   assert.ok(!/authorSwitched/.test(src), 'gate must not depend on a client author stamp');
 });
 
-test('hint is hidden with a single account in the keystore', () => {
-  // Nothing to log in as.
-  assert.equal(gate({ isContentSign: true, sharedIdentity: false, accounts: [{ pubkey: PK_A }] }), false);
-});
-
-test('hint is hidden on a shared-identity host', () => {
-  // 2+ accounts have logged in here, so the real switcher is already on screen and the
-  // user can just pick — telling them to cancel and reconnect would be worse advice.
-  assert.equal(gate({ isContentSign: true, sharedIdentity: true, accounts: TWO }), false);
-});
-
-test('hint is hidden when the request is not a content sign', () => {
-  // Payments and getPublicKey both land here. A payment names the wallet, not a signing
-  // identity, so "wrong account" has no meaning on that screen; getPublicKey already
-  // gets the real switcher.
-  assert.equal(gate({ isContentSign: false, sharedIdentity: false, accounts: TWO }), false);
-});
-
 test('relay auth is excluded via isContentSign, not a separate term', () => {
-  // isContentSign is (signEvent && !isRelayAuth) || encrypt, so a kind 22242 auth event
-  // can never reach the hint. Asserting that implication rather than passing the
-  // impossible isContentSign+isRelayAuth pair an earlier version of this test used.
+  // isContentSign is (signEvent && !isRelayAuth) || encrypt, so a kind 22242 auth event can
+  // never reach the escape.
   const m = background.match(/const isContentSign =\n([\s\S]*?);\n/);
   assert.ok(m, 'could not find isContentSign');
   assert.match(m[1], /method === 'signEvent' && !isRelayAuth/);
+});
+
+test('the offered list is built from every account, not the authorized set', () => {
+  // The account the user wants is the one that ISN'T authorized on this host yet.
+  const m = background.match(/const escapeAccounts = (st\.accounts|otherAccounts)/);
+  assert.ok(m);
+  assert.equal(m[1], 'st.accounts');
+});
+
+test('the switcher subtraction is derived from otherAccounts itself', () => {
+  // Not from a re-derived `sharedIdentity ? authorizedPool : []`, which would drift out of
+  // step with the switcher's own filter and silently re-open the overlap.
+  assert.match(background, /const offeredInSwitcher = new Set\(\(otherAccounts \|\| \[\]\)\.map\(\(a\) => a\.pubkey\)\)/);
 });
 
 // ---------------------------------------------------------------------------

--- a/themes/aegean.css
+++ b/themes/aegean.css
@@ -37,11 +37,18 @@
      every checkbox, mentions, and chosen buttons. Terracotta here made the
      checkboxes read as errors. Terracotta lives in --warn, where it belongs. */
   --orange: #1565C0;
-  /* brand — sun-bleached stone for money, so gold still reads as gold across all
-     four themes, but pitched warm-neutral rather than yellow against white */
+  /* --amber stays metallic: it is what the amber half of the relax countdown reads, and
+     amber has to mean amber even here.
+     --gold does NOT. It drives the UI accents — the active-account check, row borders,
+     tips, the "note is live" banner — and gold on whitewash reads as mustard and pulls
+     warm against a cool room. That call was already made for the wallet card, scoped to
+     it; this promotes it to the whole theme, which is what the scope should have been.
+     It is also a legibility win: #9C7A1C was 4.07:1 on white, under AA. Cobalt is 7.19:1.
+     --accent-rgb follows, so every translucent wash goes cobalt with it. */
   --amber: #B8912F;
-  --gold: #9C7A1C;
-  --gold-soft: rgba(156, 122, 28, 0.5);
+  --gold: var(--purple);
+  --gold-soft: rgba(var(--border-rgb), 0.42);
+  --accent-rgb: var(--border-rgb);
   /* Cobalt takes the accent slot the dark themes fill with purple: deep sea for the
      strong tone, door-blue for the lighter. 6.77:1 and 5.40:1 on the ground. */
   --purple: #0B57A4;
@@ -81,6 +88,14 @@
      washes out to near-invisible; cobalt instead. --pending-sub is left alone — the
      default is --muted, which clears AA on this theme's surfaces. */
   --pending-text: #0B4F94;
+
+  /* Small accent pills (reload banner, "grant" on a host row). Their default gradient
+     hardcodes gold at the first and last stop with --gold in the middle, so a themed
+     --gold alone would have left them gold-cobalt-gold. */
+  --btn-accent-top: #2A7BD4;
+  --btn-accent-mid: #1565C0;
+  --btn-accent-bot: #0B4F94;
+  --btn-accent-text: #FFFFFF;
 
   /* ink — blue-black; neutral grey looks dirty against whitewash */
   --text: #14232E;
@@ -160,17 +175,9 @@
   color: var(--text);
 }
 
-/* The wallet card is the one surface where the theme gets to be itself. Money is
-   gold in the other three and --gold still means gold here for badges, but on
-   whitewash a gold number reads as mustard and the card was pulling warm against a
-   cool room. Scoping --gold to the card turns the number, the chart line and its
-   gradient blue in one move — the chart draws from that variable inline. Both
-   balance displays share one colour, as they must. */
-[data-theme="aegean"] .wallet-card,
-[data-theme="aegean"] .pinned-balance {
-  --gold: var(--purple);
-  --gold-soft: rgba(var(--border-rgb), 0.42);
-}
+/* The wallet card used to scope --gold to cobalt on its own, because a gold balance read
+   as mustard on whitewash. --gold is cobalt theme-wide now, so this block was doing
+   nothing and is gone. The chart still picks it up — it draws from that variable inline. */
 [data-theme="aegean"] .wallet-balance,
 [data-theme="aegean"] .pinned-balance-amt {
   color: var(--purple);

--- a/themes/aegean.css
+++ b/themes/aegean.css
@@ -55,6 +55,17 @@
   --btn-primary-bot: #0B4F94;
   --btn-shadow: rgba(21, 101, 192, 0.32);
 
+  /* "Trust this site" — sea-light blue, a few shades up from the cobalt door so the two
+     actions can't be mistaken for each other: Allow is the saturated fill with a white
+     label, Trust the pale one with a dark label. The old rule put a near-black label on
+     the full cobalt --lav and it was barely readable. */
+  --btn-lav-top: #DCEBFA;
+  --btn-lav-mid: #BFD9F2;
+  --btn-lav-bot: #A3C7E9;
+  --btn-lav-text: #14232E;
+  --btn-lav-ring: rgba(11, 87, 164, 0.28);
+  --btn-lav-shadow: rgba(21, 101, 192, 0.18);
+
   /* ink — blue-black; neutral grey looks dirty against whitewash */
   --text: #14232E;
   --text-2: #2C3E4C;

--- a/themes/aegean.css
+++ b/themes/aegean.css
@@ -12,13 +12,18 @@
      plaster in sea light, so the ground is neutral-cool and the cards are plain
      white. */
   --bg: #F7F8F8;
-  --bg-2: #EDF1F4;
+  /* Sea-light blue on the secondary surfaces and the card bottoms, the same family as
+     the "Trust this site" fill below. The ground and the card TOPS stay whitewash — the
+     theme is plaster in sea light, and tinting those too turned the whole panel blue
+     rather than lighting it. Costs a little contrast on every ink sitting on a card;
+     see --faint below, which had to come down to pay for it. */
+  --bg-2: #E2ECF8;
   --velvet-1: #FFFFFF;
-  --velvet-2: #F4F7F9;
+  --velvet-2: #E8F1FC;
   --velvet-1-rgb: 255, 255, 255;
   --av-from: #FFFFFF;
   --av-to: #EDF1F4;
-  --banner-accent: #EDF1F4;
+  --banner-accent: #E2ECF8;
   --border: rgba(11, 87, 164, 0.16);
   --border-strong: rgba(11, 87, 164, 0.30);
   --border-rgb: 11, 87, 164;
@@ -45,8 +50,8 @@
   --hover-medium: rgba(11, 87, 164, 0.10);
   --hover-faint: rgba(11, 87, 164, 0.04);
   --mention-bg: rgba(21, 101, 192, 0.14);
-  --scroll-thumb: linear-gradient(180deg, #CBD8E2, #DDE6ED);
-  --scroll-thumb-hover: #B4C6D4;
+  --scroll-thumb: linear-gradient(180deg, #BFD9F2, #DCEBFA);
+  --scroll-thumb-hover: #A3C7E9;
 
   /* primary button — the cobalt door, not gold. Gold on white read as mustard, and
      blue is what the eye expects to be the action in this palette. */
@@ -66,11 +71,22 @@
   --btn-lav-ring: rgba(11, 87, 164, 0.28);
   --btn-lav-shadow: rgba(21, 101, 192, 0.18);
 
+  /* Quiet buttons (Cancel, Manage, and friends) take the top of the same blue ramp —
+     paler than "Trust this site" so the ordering still reads: filled cobalt is the
+     action, mid blue is the deliberate one, pale blue is the way back. */
+  --btn-secondary-top: #F5FAFE;
+  --btn-secondary-bot: #DCEBFA;
+
   /* ink — blue-black; neutral grey looks dirty against whitewash */
   --text: #14232E;
   --text-2: #2C3E4C;
   --muted: #5A6B78;
-  --faint: #8B99A5;
+  /* Darkened with the surface tint below. The card bottoms used to be near-white
+     (#F4F7F9); sea-light blue is darker, and every ink on them loses a little contrast.
+     --faint was the only one with no headroom left — 2.71:1 on the old card, which is
+     under AA already. Darkening it here more than pays for the tint: 3.05:1 on the new
+     card, better than before on every surface. */
+  --faint: #7C8C99;
   --red: #A8432A;
 
   --shadow: 0 10px 30px rgba(11, 42, 66, 0.10);

--- a/themes/aegean.css
+++ b/themes/aegean.css
@@ -77,6 +77,11 @@
   --btn-secondary-top: #F5FAFE;
   --btn-secondary-bot: #DCEBFA;
 
+  /* Pending confirm. The default title is --gold on a gold wash, which over whitewash
+     washes out to near-invisible; cobalt instead. --pending-sub is left alone — the
+     default is --muted, which clears AA on this theme's surfaces. */
+  --pending-text: #0B4F94;
+
   /* ink — blue-black; neutral grey looks dirty against whitewash */
   --text: #14232E;
   --text-2: #2C3E4C;

--- a/themes/art-deco.css
+++ b/themes/art-deco.css
@@ -60,6 +60,13 @@
   --btn-lav-ring: rgba(139, 115, 85, 0.34);
   --btn-lav-shadow: rgba(139, 115, 85, 0.20);
 
+  /* Pending confirm. The gold default sat at 1.68:1 for the title against this theme's
+     cream card. Dark bronze instead — same hue family, without the wash. --pending-sub is
+     overridden too because this theme's --muted is itself only 3.68:1, so inheriting the
+     new default would still miss AA here. */
+  --pending-text: #4A3410;
+  --pending-sub: #6E4E14;
+
   /* ink */
   --text: #2a2a2a;
   --text-2: #4a4a4a;

--- a/themes/art-deco.css
+++ b/themes/art-deco.css
@@ -50,6 +50,16 @@
   --btn-primary-bot: #A5853A;
   --btn-shadow: rgba(201, 170, 86, 0.35);
 
+  /* "Trust this site" — pale parchment rather than a lighter gold. A lighter gold sat
+     too close to the champagne primary above it; this reads as the quieter action while
+     staying warm, and carries the dark label the old bronze --lav could not. */
+  --btn-lav-top: #F6EEDA;
+  --btn-lav-mid: #EBE0C4;
+  --btn-lav-bot: #DDCFAB;
+  --btn-lav-text: #2a2a2a;
+  --btn-lav-ring: rgba(139, 115, 85, 0.34);
+  --btn-lav-shadow: rgba(139, 115, 85, 0.20);
+
   /* ink */
   --text: #2a2a2a;
   --text-2: #4a4a4a;

--- a/themes/film-noir.css
+++ b/themes/film-noir.css
@@ -30,6 +30,10 @@
   --amber: #b8b8b8;
   --gold: #c0c0c0;
   --gold-soft: rgba(192, 192, 192, 0.4);
+
+  /* Pending confirm sub-label — --muted sits at exactly 4.50:1 on the pending wash, which
+     is no margin at all. See speakeasy for the reasoning. */
+  --pending-sub: #989898;
   --purple: #d4d4d4; /* kept for logo compatibility */
   --lav: #e0e0e0;
   --hover-soft: rgba(192, 192, 192, 0.08);

--- a/themes/speakeasy.css
+++ b/themes/speakeasy.css
@@ -29,6 +29,11 @@
   --amber: #f4a64b;
   --gold: #cba14e;
   --gold-soft: rgba(203, 161, 78, 0.5);
+
+  /* Pending confirm sub-label. --muted is the default and lands at 4.42:1 on the gold
+     wash behind a pending row — the 12% wash lightens a dark card, so light ink loses a
+     little there. Nudged up rather than dropping the AA floor for one component. */
+  --pending-sub: #A28ECC;
   --purple: #a78bfa;
   --lav: #bda1ff;
 


### PR DESCRIPTION
Nine commits over two sessions. The first five are the feature; the last four are contrast defects found while building it.

## The escape

A client and Sidecar can disagree about which account is signed in, and the approval then names an identity you didn't pick. The existing switcher can't always fix it — on a single-login host it doesn't appear, and on a shared host it's scoped to accounts already signed in there, so a third identity stays unreachable. Both were reported as Sidecar being stuck.

The prompt now offers the accounts the switcher can't:

> **Not the right account?**
> Detach and use another identity. — expands to the account list

Picking one detaches the host, makes that account active, and cancels the request — the same primitive as Settings → Sites → "Use \<account>", which already existed three levels into Settings while the problem is discovered at the prompt.

Never "sign this one as them": the event the client built carries the pubkey the client still has cached, so signing it under another identity yields one correct event and then silent reverts. That reads as working and isn't.

Three narrower designs were tried and reverted, each recorded in the tests: gating on a host binding, gating on a client-stamped author pubkey, and suppressing the escape on shared hosts. The last one caused the reported bug directly — the switcher on those hosts is scoped, so suppressing the escape made a third account unreachable. The escape is now the complement of the switcher rather than an alternative to it.

## The contrast fixes

- **"Trust this site" was illegible in the two light themes** — Aegean 3.23:1, Art Deco 2.92:1. `.lav-btn` built its fill from `--lav`/`--purple`, which every theme overrides, while hardcoding a near-black label.
- **"Tap again to confirm" was under AA in all five themes** — it used `--gold-soft`, a 50%-alpha *border* token, as a text colour. Alpha ink blends toward whatever is behind it: 1.30:1 on Art Deco's cream card, 2.49–3.07:1 even in the dark themes.
- **Aegean's UI accents were still gold in a cobalt theme**, and fifteen rules hardcoded `rgba(203, 161, 78, x)` for accent washes that no theme could reach.
- **Aegean's surfaces now carry the sea-light blue**, which required darkening `--faint` to pay for the tint rather than quietly pushing it further under AA.

Those came with `test/theme-contrast.test.js`, which resolves the real `var()` chains out of `styles.css` and each theme file and computes WCAG ratios — including compositing alpha over its backdrop, without which the worst defect here is invisible. Asserting hex values would not have caught any of it: every individual value was reasonable, and the defects existed only in the combinations.

It also records two pre-existing gaps it found rather than papering over them: Art Deco's `--gold` at 1.67:1 as text (a `color:` in 35 rules), and `--faint` below AA in every theme. Both are design decisions, not test failures.

## Verification

430 tests. Every fix was mutation-verified — including two that initially passed and turned out to be a copy-parity check using substring containment, and a gate test that would have missed the shared-host bug entirely.

🥃 Stirred with [Claude Code](https://claude.com/claude-code)
