### PR TITLE
1.8.0 release prep: changelog, countdown dot fix, sticky settings topbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ Release practice: the latest release's highlights are also summarized in-app, in
 guide's **What's new** section (`help.html#whats-new`, linked from Settings → Updates).
 Update that section alongside this file as part of every release.
 
+## [1.8.0] — 2026-08-12
+
+### Added
+- **Sixth theme: Bauhaus.** Flat planes of primary color, black rule lines, and a Futura-lineage display face — the school's own geometric sans. White walls instead of cream keep it unmistakably separate from Art Deco. In Settings → Theme. (#170)
+- **Every theme now has its own display font.** Each of the six themes is set in a typeface from a different category — Playfair (Didone serif), Oswald (condensed grotesque), Bitter (slab serif), Josefin Sans (1920s geometric), Cinzel (Roman caps), Jost (Futura geometric). The theme picker reads as a type specimen: each card shows its name in the face you'd get by choosing it. (#170)
+- **A distinct icon per event kind in Recent activity.** Reactions, zaps, reposts, mentions and replies each carry their own glyph instead of sharing a single feather. (#164)
+- **"Wrong account?" escape on the signing prompt.** When a site is signed in with more than one of your accounts, the approval prompt says so and lets you switch — without closing the prompt, losing the request, or reloading the page. (#169)
+
+### Fixed
+- **A signing approval now outranks any open modal.** With notifications, the composer, or settings open, a signing request could be hidden behind the modal — invisible and impossible to reject. The approval overlay now closes any open modal before showing itself. (#168)
+- **A signing request the sleeping service worker never received is retried.** The MV3 service worker can be evicted mid-message; the request now reaches the signer on a second attempt instead of hanging. (#167)
+- **Relay connections are no longer exhausted.** A connection leak could leave the wallet and publisher unable to reach any relay until a reload; publish failures now say something useful instead of reporting success. (#166)
+- **The panel no longer repaints behind an open overlay.** A deferred render was firing through the modal, causing a flash of stale account names behind the approval prompt. (#165)
+- **One NWC pool per client — the wallet no longer dies until a reload.** (#162)
+- **Copied secrets are cleared from the clipboard after 60 seconds.** An exported nsec or ncryptsec left on the clipboard is now removed automatically. (#163)
+- **Wallet view no longer flashes on zap; the composer background is stable across theme switches.** (#161)
+- **Drag-to-reorder works at the top and bottom of the list.** (#160)
+- **Relax exclusion is looser for replaceable kinds.** App-settings syncs, DM inbox loads and other background work that the user didn't initiate no longer prompt during a relax window, while notes, reactions and DMs still confirm. (#160)
+
+### Changed
+- **Art Deco contrast fixed.** The gold accent ink was 1.67:1 as text on cream — the lightning address, the relax countdown, and the About links were effectively unreadable. The bright metallic is now fill-only; a deep bronze carries all text at 5.23:1. (#170)
+- **Film Noir background reworked.** The Victorian filigree tile is replaced by venetian-blind stripes — the genre's own signature, rendered as one resolution-independent gradient. (#170)
+- **Relax countdown dots are visible on light themes.** Both dot colors were tuned for dark surfaces and measured 1.28–1.74:1 on light theme status bars — invisible. Each light theme now uses its own success and warning values. (#170)
+
 ## [1.7.0] — 2026-07-29
 
 ### Added

--- a/help.html
+++ b/help.html
@@ -349,6 +349,17 @@
          linked below. -->
     <section class="guide-section" id="whats-new">
       <h2>What's new</h2>
+      <p class="whatsnew-version">Version 1.8.0</p>
+      <ul class="whatsnew-list">
+        <li><strong>New theme: Bauhaus.</strong> Flat planes of primary color, black rule lines, and a Futura-lineage display face — the school's own geometric sans. White walls keep it unmistakably separate from Art Deco. Six themes now, in Settings → Theme.</li>
+        <li><strong>Every theme has its own display font.</strong> Each theme is now set in a typeface from a different category — a high-contrast serif for Speakeasy, a condensed grotesque for Film Noir, a slab serif for Brownstone, a 1920s geometric for Art Deco, Roman caps for Aegean, and a Futura-lineage sans for Bauhaus. The theme picker shows each name in its own face.</li>
+        <li><strong>"Wrong account?" on the signing prompt.</strong> When a site is signed in with more than one of your accounts, the approval prompt tells you and lets you switch without closing the prompt or reloading the page.</li>
+        <li><strong>Art Deco legibility.</strong> Gold text on cream — the lightning address, the countdown, the links — was nearly unreadable. Now a deep bronze at five times the contrast.</li>
+        <li><strong>A signing request can no longer be hidden.</strong> If notifications or the composer were open, a signature prompt could sit invisible behind them. It now closes whatever's in the way first.</li>
+        <li><strong>Relay and wallet reliability.</strong> A connection leak that could leave the wallet and publisher dead until a reload is fixed, and a signing request lost to a sleeping service worker is retried instead of hanging.</li>
+        <li><strong>Copied secrets self-destruct.</strong> An exported key left on the clipboard is cleared after 60 seconds.</li>
+        <li><strong>Distinct activity icons.</strong> Reactions, zaps, reposts and mentions each carry their own glyph in Recent activity.</li>
+      </ul>
       <p class="whatsnew-version">Version 1.7.0</p>
       <ul class="whatsnew-list">
         <li><strong>Comment on any webpage.</strong> The speech-bubble icon in the top bar opens a composer for the page you're reading. Your comment is published as a kind 1111 (NIP-22) addressed to the page's URL, and threads with anyone else commenting on the same page. Mentions work the same way they do in a note — type <em>@</em> and tag someone. View your comment and see all comments on the page via Jumble, currently the only client that renders them.</li>

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Sidecar | A Classy Nostr Signer",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "minimum_chrome_version": "114",
   "description": "A multi-account NIP-07 Nostr signer with a built-in Lightning wallet, in your browser sidebar.",
   "permissions": [

--- a/styles.css
+++ b/styles.css
@@ -496,6 +496,19 @@ button:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(var(--accent-rg
   background: linear-gradient(180deg, rgba(var(--velvet-1-rgb), 0.5), transparent);
   box-shadow: var(--sheen);
 }
+/* The settings screen has 16 sections. Its topbar carries the only close button, so
+   it has to stay reachable while scrolling — otherwise exiting means scrolling all the
+   way back up.
+
+   Two things have to be true for the sticky to work: (1) the section itself has to be
+   a fixed-height column so its child .content becomes the scroll container, and (2)
+   the topbar has to be position:sticky inside that column. Without (1) the whole
+   section scrolls as one block in the viewport and sticky does nothing — which is what
+   shipped the first time, because #view-main has this layout but #view-settings never
+   did. Scoped here rather than added to the shared .topbar rule so the main view's
+   topbar (which has its own sticky behavior via the wallet card) is unaffected. */
+#view-settings { display: flex; flex-direction: column; height: 100vh; }
+#view-settings .topbar { position: sticky; top: 0; z-index: 5; flex-shrink: 0; }
 .brand { display: flex; align-items: center; }
 .brand-logo-sm { height: 24px; width: auto; display: block; filter: drop-shadow(0 2px 8px rgba(0, 0, 0, 0.4)); }
 

--- a/themes/aegean.css
+++ b/themes/aegean.css
@@ -59,10 +59,11 @@
      strong tone, door-blue for the lighter. 6.77:1 and 5.40:1 on the ground. */
   --purple: #0B57A4;
   --lav: #1565C0;
-  /* Relax countdown dot — 1.74:1 and 2.95:1 on this whitewash with the shared defaults.
-     The amber was the near miss of the three light themes, which is exactly the kind that
-     ships: visible enough in a screenshot, not against a window. 6.01:1 / 6.00:1 now. */
-  --relax-dot-ok: var(--success);
+  /* Relax countdown dot. The shared default (#4ade80) measured 1.74:1 on this whitewash;
+     --success (#4F6B3A) was the first fix and read as muddy — darker than it needs to be,
+     since a 7px indicator only has to clear 3.0:1, not the 4.5 a label does. #1A9943
+     clears 3.24:1 on the blue card-bottom surface and reads as green, not olive. */
+  --relax-dot-ok: #1A9943;
   --relax-dot-low: var(--warn);
 
   --hover-soft: rgba(11, 87, 164, 0.06);

--- a/themes/bauhaus.css
+++ b/themes/bauhaus.css
@@ -131,12 +131,12 @@
   --purple: #0043C8;
   --lav: #0057FF;
 
-  /* Relax countdown dot. The shared rule's defaults are a mint green and --amber, which
-     measure 1.74:1 and 1.43:1 on this theme's white status bar — invisible. Green stays
-     green via --success (6.50:1), and the amber half becomes the balance orange (3.79:1)
-     rather than --warn's red, so the countdown still reads green -> amber -> and not
-     green -> already-failed. */
-  --relax-dot-ok: var(--success);
+  /* Relax countdown dot. The shared default (#4ade80) measured 1.74:1 on this white
+     status bar; --success (#1F6B3F) was the first fix and was too dark — muddy on a
+     bright plane. #16A34A clears 3.07:1 on both surfaces and reads as a clear green.
+     The low state is the balance orange (3.79:1) rather than --warn's red, so the
+     countdown reads green -> amber -> and not green -> already-failed. */
+  --relax-dot-ok: #16A34A;
   --relax-dot-low: var(--balance-ink);
 
   --hover-soft: rgba(17, 17, 17, 0.05);


### PR DESCRIPTION
Three post-#170 fixes that belong in the 1.8.0 release.

**Release prep.** `manifest.json` bumped to 1.8.0, `CHANGELOG.md` has the full entry (4 added, 8 fixed, 3 changed), and `help.html` What's New is updated.

**Relax countdown dot.** The dot fix from #170 used `--success` (tuned for 4.5:1 text contrast), which was unnecessarily dark — a 7px indicator only needs 3.0:1. Brighter per-theme values now: `#1A9943` on Aegean (was olive `#4F6B3A`), `#16A34A` on Bauhaus (was forest `#1F6B3F`). Art Deco keeps `--success` since its cream is the hardest surface to clear. The progress bar fill, time text, and review ring stay on `--gold` — those are themed chrome, not indicators.

**Sticky settings topbar.** 16 settings sections in a 400px panel, and the only close button scrolled away. `#view-settings` now has the same flex-column + height:100vh layout `#view-main` already had, so `.content` becomes the scroll container and the topbar stays pinned. First attempt failed because the section had no height constraint — sticky needs the scrolling to happen in a parent, not the viewport.

388 tests, 386 pass — two pre-existing failures (`search-entity`, `web-comment`).

🍸 stirred with [Claude Code](https://claude.ai/code)