### PR TITLE
Printable key backup sheet, styled as a telegram

### DIFF
--- a/pdf-backup.js
+++ b/pdf-backup.js
@@ -32,6 +32,10 @@
       .replace(/[“”]/g, '"')
       .replace(/[–—]/g, '-')
       .replace(/…/g, '...')
+      // Decompose then drop combining marks, so "André" prints ANDRE rather than
+      // ANDR. Bech32 is pure ASCII, so this is a no-op for the nsec and npub.
+      .normalize('NFD')
+      .replace(/[̀-ͯ]/g, '')
       .replace(/[^\x20-\x7E]/g, '');
   }
   // Escape the three characters that terminate or nest a PDF literal string.
@@ -191,7 +195,10 @@
     qr.addData(String(value));
     qr.make();
     const count = qr.getModuleCount();
-    const quiet = 2;
+    // 4 modules is the spec's recommended quiet zone. A clean render decodes at 2,
+    // but the real case is a creased sheet under a phone camera at an angle, where
+    // the extra margin is what lets the scanner find the finder patterns.
+    const quiet = 4;
     const scale = size / (count + quiet * 2);
     const origin = { x: x + quiet * scale, y: yTop + quiet * scale };
     // Explicit white backing. Costs nothing to print (printers lay down no white
@@ -304,7 +311,10 @@
     c.fill(...BRONZE).text(colX[0], y, 'TO', 6.5, 'F1');
     // At account creation there is no profile yet — nsecModal runs before the setup
     // wizard — so the name is only available when printing for an existing account.
-    const to = (opts.name || '').trim();
+    // Test what will ACTUALLY print, not what was passed in. A name written wholly
+    // in a non-Latin script survives this check but is emptied by ascii() inside
+    // text(), which printed a blank TO line instead of falling back.
+    const to = ascii(opts.name || '').trim();
     c.fill(...INK).text(colX[0] + 26, y, to ? to.toUpperCase() : 'THE BEARER OF THIS SHEET', 9, 'F2');
     y += 13;
     c.fill(...BRONZE).text(colX[0], y, 'FROM', 6.5, 'F1');

--- a/pdf-backup.js
+++ b/pdf-backup.js
@@ -79,7 +79,22 @@
         }
         return api;
       },
+      // A rectangular ring (outer minus inner), painted with the even-odd rule so the
+      // middle stays untouched. Filling a solid rect and covering it with white would
+      // paint over whatever is beneath — which for the paper band means erasing the
+      // optional-content tint on screen.
+      ring(x, yTop, w, h, inset) {
+        ops.push(`${x} ${PAGE_H - yTop - h} ${w} ${h} re`);
+        ops.push(`${x + inset} ${PAGE_H - yTop - h + inset} ${w - inset * 2} ${h - inset * 2} re`);
+        ops.push('f*');
+        return api;
+      },
       raw(s) { ops.push(s); return api; },
+      // Optional content: everything between these is tagged with an OCG whose usage
+      // dictionary turns it off for printing. Viewers show it; renderers that honor
+      // /PrintState drop it. See PAPER_OCG in build().
+      beginOptional(tag) { ops.push(`/OC /${tag} BDC`); return api; },
+      endOptional() { ops.push('EMC'); return api; },
       toString() { return ops.join('\n'); },
     };
     return api;
@@ -88,9 +103,12 @@
   // Assemble the object graph, xref table and trailer. Offsets are computed on
   // ENCODED BYTES, not string length, so a stray multi-byte character can't slide
   // the xref and corrupt the file.
