### PR TITLE
Fix the NWC dead socket: rebuild the client instead of reusing a corpse

### DIFF
--- a/background.js
+++ b/background.js
@@ -1717,6 +1717,19 @@ async function payAndConfirm(c, invoice) {
     dlog('error', 'pay', 'reporting failure; wallet never confirmed a settlement', {
       error: (first.err && first.err.message) || 'unknown',
     });
+    // Drop the cached client so the NEXT attempt builds a fresh socket.
+    //
+    // This is the actual fix for the reported failure. getSwNwc caches on pubkey with
+    // no health check, and the only invalidations were lock / SET_NWC / CLEAR_NWC — so
+    // a dead socket was reused forever and every retry burned the full 30s timeout.
+    // Recovery only happened by accident, when the service worker was evicted and
+    // cleared the module-level cache; that's why "it worked after I waited".
+    //
+    // Safe here: we've already exhausted pay_invoice AND the lookup_invoice grace
+    // window, so nothing is in flight on this client. Only reached on an
+    // indeterminate outcome — a walletDenied answer returns above and keeps the
+    // working connection, since the wallet plainly reached us.
+    closeSwNwc();
     throw first.err || (second.kind === 'error' ? second.err : new Error('Payment status unknown'));
   } finally {
     stop = true;

--- a/nwc-client.js
+++ b/nwc-client.js
@@ -77,7 +77,16 @@
     // most a couple of clients are alive at once and the validation probes are
     // short-lived.
     let _pool = null;
-    const pool = () => (_pool || (_pool = new NT.SimplePool()));
+    // enableReconnect, because nostr-tools defaults it to FALSE: without it,
+    // handleHardClose closes every subscription and never reopens, so one dropped
+    // socket leaves this client permanently dead. Every later request then publishes
+    // into a corpse and waits out the full REQUEST_TIMEOUT — which is how a healthy
+    // relay got reported as "the relay looks down".
+    //
+    // Not a complete fix on its own: reconnect backoff starts at 10s and the kind:23195
+    // reply is ephemeral, so a request already in flight is still lost. It keeps a
+    // long-lived client healthy; getSwNwc's invalidation handles the in-flight case.
+    const pool = () => (_pool || (_pool = new NT.SimplePool({ enableReconnect: true })));
     let closed = false;
 
     const encrypt = (text) => NT.nip04.encrypt(sk, walletPubkey, text);
@@ -104,6 +113,10 @@
           );
           let settled = false;
           let timer = null;
+          // Whether any relay accepted the request event. Distinguishes "nobody heard
+          // us" (a dead local socket) from "we were heard and nothing came back"
+          // (a quiet wallet) when the timeout fires.
+          let published = false;
           // nostr-tools ≥2.20 subscriptions take a single filter object, not an array.
           const sub = pool().subscribeMany(
             [relay],
@@ -143,6 +156,15 @@
               const host = (() => { try { return new URL(relay).host; } catch (_) { return relay; } })();
               err = new Error("Can't reach your wallet's relay (" + host + ") — the relay looks down, not Sidecar.");
               err.relayDown = true;
+            } else if (!published) {
+              // Third case, and the one that produced a false accusation: the relay
+              // answers a fresh probe, but OUR socket never accepted the publish — a
+              // connection that died while idle. Blaming the relay or the wallet is
+              // wrong; the honest answer is that the link went stale and a retry
+              // (which now builds a new client — see closeSwNwc in payAndConfirm)
+              // will work.
+              err = new Error('Lost the connection to your wallet — please try again.');
+              err.staleSocket = true;
             } else {
               err = new Error("Your wallet didn't respond in time — it may be offline or not running.");
               err.walletSilent = true;
@@ -153,6 +175,7 @@
           }, timeoutMs || REQUEST_TIMEOUT);
           try {
             await Promise.any(pool().publish([relay], reqEvent));
+            published = true;
           } catch (_) {
             /* if no relay accepted, the timeout will reject — with a probed message */
           }

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -1647,9 +1647,13 @@
   }
 
   // ---- relay pool (fetch + publish) ----