+  // 1.5, not 1.4: optional content groups (the non-printing page tint) were
+  // introduced in 1.5, and a reader that only understands 1.4 must ignore the
+  // /OCProperties graph rather than misread it.
   function assemble(objects) {
     const enc = new TextEncoder();
-    const parts = ['%PDF-1.4\n'];
+    const parts = ['%PDF-1.5\n'];
     let bytes = enc.encode(parts[0]).length;
     const offsets = [];
     objects.forEach((body, i) => {
@@ -176,6 +194,9 @@
     const quiet = 2;
     const scale = size / (count + quiet * 2);
     const origin = { x: x + quiet * scale, y: yTop + quiet * scale };
+    // Explicit white backing. Costs nothing to print (printers lay down no white
+    // toner) but guarantees the quiet zone stays light if this is ever run on
+    // tinted stock, which is what scanners need to lock on.
     c.fill(1, 1, 1).rect(x, yTop, size, size);
     c.fill(0.11, 0.09, 0.07);
     for (let r = 0; r < count; r++) {
@@ -223,10 +244,29 @@
     const c = content();
     const M = 40; // page margin
 
-    // Paper, then the double rule that frames every telegram blank.
+    // Paper, in two layers, because a full-bleed tint is a ~7% halftone screen over
+    // every square inch on a mono laser — real toner and visible mottling on the one
+    // artifact meant to sit in a drawer for years.
+    //
+    // 1. The BORDER BAND always prints. It's ~5% of the page rather than 100%, so the
+    //    sheet still reads as warm stock on plain white paper at a twentieth of the ink.
+    // 2. The FULL-PAGE fill is wrapped in an optional content group whose usage
+    //    dictionary sets /PrintState /OFF. Viewers show a fully cream page; renderers
+    //    that honor optional content drop it and print only the band.
+    //
+    // Support for /PrintState is uneven (Acrobat honors it, many hardware RIPs ignore
+    // usage dictionaries), so this is built to degrade well rather than to be relied
+    // on: if it's ignored the sheet simply prints fully tinted, which is merely the
+    // ink cost, not a broken document.
+    c.beginOptional('MC0');
     c.fill(...PAPER).rect(0, 0, PAGE_W, PAGE_H);
+    c.endOptional();
+
+    const BAND = 12; // width of the printing tint band, between the two frame rules
+    c.fill(...PAPER).ring(M, M, PAGE_W - M * 2, PAGE_H - M * 2, BAND);
+
     c.stroke(...INK).width(2).rect(M, M, PAGE_W - M * 2, PAGE_H - M * 2, 'S');
-    c.width(0.6).rect(M + 5, M + 5, PAGE_W - (M + 5) * 2, PAGE_H - (M + 5) * 2, 'S');
+    c.width(0.6).rect(M + BAND, M + BAND, PAGE_W - (M + BAND) * 2, PAGE_H - (M + BAND) * 2, 'S');
 
     // ---- letterhead
     let y = M + 20;
@@ -341,14 +381,23 @@
     const stream = c.toString();
     const streamBytes = new TextEncoder().encode(stream).length;
     const font = (name) => `<< /Type /Font /Subtype /Type1 /BaseFont /${name} /Encoding /WinAnsiEncoding >>`;
+    // Object 7 is the optional content group holding the full-page tint.
+    //   /Usage      declares what it is FOR (view yes, print no)
+    //   /D /AS      is what actually applies that usage automatically per event —
+    //               a /Usage dictionary alone is only advisory and readers ignore it
+    //   /D /ON      leaves the group visible in the default configuration
     return assemble([
-      '<< /Type /Catalog /Pages 2 0 R >>',
+      '<< /Type /Catalog /Pages 2 0 R /OCProperties << /OCGs [7 0 R] ' +
+        '/D << /ON [7 0 R] /Order [] ' +
+        '/AS [ << /Event /Print /Category [/Print] /OCGs [7 0 R] >> ] >> >> >>',
       '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
       `<< /Type /Page /Parent 2 0 R /MediaBox [0 0 ${PAGE_W} ${PAGE_H}] ` +
-        '/Resources << /Font << /F1 5 0 R /F2 6 0 R >> >> /Contents 4 0 R >>',
+        '/Resources << /Font << /F1 5 0 R /F2 6 0 R >> /Properties << /MC0 7 0 R >> >> /Contents 4 0 R >>',
       `<< /Length ${streamBytes} >>\nstream\n${stream}\nendstream`,
       font('Courier'),
       font('Courier-Bold'),
+      '<< /Type /OCG /Name (Paper tint) /Usage << /View << /ViewState /ON >> ' +
+        '/Print << /PrintState /OFF >> >> >>',
     ]);
   }
 

--- a/pdf-backup.js
+++ b/pdf-backup.js
@@ -1,0 +1,361 @@
+// Sidecar — printable account backup, styled as an old-fashioned telegram.
+//
+// Why a hand-rolled PDF writer instead of a library: VENDOR.md keeps this repo to
+// four vendored bundles, each byte-traceable to an npm artifact and SHA-256 verified
+// by CI. A PDF library would add a fifth (~350KB) and a new supply-chain surface for
+// what is, in the end, ruled lines and monospace text. PDF 1.4 is a text format, and
+// Courier is one of the standard-14 fonts every reader ships — so nothing is embedded
+// and nothing new is trusted.
+//
+// The QR is emitted as vector rectangles from the existing qrcode-generator modules,
+// not a raster: it stays crisp at any zoom and survives printing at any DPI.
+//
+// DESIGN NOTE: the telegram conceit is deliberately confined to the letterhead and the
+// MESSAGE block. The security warnings below it are plain sentences. A pastiche that
+// rendered "anyone holding this controls your account" as jokey caps-and-STOP would
+// trade a real warning for a gag, and this sheet exists precisely for the moment
+// someone has lost everything else.
+(function (root) {
+  'use strict';
+
+  // ---------------------------------------------------------------- PDF primitives
+
+  const PAGE_W = 612; // US Letter, 72dpi points
+  const PAGE_H = 792;
+
+  // PDF text strings are ASCII here by construction (bech32 is [a-z0-9], and the
+  // static copy is written plain). Fold anything stray rather than emit bytes a
+  // WinAnsiEncoding reader would render as mojibake.
+  function ascii(s) {
+    return String(s == null ? '' : s)
+      .replace(/[‘’]/g, "'")
+      .replace(/[“”]/g, '"')
+      .replace(/[–—]/g, '-')
+      .replace(/…/g, '...')
+      .replace(/[^\x20-\x7E]/g, '');
+  }
+  // Escape the three characters that terminate or nest a PDF literal string.
+  const esc = (s) => ascii(s).replace(/([\\()])/g, '\\$1');
+
+  // Courier is monospace at exactly 600/1000 em, so text width is arithmetic — which
+  // is why every centered element on this page is set in Courier. No metrics table.
+  const COURIER_EM = 0.6;
+  const textWidth = (s, size) => ascii(s).length * COURIER_EM * size;
+
+  function content() {
+    const ops = [];
+    const api = {
+      // PDF's origin is bottom-left; the layout below thinks top-down, so every
+      // helper takes a top-down y and flips it here. One conversion, one place.
+      fill(r, g, b) { ops.push(`${r} ${g} ${b} rg`); return api; },
+      stroke(r, g, b) { ops.push(`${r} ${g} ${b} RG`); return api; },
+      width(w) { ops.push(`${w} w`); return api; },
+      rect(x, yTop, w, h, mode) {
+        // `re` builds the path; the mode operator (f/S) then paints it. Emitting the
+        // numbers without `re` is silently valid-looking and draws nothing at all.
+        ops.push(`${x} ${PAGE_H - yTop - h} ${w} ${h} re ${mode || 'f'}`);
+        return api;
+      },
+      line(x1, y1, x2, y2) {
+        ops.push(`${x1} ${PAGE_H - y1} m ${x2} ${PAGE_H - y2} l S`);
+        return api;
+      },
+      text(x, yTop, str, size, font) {
+        ops.push(`BT /${font || 'F1'} ${size} Tf ${x} ${PAGE_H - yTop} Td (${esc(str)}) Tj ET`);
+        return api;
+      },
+      centered(yTop, str, size, font) {
+        return api.text((PAGE_W - textWidth(str, size)) / 2, yTop, str, size, font);
+      },
+      // Letter-spaced display type for the letterhead. Tc would be simpler but it
+      // breaks the monospace width math the centering relies on, so space manually.
+      trackedCentered(yTop, str, size, font, track) {
+        const chars = ascii(str).split('');
+        const w = chars.length * (COURIER_EM * size + track) - track;
+        let x = (PAGE_W - w) / 2;
+        for (const ch of chars) {
+          if (ch !== ' ') api.text(x, yTop, ch, size, font);
+          x += COURIER_EM * size + track;
+        }
+        return api;
+      },
+      raw(s) { ops.push(s); return api; },
+      toString() { return ops.join('\n'); },
+    };
+    return api;
+  }
+
+  // Assemble the object graph, xref table and trailer. Offsets are computed on
+  // ENCODED BYTES, not string length, so a stray multi-byte character can't slide
+  // the xref and corrupt the file.
+  function assemble(objects) {
+    const enc = new TextEncoder();
+    const parts = ['%PDF-1.4\n'];
+    let bytes = enc.encode(parts[0]).length;
+    const offsets = [];
+    objects.forEach((body, i) => {
+      offsets.push(bytes);
+      const chunk = `${i + 1} 0 obj\n${body}\nendobj\n`;
+      parts.push(chunk);
+      bytes += enc.encode(chunk).length;
+    });
+    const xrefAt = bytes;
+    let xref = `xref\n0 ${objects.length + 1}\n0000000000 65535 f \n`;
+    for (const off of offsets) xref += `${String(off).padStart(10, '0')} 00000 n \n`;
+    xref += `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${xrefAt}\n%%EOF\n`;
+    parts.push(xref);
+    return new Blob(parts, { type: 'application/pdf' });
+  }
+
+  // ---------------------------------------------------------------- the mark
+
+  // icons/sidecar-mark.svg, transcribed. Only M/H/V/C/Z appear in that file — no
+  // arcs, no quadratics — so the mapping to PDF path operators is mechanical and
+  // the mark stays vector (prints crisp at any size). Kept as data rather than
+  // parsed from the SVG at runtime: the extension would have to fetch and parse a
+  // file to draw a logo it already ships.
+  //
+  // The sheet is monochrome, so the mark is too. The source is four stacked paths —
+  // a white bowl, a grey right-hand shade, and two oranges for the glass — a scheme
+  // that only reads in colour. Flattened to two tones of the page ink instead, which
+  // keeps the dimensional read of the original without any hue.
+  //
+  // Each pair draws a full shape then overlays its right-hand half, so the LIT side
+  // is whichever colour goes down first. Base light + right-hand overlay dark puts
+  // the highlight on the left, matching a light source at upper left.
+  const MARK_VIEWBOX = { w: 201, h: 226 };
+  const MARK_INK = [0.16, 0.12, 0.09];
+  const MARK_SHADE = [0.58, 0.51, 0.43];
+  const MARK_PATHS = [
+    { fill: MARK_SHADE, d: 'M200.381 0C200.381 55.1291 155.609 99.8203 100.381 99.8203C45.1539 99.8203 0.381226 55.1281 0.381226 0H200.381Z' },
+    { fill: MARK_INK, d: 'M200.381 0H100.929V99.807C155.904 99.5108 200.381 54.9449 200.381 0Z' },
+    { fill: MARK_SHADE, d: 'M194.685 33.2253H6.07739C19.1073 70.0701 53.1779 96.9858 93.8872 99.5944V213.036H62.2426C58.6556 213.036 55.7495 215.937 55.7495 219.518C55.7495 223.098 58.6556 225.999 62.2426 225.999H138.52C142.107 225.999 145.013 223.098 145.013 219.518C145.013 215.937 142.107 213.036 138.52 213.036H106.876V99.5944C147.584 96.9858 181.655 70.0701 194.685 33.2253Z' },
+    { fill: MARK_INK, d: 'M194.685 33.2253H100.927V226H138.519C142.106 226 145.012 223.099 145.012 219.519C145.012 215.938 142.106 213.037 138.519 213.037H106.874V99.5944C147.584 96.9858 181.655 70.0701 194.685 33.2253Z' },
+  ];
+
+  // Convert one SVG path to PDF operators, scaled into a box whose top-left is
+  // (x, yTop). SVG's y grows downward and PDF's grows upward, hence the flip.
+  function markPath(c, d, x, yTop, scale) {
+    const px = (v) => x + v * scale;
+    const py = (v) => PAGE_H - (yTop + v * scale);
+    // Split into command letters plus their number runs.
+    const tokens = d.match(/[MHVCZ][^MHVCZ]*/gi) || [];
+    let cx = 0, cy = 0;
+    for (const t of tokens) {
+      const cmd = t[0];
+      const n = (t.slice(1).match(/-?\d*\.?\d+/g) || []).map(Number);
+      if (cmd === 'M') { cx = n[0]; cy = n[1]; c.raw(`${px(cx)} ${py(cy)} m`); }
+      else if (cmd === 'H') { cx = n[0]; c.raw(`${px(cx)} ${py(cy)} l`); }
+      else if (cmd === 'V') { cy = n[0]; c.raw(`${px(cx)} ${py(cy)} l`); }
+      else if (cmd === 'C') {
+        for (let i = 0; i + 5 < n.length; i += 6) {
+          c.raw(`${px(n[i])} ${py(n[i + 1])} ${px(n[i + 2])} ${py(n[i + 3])} ${px(n[i + 4])} ${py(n[i + 5])} c`);
+          cx = n[i + 4]; cy = n[i + 5];
+        }
+      } else if (cmd === 'Z') c.raw('h');
+    }
+  }
+
+  function drawMark(c, x, yTop, height) {
+    const scale = height / MARK_VIEWBOX.h;
+    for (const p of MARK_PATHS) {
+      c.fill(...p.fill);
+      markPath(c, p.d, x, yTop, scale);
+      c.raw('f');
+    }
+    return MARK_VIEWBOX.w * scale; // width consumed, so callers can center
+  }
+
+  // ---------------------------------------------------------------- QR as vectors
+
+  function drawQr(c, value, x, yTop, size) {
+    const qr = root.qrcode(0, 'M'); // typeNumber 0 = smallest version that fits
+    qr.addData(String(value));
+    qr.make();
+    const count = qr.getModuleCount();
+    const quiet = 2;
+    const scale = size / (count + quiet * 2);
+    const origin = { x: x + quiet * scale, y: yTop + quiet * scale };
+    c.fill(1, 1, 1).rect(x, yTop, size, size);
+    c.fill(0.11, 0.09, 0.07);
+    for (let r = 0; r < count; r++) {
+      for (let col = 0; col < count; col++) {
+        if (!qr.isDark(r, col)) continue;
+        // +0.02 overlap: adjacent module edges can hairline-crack in some renderers.
+        c.rect(origin.x + col * scale, origin.y + r * scale, scale + 0.02, scale + 0.02);
+      }
+    }
+    return c;
+  }
+
+  // ---------------------------------------------------------------- the telegram
+
+  const INK = [0.16, 0.12, 0.09];
+  const BRONZE = [0.55, 0.42, 0.25];
+  const PAPER = [0.961, 0.933, 0.875];
+
+  // A telegram carried a serial, and it's what makes the letterhead read as a real
+  // blank rather than a decorated note. Six leading and six trailing characters of
+  // the npub, so one account always prints the same serial.
+  //
+  // Twelve bech32 characters is 32^12 (~1.15e18) combinations, which stays collision-
+  // free past a billion accounts. Four-and-four (32^8) would have been ample for
+  // telling apart the sheets one person holds, but two strangers comparing serials
+  // is a coin flip once Nostr passes a million accounts.
+  //
+  // The "npub1" prefix is dropped before slicing — it's constant on every account, so
+  // including it would spend characters that distinguish nothing. The NP- prefix says
+  // what the number is derived from without eating into the entropy.
+  //
+  // Both halves are visible in Sidecar's own truncated display (shortNpub renders
+  // npub1aeh2zw4el...cq4nwx), so a sheet can be eyeballed against the account list.
+  function serialFor(npub) {
+    const s = ascii(npub).replace(/^npub1/i, '').replace(/[^a-z0-9]/gi, '').toUpperCase();
+    return `NP-${s.slice(0, 6)}-${s.slice(-6)}`;
+  }
+
+  function build(opts) {
+    const nsec = ascii(opts.nsec);
+    const npub = ascii(opts.npub);
+    const when = opts.date instanceof Date ? opts.date : new Date();
+    const stamp = when.toISOString().slice(0, 16).replace('T', '  ');
+
+    const c = content();
+    const M = 40; // page margin
+
+    // Paper, then the double rule that frames every telegram blank.
+    c.fill(...PAPER).rect(0, 0, PAGE_W, PAGE_H);
+    c.stroke(...INK).width(2).rect(M, M, PAGE_W - M * 2, PAGE_H - M * 2, 'S');
+    c.width(0.6).rect(M + 5, M + 5, PAGE_W - (M + 5) * 2, PAGE_H - (M + 5) * 2, 'S');
+
+    // ---- letterhead
+    let y = M + 20;
+    const markH = 30;
+    drawMark(c, (PAGE_W - MARK_VIEWBOX.w * (markH / MARK_VIEWBOX.h)) / 2, y, markH);
+    y += markH + 20;
+    c.fill(...INK).trackedCentered(y, 'SIDECAR TELEGRAPH COMPANY', 15, 'F2', 2.2);
+    y += 16;
+    c.fill(...BRONZE).trackedCentered(y, 'KEY CUSTODY DIVISION', 8, 'F1', 1.6);
+    y += 14;
+    c.stroke(...BRONZE).width(1).line(M + 22, y, PAGE_W - M - 22, y);
+    y += 3;
+    c.width(0.5).line(M + 22, y, PAGE_W - M - 22, y);
+
+    // ---- the form strip a real blank carried across the top
+    y += 20;
+    const colX = [M + 22, M + 190, M + 350];
+    c.fill(...BRONZE);
+    c.text(colX[0], y, 'CLASS OF SERVICE', 6.5, 'F1');
+    c.text(colX[1], y, 'SERIAL', 6.5, 'F1');
+    c.text(colX[2], y, 'FILED (UTC)', 6.5, 'F1');
+    y += 11;
+    c.fill(...INK);
+    // A real blank's classes (FULL RATE, DAY LETTER, NIGHT LETTER) all describe
+    // delivery speed, which means nothing for a key backup. Same visual slot, but
+    // spend it on an instruction the holder can act on.
+    c.text(colX[0], y, 'PERMANENT RECORD', 9, 'F2');
+    c.text(colX[1], y, serialFor(npub), 9, 'F2');
+    c.text(colX[2], y, stamp, 9, 'F2');
+    y += 9;
+    c.stroke(...INK).width(0.5).line(M + 22, y, PAGE_W - M - 22, y);
+
+    // ---- addressing
+    y += 18;
+    c.fill(...BRONZE).text(colX[0], y, 'TO', 6.5, 'F1');
+    // At account creation there is no profile yet — nsecModal runs before the setup
+    // wizard — so the name is only available when printing for an existing account.
+    const to = (opts.name || '').trim();
+    c.fill(...INK).text(colX[0] + 26, y, to ? to.toUpperCase() : 'THE BEARER OF THIS SHEET', 9, 'F2');
+    y += 13;
+    c.fill(...BRONZE).text(colX[0], y, 'FROM', 6.5, 'F1');
+    c.fill(...INK).text(colX[0] + 26, y, 'SIDECAR SIGNER, YOUR OWN DEVICE', 9, 'F2');
+    y += 13;
+    // KEY, not NPUB: the value on this line already begins "npub1", so an NPUB label
+    // prints the same word twice on one line. "PUBLIC KEY" would be more precise but
+    // overruns the 26pt label gutter TO and FROM share — and the value self-identifies
+    // anyway, with the secret half explicitly labelled on the box below.
+    c.fill(...BRONZE).text(colX[0], y, 'KEY', 6.5, 'F1');
+    c.fill(...INK).text(colX[0] + 26, y, npub, 7.4, 'F1');
+    y += 10;
+    c.stroke(...BRONZE).width(0.5).line(M + 22, y, PAGE_W - M - 22, y);
+
+    // ---- message (the conceit lives here and nowhere else)
+    y += 20;
+    c.fill(...BRONZE).trackedCentered(y, 'M E S S A G E', 7.5, 'F1', 1.2);
+    y += 18;
+    c.fill(...INK);
+    // STOP on the closing line only. Telegrams used it because punctuation cost
+    // extra and read ambiguously over the wire — it was sparing, not rhythmic.
+    for (const l of [
+      // "Identity", not "account": there is no account here, no provider and nothing
+      // to log into, which is exactly why nobody can reset it for you. Borrowing the
+      // web word would import the mental model this sheet exists to correct.
+      'THIS SHEET RESTORES YOUR NOSTR IDENTITY.',
+      'THE KEY BELOW IS THAT IDENTITY.',
+      'SIDECAR KEEPS NO COPY AND CANNOT REISSUE IT.',
+      'STORE IT WHERE YOU STORE PASSPORTS. STOP',
+    ]) { c.text(colX[0], y, l, 9.5, 'F2'); y += 14; }
+
+    // ---- the key, in a box, as selectable text
+    y += 8;
+    const boxH = 44;
+    c.fill(1, 1, 1).rect(M + 22, y, PAGE_W - (M + 22) * 2, boxH);
+    c.stroke(...INK).width(1).rect(M + 22, y, PAGE_W - (M + 22) * 2, boxH, 'S');
+    c.fill(...BRONZE).text(M + 30, y + 12, 'SECRET KEY (NSEC) - SELECTABLE TEXT, COPY IT EXACTLY', 6.5, 'F1');
+    // 8.2pt Courier keeps all 63 bech32 characters on one unbroken line: a wrapped
+    // key invites a transcription error at the one moment that must not go wrong.
+    c.fill(...INK).text(M + 30, y + 31, nsec, 8.2, 'F2');
+    y += boxH + 22;
+
+    // ---- QR, captioned
+    const qrSize = 150;
+    const qrX = (PAGE_W - qrSize) / 2;
+    c.stroke(...INK).width(1).rect(qrX - 6, y - 6, qrSize + 12, qrSize + 12, 'S');
+    drawQr(c, nsec, qrX, y, qrSize);
+    y += qrSize + 16;
+    c.fill(...BRONZE).centered(y, 'SCAN TO RESTORE - THIS CODE IS THE KEY', 7, 'F1');
+
+    // ---- warnings, in plain sentences on purpose
+    y += 26;
+    c.stroke(...INK).width(0.5).line(M + 22, y, PAGE_W - M - 22, y);
+    y += 16;
+    c.fill(...INK).text(colX[0], y, 'Keep this safe', 10, 'F2');
+    y += 15;
+    for (const l of [
+      'Anyone who photographs or copies this sheet becomes you on Nostr.',
+      'It cannot be undone or revoked. Treat it like cash.',
+      '',
+      'Sidecar erases every key on this device after 21 wrong PIN attempts.',
+      'If that happens, this sheet is the only way back. Store it offline -',
+      "anywhere that syncs is a copy you don't control.",
+    ]) { if (l) c.text(colX[0], y, l, 8.6, 'F1'); y += 12; }
+
+    // ---- footer
+    const footY = PAGE_H - M - 22;
+    c.stroke(...BRONZE).width(0.5).line(M + 22, footY - 12, PAGE_W - M - 22, footY - 12);
+    c.fill(...BRONZE).text(colX[0], footY, 'SIDECAR - A CLASSY NOSTR SIGNER', 7, 'F1');
+    const site = 'sidecar.top';
+    c.text(PAGE_W - M - 22 - textWidth(site, 7), footY, site, 7, 'F1');
+
+    // ---- object graph
+    const stream = c.toString();
+    const streamBytes = new TextEncoder().encode(stream).length;
+    const font = (name) => `<< /Type /Font /Subtype /Type1 /BaseFont /${name} /Encoding /WinAnsiEncoding >>`;
+    return assemble([
+      '<< /Type /Catalog /Pages 2 0 R >>',
+      '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+      `<< /Type /Page /Parent 2 0 R /MediaBox [0 0 ${PAGE_W} ${PAGE_H}] ` +
+        '/Resources << /Font << /F1 5 0 R /F2 6 0 R >> >> /Contents 4 0 R >>',
+      `<< /Length ${streamBytes} >>\nstream\n${stream}\nendstream`,
+      font('Courier'),
+      font('Courier-Bold'),
+    ]);
+  }
+
+  // Filename mirrors the vault export's convention (sidecar-backup-<npub12>.json).
+  function filename(npub) {
+    return 'sidecar-key-' + ascii(npub).slice(0, 12) + '.pdf';
+  }
+
+  root.SidecarBackupPdf = { build, filename };
+})(window);

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -558,6 +558,8 @@
   <script src="crypto.js"></script>
   <script src="qrcode-generator.js"></script>
   <script src="qr.js"></script>
+  <!-- after qrcode-generator: pdf-backup draws the QR from its module matrix -->
+  <script src="pdf-backup.js"></script>
   <script src="nwc-client.js"></script>
   <script src="version.js"></script>
   <script src="sidepanel.js"></script>

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -3499,14 +3499,22 @@
       if (gen && gen.nsec) {
         nsecModal({
           nsec: gen.nsec,
-          offerSheet: true,
           title: 'Back up your new key',
           intro:
-            'Sidecar generated a new account. This nsec is the only way to recover it — save it now, or download a printable backup sheet. You can view it again later behind your PIN.',
+            'Sidecar generated a new account. This nsec is the only way to recover it — save it now. You can view it again later behind your PIN.',
           // A brand-new key has no profile yet — once they've backed it up, run a
           // short setup wizard (name → photo → bio), which publishes what they
           // fill in and lands them on the Profile tab to complete the rest.
-          onDone: () => profileSetupWizard(gen.pubkey),
+          //
+          // The backup sheet is offered AFTER the wizard, not here: it prints the
+          // display name in its TO line, so a sheet taken before the profile exists
+          // is addressed to "THE BEARER OF THIS SHEET" forever. The nsec is still in
+          // this closure by then, so the offer costs no PIN prompt.
+          onDone: () =>
+            profileSetupWizard(gen.pubkey, () => {
+              const acct = (state.accounts || []).find((a) => a.pubkey === gen.pubkey);
+              backupSheetPromptModal(gen.nsec, acct || null);
+            }),
         });
       }
     } catch (e) {
@@ -3844,6 +3852,30 @@
     }
   }
 
+  // Offered once, after the setup wizard, so the sheet carries their name.
+  // Dismissible: the key is already stored, so gating anything here would be
+  // theatre. Copy is deliberately two lines — this renders in a ~360px panel,
+  // and a wall of text in a small rectangle just gets clicked past.
+  function backupSheetPromptModal(nsec, account) {
+    openModal((modal) => {
+      const grab = h('button', { className: 'primary', textContent: 'Download' });
+      grab.addEventListener('click', () => {
+        downloadBackupSheet(nsec, account);
+        closeModal();
+      });
+      const skip = h('button', { className: 'ghost', textContent: 'Not now' });
+      skip.addEventListener('click', closeModal);
+      modal.append(
+        h('h3', { textContent: 'Print a backup sheet' }),
+        h('p', {
+          className: 'hint',
+          textContent: 'One page with your key and a QR code. The only way back if you forget your PIN.',
+        }),
+        h('div', { className: 'actions' }, [grab, skip])
+      );
+    });
+  }
+
   function nsecModal(opts) {
     let stop = null;
     openModal(
@@ -3852,28 +3884,15 @@
         const done = h('button', { className: 'primary', textContent: "I've saved it" });
         done.addEventListener('click', closeModal);
 
-        const actions = [];
-        // The printable sheet is the durable artifact this screen was missing: the
-        // only other ways off this modal are the clipboard (cleared after 60s) and a
-        // screenshot. Offered for an nsec only — an ncryptsec sheet would be useless
-        // without the separate password, which is the thing people forget.
-        if (opts.offerSheet && (opts.secret || opts.nsec)) {
-          const sheet = h('button', { className: 'secondary', textContent: 'Download backup sheet' });
-          sheet.addEventListener('click', () => {
-            // The reveal's 30s timer would close this modal mid-decision. Cancel it
-            // once the user commits to the download and let them close deliberately.
-            if (stop) { stop(); stop = null; }
-            downloadBackupSheet(opts.secret || opts.nsec, opts.account);
-          });
-          actions.push(sheet);
-        }
-        actions.push(done);
-
+        // No sheet button here on purpose. At account creation there is no profile
+        // yet, and the sheet prints the display name — one taken now is addressed to
+        // "THE BEARER OF THIS SHEET" permanently. It's offered after the setup
+        // wizard instead (see generateAccount), and from Profile → Backup & restore.
         modal.append(
           h('h3', { textContent: opts.title }),
           opts.intro ? h('p', { className: 'hint', textContent: opts.intro }) : document.createTextNode(''),
           body,
-          h('div', { className: 'actions' }, actions)
+          h('div', { className: 'actions' }, [done])
         );
         stop = renderSecretReveal(body, {
           secret: opts.secret || opts.nsec,
@@ -6723,7 +6742,9 @@
   // Finish, "I'll do this later", the X, or the backdrop — runs `commit` once
   // (guarded), which publishes BEFORE closing so the profile never flashes the
   // interim auto-generated cocktail name.
-  function profileSetupWizard(newPubkey) {
+  // onDone runs after the wizard commits, whichever way it exits (finish, "later",
+  // or the X) — commit() is the single exit for all three.
+  function profileSetupWizard(newPubkey, onDone) {
     const draft = { display_name: '', picture: '', about: '' };
     const STEPS = 3;
     let step = 1;
@@ -6762,6 +6783,9 @@
       renderMain();
       closeModal();
       if (hasContent && targetOk) toast('Profile saved', 'success');
+      // Deferred a tick for the same reason nsecModal defers: closeModal clears
+      // #modal right after this returns, and onDone opens another modal.
+      if (onDone) setTimeout(onDone, 0);
     }
 
     openModal(

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -3499,9 +3499,10 @@
       if (gen && gen.nsec) {
         nsecModal({
           nsec: gen.nsec,
+          offerSheet: true,
           title: 'Back up your new key',
           intro:
-            'Sidecar generated a new account. This nsec is the only way to recover it — save it now. You can view it again later behind your PIN.',
+            'Sidecar generated a new account. This nsec is the only way to recover it — save it now, or download a printable backup sheet. You can view it again later behind your PIN.',
           // A brand-new key has no profile yet — once they've backed it up, run a
           // short setup wizard (name → photo → bio), which publishes what they
           // fill in and lands them on the Profile tab to complete the rest.
@@ -3816,6 +3817,33 @@
   // the post-generate "back this up now" flow (a brand-new key has no
   // ncryptsec-export use case yet). Backing up an *existing* account's key
   // goes through keyBackupModal instead, which offers both nsec and ncryptsec.
+  // Download the printable backup sheet (see pdf-backup.js) for one account.
+  // Generated entirely in the panel — the nsec never leaves the extension, and no
+  // network call is involved.
+  function downloadBackupSheet(nsec, account) {
+    try {
+      const npub = (account && account.npub) || (nsec ? NT.nip19.npubEncode(NT.nip19.decode(nsec).data) : '');
+      const blob = window.SidecarBackupPdf.build({
+        nsec,
+        npub,
+        // Only present for an existing account; a key made seconds ago has no
+        // profile yet, and the sheet falls back to "THE BEARER OF THIS SHEET".
+        name: account && account.name ? displayName(account) : '',
+      });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = window.SidecarBackupPdf.filename(npub);
+      a.click();
+      URL.revokeObjectURL(url);
+      toast('Backup sheet downloaded', 'success');
+      return true;
+    } catch (e) {
+      toast("Couldn't create the backup sheet", 'error');
+      return false;
+    }
+  }
+
   function nsecModal(opts) {
     let stop = null;
     openModal(
@@ -3823,11 +3851,29 @@
         const body = h('div', {});
         const done = h('button', { className: 'primary', textContent: "I've saved it" });
         done.addEventListener('click', closeModal);
+
+        const actions = [];
+        // The printable sheet is the durable artifact this screen was missing: the
+        // only other ways off this modal are the clipboard (cleared after 60s) and a
+        // screenshot. Offered for an nsec only — an ncryptsec sheet would be useless
+        // without the separate password, which is the thing people forget.
+        if (opts.offerSheet && (opts.secret || opts.nsec)) {
+          const sheet = h('button', { className: 'secondary', textContent: 'Download backup sheet' });
+          sheet.addEventListener('click', () => {
+            // The reveal's 30s timer would close this modal mid-decision. Cancel it
+            // once the user commits to the download and let them close deliberately.
+            if (stop) { stop(); stop = null; }
+            downloadBackupSheet(opts.secret || opts.nsec, opts.account);
+          });
+          actions.push(sheet);
+        }
+        actions.push(done);
+
         modal.append(
           h('h3', { textContent: opts.title }),
           opts.intro ? h('p', { className: 'hint', textContent: opts.intro }) : document.createTextNode(''),
           body,
-          h('div', { className: 'actions' }, [done])
+          h('div', { className: 'actions' }, actions)
         );
         stop = renderSecretReveal(body, {
           secret: opts.secret || opts.nsec,
@@ -3936,32 +3982,43 @@
   }
 
   // PIN-gated step-up, then the tabbed nsec/ncryptsec backup view below.
-  function backupKeyModal(a) {
+  // opts.sheetOnly: the caller wants the printable sheet, so the PIN gate hands the
+  // revealed nsec straight to the download instead of putting it on screen. Same
+  // gate either way — the sheet is the key in another wrapper.
+  function backupKeyModal(a, opts) {
+    const sheetOnly = !!(opts && opts.sheetOnly);
     openModal((modal) => {
       const pin = h('input', { type: 'password', maxLength: 32 });
       const err = h('div', { className: 'error' });
-      const go = h('button', { className: 'primary', textContent: 'Reveal' });
+      const goLabel = sheetOnly ? 'Download sheet' : 'Reveal';
+      const go = h('button', { className: 'primary', textContent: goLabel });
       go.addEventListener('click', async () => {
         err.textContent = '';
         if (!pin.value) return (err.textContent = 'Enter your PIN.');
         go.disabled = true;
-        go.textContent = 'Revealing…';
+        go.textContent = sheetOnly ? 'Preparing…' : 'Revealing…';
         try {
           const r = await call({ type: 'SIDECAR_REVEAL_NSEC', pubkey: a.pubkey, pin: pin.value });
           closeModal();
-          setTimeout(() => keyBackupModal(a, r.nsec), 0);
+          if (sheetOnly) downloadBackupSheet(r.nsec, a);
+          else setTimeout(() => keyBackupModal(a, r.nsec), 0);
         } catch (e) {
           err.textContent = e.message;
           go.disabled = false;
-          go.textContent = 'Reveal';
+          go.textContent = goLabel;
           toast(e.message, 'error');
         }
       });
       const cancel = h('button', { className: 'ghost', textContent: 'Cancel' });
       cancel.addEventListener('click', closeModal);
       modal.append(
-        h('h3', { textContent: 'Back up private key' }),
-        h('p', { className: 'hint', textContent: 'Enter your PIN to reveal the key for ' + displayName(a) + '.' }),
+        h('h3', { textContent: sheetOnly ? 'Download key sheet' : 'Back up private key' }),
+        h('p', {
+          className: 'hint',
+          textContent: sheetOnly
+            ? 'Enter your PIN to build a printable backup sheet for ' + displayName(a) + '.'
+            : 'Enter your PIN to reveal the key for ' + displayName(a) + '.',
+        }),
         h('label', { textContent: 'PIN' }),
         pin,
         err,
@@ -4065,6 +4122,14 @@
         const done = h('button', { className: 'primary', textContent: "I've saved it" });
         done.addEventListener('click', closeModal);
 
+        // Also offered here, so someone who came to look at the key can leave with
+        // the printable copy instead of reaching for a screenshot.
+        const sheet = h('button', { className: 'secondary', textContent: 'Download backup sheet' });
+        sheet.addEventListener('click', () => {
+          stop(); // cancel the 30s auto-hide; let them close deliberately
+          downloadBackupSheet(nsec, a);
+        });
+
         modal.append(
           h('h3', { textContent: 'Back up private key' }),
           h('p', {
@@ -4073,7 +4138,7 @@
           }),
           h('div', { className: 'modal-tabs' }, [tabNsec, tabNcrypt]),
           body,
-          h('div', { className: 'actions' }, [done])
+          h('div', { className: 'actions' }, [sheet, done])
         );
 
         showNsecTab();
@@ -7821,6 +7886,27 @@
       exportBtn.disabled = false;
     });
 
+    // The printable key sheet. Deliberately in its own block below the JSON export
+    // with its own heading and warning: that file contains no secret and is safe to
+    // click, this one IS the key. Two lookalike buttons side by side would invite
+    // exactly the mistake that matters most here.
+    const sheetWrap = h('div', { className: 'export-block' });
+    sheetWrap.append(
+      h('h3', { textContent: 'Printable key sheet' }),
+      h('p', {
+        className: 'hint',
+        textContent:
+          'A one-page sheet with your secret key as text and a QR, made to be printed and stored offline. Unlike the file above, this IS your key — anyone holding it becomes you.',
+      })
+    );
+    const sheetBtn = h('button', { className: 'secondary', textContent: 'Download key sheet' });
+    sheetBtn.addEventListener('click', () => {
+      // Same step-up PIN gate as revealing the nsec anywhere else — the sheet is
+      // the key in another wrapper, so it can't be a cheaper way to get at it.
+      backupKeyModal(active, { sheetOnly: true });
+    });
+    sheetWrap.append(sheetBtn);
+
     const importBtn = h('button', { className: 'secondary', textContent: 'Restore from file' });
     const fileInput = document.createElement('input');
     fileInput.type = 'file';
@@ -7840,7 +7926,7 @@
     });
 
     exportWrap.append(exportBtn, importBtn, fileInput);
-    setting.append(exportWrap);
+    setting.append(exportWrap, sheetWrap);
 
     // Follow-list recovery — scan relays for an older kind:3 and republish it.
     const recoveryWrap = h('div', { className: 'export-block recovery-block' });

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -3508,8 +3508,13 @@
           //
           // The backup sheet is offered AFTER the wizard, not here: it prints the
           // display name in its TO line, so a sheet taken before the profile exists
-          // is addressed to "THE BEARER OF THIS SHEET" forever. The nsec is still in
-          // this closure by then, so the offer costs no PIN prompt.
+          // is addressed to "THE BEARER OF THIS SHEET" forever.
+          //
+          // This keeps gen.nsec reachable in the closure for the wizard's duration
+          // rather than only the reveal modal's. Considered and accepted: JS strings
+          // can't be zeroed, the panel already holds the key for the reveal, and the
+          // alternative is a PIN step-up moments after the user set the PIN. It ends
+          // when generateAccount's frame is collected.
           onDone: () =>
             profileSetupWizard(gen.pubkey, () => {
               const acct = (state.accounts || []).find((a) => a.pubkey === gen.pubkey);
@@ -3844,7 +3849,11 @@
       a.download = window.SidecarBackupPdf.filename(npub);
       a.click();
       URL.revokeObjectURL(url);
-      toast('Backup sheet downloaded', 'success');
+      // Every warning on the sheet addresses the printed paper. This one addresses
+      // the file: it lands in ~/Downloads as a plaintext key, in a folder that is
+      // routinely cloud-synced, indexed and backed up — exactly what the sheet
+      // itself tells you not to do with it.
+      toast('Downloaded — print it, then delete the file', 'success');
       return true;
     } catch (e) {
       toast("Couldn't create the backup sheet", 'error');
@@ -3869,7 +3878,7 @@
         h('h3', { textContent: 'Print a backup sheet' }),
         h('p', {
           className: 'hint',
-          textContent: 'One page with your key and a QR code. The only way back if you forget your PIN.',
+          textContent: 'One page with your key and a QR code. Print it, then delete the file.',
         }),
         h('div', { className: 'actions' }, [grab, skip])
       );
@@ -4145,8 +4154,12 @@
         // the printable copy instead of reaching for a screenshot.
         const sheet = h('button', { className: 'secondary', textContent: 'Download backup sheet' });
         sheet.addEventListener('click', () => {
-          stop(); // cancel the 30s auto-hide; let them close deliberately
           downloadBackupSheet(nsec, a);
+          // RESTART the 30s auto-hide rather than cancelling it. Cancelling would
+          // leave the nsec on screen indefinitely, trading shoulder-surfing
+          // protection for the convenience of one click; restarting gives a full
+          // fresh window without ever removing the guard.
+          if (tabNsec.classList.contains('active')) showNsecTab();
         });
 
         modal.append(
@@ -7920,7 +7933,7 @@
       h('p', {
         className: 'hint',
         textContent:
-          'A one-page sheet with your secret key as text and a QR, made to be printed and stored offline. Unlike the file above, this IS your key — anyone holding it becomes you.',
+          'A one-page sheet with your secret key as text and a QR, made to be printed and stored offline. Unlike the file above, this IS your key — print it, then delete the download.',
       })
     );
     const sheetBtn = h('button', { className: 'secondary', textContent: 'Download key sheet' });


### PR DESCRIPTION
## Why

A new account's nsec is shown once behind a 30-second auto-hide, and the only ways to capture it were the clipboard (which we clear after 60s) or a screenshot. Neither is a durable backup.

That matters more than it looks: **21 wrong PIN attempts erases every key on the device** (`MAX_UNLOCK_FAILS`, background.js). An account whose nsec was never written down is permanently gone. This is the artifact that makes that recoverable.

## What

`pdf-backup.js` builds a one-page sheet — nsec as selectable text, a QR of the same key, the npub, a serial, and plain-language warnings.

**No new dependency.** VENDOR.md holds us to four bundles, each byte-traceable to an npm artifact and SHA-256 verified in CI. A PDF library would add a fifth (~350KB) and fresh supply-chain surface for what is, in the end, ruled lines and monospace text. PDF is a text format and Courier is one of the standard-14 fonts, so nothing is embedded. The QR draws as vector rectangles from the `qrcode-generator` modules we already vendor; the logo is `icons/sidecar-mark.svg` transcribed to path operators. Both stay crisp at any print size.

## Verified, not eyeballed

- All xref offsets resolve to their objects; declared stream length matches actual
- The nsec is emitted as a `Tj` literal, so it is genuinely selectable/copyable
- The rendered QR decodes back to the exact nsec through our own `jsqr.js`

## Entry points

PIN-gated wherever the key isn't already on screen:

1. **After the profile setup wizard** — a short, dismissible prompt
2. **Profile → Backup & restore** — its own block *below* the JSON export
3. **Account menu → Back up private key**

It is deliberately *not* offered at key reveal. The sheet prints the display name in its `TO` line, and the profile doesn't exist yet at that point — a sheet taken there would be addressed to "THE BEARER OF THIS SHEET" permanently. `profileSetupWizard` gained an `onDone` hook fired from `commit()`, its single exit, so the prompt can't be skipped by closing the wizard sideways.

The prompt is dismissible; the key is already stored by then, so gating behind it would be theatre. Copy is 18 words — this renders in a ~360px panel, where a wall of text isn't read, it's clicked past.

The profile block is deliberately **not** a matching button beside the JSON export. That file carries no secret and is safe to click without thinking; this one is the key itself. Two lookalike buttons in a row is the arrangement that produces the mistake you can't take back.

## Paper tint

Split in two, because a full-bleed tint is a ~7% halftone over every square inch on a mono laser:

- The **border band** always prints — 6% of the page instead of 100%, so it still reads as warm stock at a twentieth of the ink.
- The **full-page fill** sits in an optional content group with `/PrintState /OFF`, so viewers show a fully cream page and renderers that honor optional content drop it.

Support is uneven (Acrobat honors it; CUPS on macOS passes the file through byte-identically, so the decision falls to whatever renders last). Built to degrade well rather than be relied on: if ignored, the sheet prints fully tinted — the ink cost, not a broken document.

## Note on tone

The telegram conceit is confined to the letterhead and MESSAGE block. The warnings below it are plain sentences. A pastiche rendering "anyone holding this becomes you" as caps-and-STOP would trade a real warning for a gag, on the one sheet that exists for the moment someone has lost everything else.

## Not done here

- Not exercised in an unpacked build — the download path, PIN gate and auto-hide interaction all want a real click-through
- The QR encodes the nsec, so a photo of the sheet is instant, irreversible compromise. Deliberate (one-scan restore) but worth a second opinion before printing sheets in the wild
- Letter only, no A4

🥃 stirred with [Claude Code](https://claude.ai/code)