+  // enableReconnect: nostr-tools defaults it to false, which means a socket dropped
+  // while the panel sat idle is never reopened — the same latent bug the NWC client
+  // had. The panel is long-lived, so this pool is exactly where it bites: a composer
+  // publish or profile fetch after the laptop wakes would go into a dead socket.
   let _pool = null;
   function getPool() {
-    if (!_pool) _pool = new NT.SimplePool();
+    if (!_pool) _pool = new NT.SimplePool({ enableReconnect: true });
     return _pool;
   }
   const poolGet = (relays, filter) => getPool().get(relays, filter);
@@ -9537,8 +9541,12 @@
         // Name the cause when the client could work it out (#120): a relay that's
         // down reads as a Sidecar failure otherwise. Kept short — this sits under
         // the balance in a narrow panel; the full sentence goes in the toast.
-        unit.textContent = e && e.relayDown ? 'wallet relay unreachable' : 'balance unavailable';
-        if (e && (e.relayDown || e.walletSilent)) toast(e.message, 'error');
+        unit.textContent = e && e.relayDown
+          ? 'wallet relay unreachable'
+          : e && e.staleSocket
+            ? 'connection lost — retry'
+            : 'balance unavailable';
+        if (e && (e.relayDown || e.walletSilent || e.staleSocket)) toast(e.message, 'error');
       }
     }
     bal.classList.remove('loading');

--- a/test/nwc-pool-lifecycle.test.js
+++ b/test/nwc-pool-lifecycle.test.js
@@ -41,12 +41,13 @@ const CONN = 'nostr+walletconnect://' + WALLET_PK + '?relay=' + encodeURICompone
 // Builds a context with a fake nostr-tools whose SimplePool records every
 // construction and close, so the test can see how many pools exist and which
 // relays each one shut.
-function harness({ respond, probeOpens = true } = {}) {
+function harness({ respond, probeOpens = true, publishFails = false } = {}) {
   const pools = [];
   const sockets = [];
 
   class FakePool {
-    constructor() {
+    constructor(opts) {
+      this.opts = opts || null;
       this.id = pools.length;
       this.closedRelays = [];
       this.subs = [];
@@ -65,7 +66,7 @@ function harness({ respond, probeOpens = true } = {}) {
       return sub;
     }
     publish(relays, ev) {
-      const dead = relays.some((r) => this.closedRelays.includes(r));
+      const dead = relays.some((r) => this.closedRelays.includes(r)) || publishFails;
       this.published.push({ ev, dead });
       return dead ? [Promise.reject(new Error('relay closed'))] : [Promise.resolve('ok')];
     }
@@ -213,6 +214,39 @@ test('a timeout with a reachable relay blames the wallet', async () => {
   );
 });
 
+test('a reachable relay that never accepted the publish blames the CONNECTION', async () => {
+  // The third case, and the one that produced a false accusation in the field: the
+  // relay answers a fresh probe, but our own socket died while idle so the request
+  // was never accepted. Reported as the wallet being quiet, it sent the user to
+  // check a wallet that was fine; reported as the relay being down, it accused a
+  // healthy relay.
+  const h = harness({ probeOpens: true, publishFails: true });
+  const c = h.makeClient(CONN);
+  await assert.rejects(
+    () => c.lookupInvoice({ payment_hash: 'x' }, 1),
+    (err) => {
+      assert.match(err.message, /lost the connection/i);
+      assert.equal(err.staleSocket, true);
+      assert.ok(!err.relayDown, 'must not accuse the relay — the probe reached it');
+      assert.ok(!err.walletSilent, 'must not accuse the wallet — it was never asked');
+      assert.ok(!err.walletDenied, 'still indeterminate for spends');
+      return true;
+    }
+  );
+});
+
+test('an unreachable relay still blames the relay even when the publish fails', async () => {
+  // Ordering guard: a dead relay ALSO fails to accept the publish, so the staleSocket
+  // branch must not shadow relayDown. The probe is the stronger signal and wins.
+  const h = harness({ probeOpens: false, publishFails: true });
+  const c = h.makeClient(CONN);
+  await assert.rejects(() => c.lookupInvoice({ payment_hash: 'x' }, 1), (err) => {
+    assert.equal(err.relayDown, true);
+    assert.ok(!err.staleSocket);
+    return true;
+  });
+});
+
 test('neither timeout claims the money stayed put', async () => {
   // The rejection contract: only walletDenied means no money moved. A caller that
   // spends must still verify with lookup_invoice after either of these.
@@ -275,4 +309,17 @@ test('the notification handle close() does not close the client', () => {
 test('the client-level close is not shadowed', () => {
   assert.match(source, /let subClosed = false;/,
     'the notification subscription must not reuse the name `closed`');
+});
+
+test('the pool is built with reconnect ENABLED', async () => {
+  // The root cause of the reported dead-socket failure: nostr-tools defaults
+  // enableReconnect to false, so handleHardClose closed every subscription and never
+  // reopened. One dropped socket left the client permanently dead, and every later
+  // request burned the full timeout publishing into a corpse. Recovery only happened
+  // by accident, when the service worker was evicted and cleared the cache.
+  const h = harness({ probeOpens: true });
+  const c = h.makeClient(CONN);
+  await h.touch(c);
+  assert.equal(h.pools.length, 1);
+  assert.equal(h.pools[0].opts && h.pools[0].opts.enableReconnect, true);
 });


### PR DESCRIPTION
Closes #178 — the diagnosed cause of a real zap failure, where a payment timed out and reported *"Can't reach your wallet's relay (relay.getalby.com) — the relay looks down, not Sidecar"* while the relay was in fact fine.

## What was happening

1. `nwc-client.js` built `new NT.SimplePool()` with no options, and nostr-tools defaults **`enableReconnect` to `false`** — so `handleHardClose` closed every subscription and never reopened.
2. `getSwNwc` caches that client on **pubkey alone**, with no health check. The only invalidations were lock / `SET_NWC` / `CLEAR_NWC` — **nothing on failure**.
3. So once the socket died (sleep, network change, relay idle-disconnect), every later `pay_invoice` published into a corpse and waited out the full 30s `REQUEST_TIMEOUT`.
4. `probeRelay` then opened a *fresh* socket. With the network still waking that failed inside 5s, and we blamed the relay.

Recovery was accidental: `swNwc` is module state, so it only cleared when the service worker was evicted (~30s idle). That is why retrying "just worked" after a wait.

## The fix

**Invalidate on an indeterminate outcome.** `payAndConfirm` now calls `closeSwNwc()` before reporting failure, so the next attempt builds a fresh client and socket. Deterministic instead of depending on SW eviction. Safe there: `pay_invoice` and the `lookup_invoice` grace window are both exhausted, so nothing is in flight — and a `walletDenied` answer returns earlier and keeps the connection, since the wallet plainly reached us.

**`enableReconnect: true` on both pools.** `nwc-client.js:80` and `sidepanel.js:1652`. The panel pool had the same latent bug: a composer publish or profile fetch after the laptop wakes would go into a dead socket. Won't rescue a request already in flight — kind 23195 is ephemeral and isn't replayed, and backoff starts at 10s — but it keeps a long-lived client healthy.

**A third error branch, so we stop accusing the innocent.** The timeout had two: probe fails → blame the relay; probe succeeds → blame the wallet. Neither fits the actual case. It now tracks whether any relay accepted the publish, and reports *"Lost the connection to your wallet — please try again"* (`staleSocket`), surfaced on the wallet card as "connection lost — retry".

## Tests

`publishFails` added to the harness, plus three cases:

- a reachable relay that never accepted the publish blames the **connection**, not the relay or the wallet
- an unreachable relay still wins over that branch — an **ordering guard**, since a dead relay also fails to publish and `relayDown` must not be shadowed
- the pool is constructed with **reconnect enabled** — the root cause deserves a regression guard

17 tests in that file, full suite green.

## Worth a real check

The invalidation and error wording are unit-covered, but the original failure needed a genuinely stale socket. Reproducing it — sleep the machine or kill the network mid-payment — would confirm the retry now succeeds on the first attempt rather than after a wait. Also related: #180, the "Stop waiting" escape, is reached far less often once this is fixed.

🥂 toasted with [Claude Code](https://claude.ai/code)