### PR TITLE
relays: make the NIP-65-only toggle per account, and say which relay set the overview counts

### DIFF
--- a/background.js
+++ b/background.js
@@ -2413,6 +2413,23 @@ async function handleControl(message, sendResponse) {
         result = { ...resolveSettings(raw), autoLockDefaulted: !('autoLockMinutes' in raw) };
         break;
       }
+      // NIP-65-only is PER ACCOUNT, so it lives in a pubkey-keyed map rather than as a
+      // flag on the settings object. Merged here rather than in the panel because
+      // SIDECAR_SET_SETTINGS merges shallowly — a panel sending the whole map would
+      // clobber other accounts' values, and two panels racing would lose one.
+      //
+      // It has to be per account because the setting fails closed: an account with no
+      // published relay list gets an empty publish set. One global flag would silently
+      // stop a second account from posting at all.
+      case 'SIDECAR_SET_NIP65_ONLY': {
+        const prev = (await sget('sidecar_settings')).sidecar_settings || {};
+        const map = { ...(prev.nip65OnlyBy || {}) };
+        if (message.on) map[message.pubkey] = true;
+        else delete map[message.pubkey];
+        await sset({ sidecar_settings: { ...prev, nip65OnlyBy: map } });
+        result = { ok: true };
+        break;
+      }
       case 'SIDECAR_SET_SETTINGS': {
         const prev = (await sget('sidecar_settings')).sidecar_settings || {};
         const merged = { ...prev, ...message.settings };

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -394,9 +394,11 @@
       <div class="setting">
         <h3>Bootstrap relays</h3>
         <p class="hint">Used to discover your relay list on first load, and as a fallback if it can't be reached. Once you've published a relay list from the <strong>Profile</strong> tab, these take a back seat.</p>
-        <p class="hint">When NIP-65 only is on, these relays are excluded from all reads and publishes — except the initial discovery fetch itself, which still queries them once per session to find your relay list. Sites calling <code>getRelays()</code> still see the bootstrap set regardless.</p>
+        <p class="hint">NIP-65 only is set <strong>per account</strong>. When it's on for an account, these relays are excluded from its reads and publishes — except the initial discovery fetch, which still queries them once per session to find that account's relay list. Sites calling <code>getRelays()</code> still see the bootstrap set regardless.</p>
         <label class="switch-label">
-          <span>NIP-65 only</span>
+          <!-- Per account: the scope span names the active account, so with more than
+               one it's clear this isn't a global switch. -->
+          <span>NIP-65 only <span class="switch-scope" id="nip65-only-scope"></span></span>
           <span class="switch">
             <input type="checkbox" id="nip65-only-toggle" />
             <span class="switch-track"></span>

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -3224,19 +3224,25 @@
     const followNum = placeholder();
     const notifNum = placeholder();
     const relayNum = placeholder();
+    // The relay label is variable, unlike the other two: the number is meaningless
+    // without saying WHICH set it counts, so loadStats() rewrites it below.
+    const relayLabel = h('span', { className: 'account-stat-block-label', textContent: 'Relays' });
     function statBlock(iconName, numEl, label) {
       const ic = icon(iconName);
       ic.classList.add('account-stat-block-ic');
       return h('div', { className: 'account-stat-block' }, [
         ic,
         numEl,
-        h('span', { className: 'account-stat-block-label', textContent: label }),
+        typeof label === 'string'
+          ? h('span', { className: 'account-stat-block-label', textContent: label })
+          : label,
       ]);
     }
+    const relayBlock = statBlock('wifi', relayNum, relayLabel);
     const topRow = h('div', { className: 'account-stat-grid' }, [
       statBlock('users', followNum, 'Following'),
       statBlock('bell', notifNum, 'Alerts'),
-      statBlock('wifi', relayNum, 'Relays'),
+      relayBlock,
     ]);
 
     // Full-width identity rows, each led by a themed icon.
@@ -3299,11 +3305,42 @@
       notifNum.classList.add('account-stat-num');
       if (!unseen) notifNum.classList.add('account-stat-dim');
 
-      getNip65(pubkey).then((nip65) => {
-        const count = nip65 ? new Set([...nip65.read, ...nip65.write]).size : 0;
+      // This number has to say WHICH relays, because it was misleading in both
+      // directions when it didn't. It counted only the declared NIP-65 set, so an
+      // account that had never published a relay list showed 0 while happily reading
+      // and writing through the bootstrap relays — 0 reads as broken. And a user with
+      // a declared list saw a count that didn't match the one in Settings, with
+      // nothing on either screen saying they measure different sets.
+      Promise.all([getNip65(pubkey), nip65OnlyFor(pubkey)]).then(async ([nip65, only]) => {
+        const declared = nip65 ? new Set([...nip65.read, ...nip65.write]).size : 0;
+        let count = declared;
+        let label = 'Relays';
+        let warn = false;
+        if (!declared) {
+          if (only) {
+            // Fail-closed with nothing declared: this account genuinely cannot
+            // publish. 0 is accurate here, but it's a fault to flag, not a neutral
+            // zero to dim — the same failure the per-account fix was about.
+            warn = true;
+            relayBlock.title =
+              'NIP-65 only is on for this account, but it has no published relay list — ' +
+              'it can’t publish. Publish a relay list from the Profile tab, or turn the ' +
+              'setting off in Settings.';
+          } else {
+            // Bootstrap relays are what this account is actually using. Naming them
+            // keeps the number honest instead of silently reporting a different set.
+            count = (await relayUrls(false)).length;
+            label = 'Bootstrap';
+            relayBlock.title =
+              'Using Sidecar’s bootstrap relays. Publish a relay list from the Profile ' +
+              'tab to use your own.';
+          }
+        }
         relayNum.textContent = String(count);
         relayNum.classList.add('account-stat-num');
-        if (!count) relayNum.classList.add('account-stat-dim');
+        if (warn) relayNum.classList.add('account-stat-warn');
+        else if (!count) relayNum.classList.add('account-stat-dim');
+        relayLabel.textContent = label;
       });
 
       // Identity stats — need the profile.

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -1659,14 +1659,27 @@
     return Object.keys(map).filter((u) => (writableOnly ? map[u].write !== false : true));
   }
 
+  // Is NIP-65-only mode on for THIS account? Per account, not global, because the
+  // mode fails closed: one flag governing every account would leave an account with
+  // no published relay list unable to read or publish at all.
+  async function nip65OnlyFor(pubkey) {
+    if (!pubkey) return false;
+    try {
+      const s = await call({ type: 'SIDECAR_GET_SETTINGS' });
+      return !!(s && s.nip65OnlyBy && s.nip65OnlyBy[pubkey]);
+    } catch (_) {
+      return false; // can't read the setting → behave as if off, which keeps bootstrap
+    }
+  }
+
   // Relay set for reading an account's replaceable events (kind:3, kind:0, etc.).
   // The user's configured relays may not carry the freshest copy — NIP-65 declared
   // read relays often do, and purplepag.es aggregates kind:0/3/10002 as a fallback.
   // Without these, a stale or empty kind:3 on a configured relay can hide a healthy
   // 1000+ follow list that the account's NIP-65 relays do have.
   //
-  // When nip65Only is on, configured/Settings relays are excluded — the account's
-  // declared relays are the source of truth. The configured set still seeds the
+  // With NIP-65 only on for the account, configured/Settings relays are excluded —
+  // the declared relays are the source of truth. The configured set still seeds the
   // initial NIP-65 fetch (via getNip65's own relayUrls call), but once the list is
   // loaded it doesn't participate in any further reads. purplepag.es stays as a
   // read-only aggregator regardless.
@@ -1676,19 +1689,11 @@
     // Always include purplepag.es — it's a read-only aggregator, not a relay the
     // user publishes to, so it can't serve stale data the way a gossip relay can.
     const base = [...declared, 'wss://purplepag.es'];
-    // If the account has no NIP-65 list yet, fall back to configured regardless —
-    // a brand-new account has nothing else.
-    if (!declared.length) {
-      const settings = await call({ type: 'SIDECAR_GET_SETTINGS' });
-      // Fail closed: when nip65Only is on and the list is empty (whether genuinely
-      // absent or because the fetch failed), do NOT fall back to bootstrap relays.
-      // The user explicitly opted out of them; a silent fallback would be the wrong
-      // failure direction for a privacy feature.
-      if (settings && settings.nip65Only) return [...new Set(base)];
-      return [...new Set([...base, ...(await relayUrls(false))])];
-    }
-    const settings = await call({ type: 'SIDECAR_GET_SETTINGS' });
-    if (settings && settings.nip65Only) return [...new Set(base)];
+    // Fail closed when this account opted out of bootstrap relays: an empty list
+    // (genuinely absent, or a fetch that failed) must NOT silently fall back to the
+    // relays the user excluded — that's the wrong failure direction for a privacy
+    // setting. Per account, so a second account without a relay list is unaffected.
+    if (await nip65OnlyFor(pubkey)) return [...new Set(base)];
     return [...new Set([...base, ...(await relayUrls(false))])];
   }
 
@@ -1831,8 +1836,7 @@
   async function postRelays() {
     const n = await getNip65(state.activePubkey);
     const declared = n ? n.write : [];
-    const settings = await call({ type: 'SIDECAR_GET_SETTINGS' });
-    if (settings && settings.nip65Only) return [...new Set(declared)];
+    if (await nip65OnlyFor(state.activePubkey)) return [...new Set(declared)];
     // No NIP-65 list → fall back to configured so a fresh account can still publish.
     if (!declared.length) return relayUrls(true);
     return [...new Set([...declared, ...(await relayUrls(true))])];
@@ -4513,9 +4517,17 @@
     }
     fiatSel.value = settings.fiatCurrency || 'USD'; // default USD
     $('zapflash-toggle').checked = settings.zapFlash !== false; // default on
-    $('nip65-only-toggle').checked = settings.nip65Only === true; // default off
+    // Per account: reflects the ACTIVE account, and the label below names it so the
+    // scope is unmistakable when more than one account exists.
+    const nip65Only = await nip65OnlyFor(state.activePubkey);
+    $('nip65-only-toggle').checked = nip65Only;
     const relayBody = $('relay-section-body');
-    if (relayBody) relayBody.classList.toggle('dimmed', settings.nip65Only === true);
+    if (relayBody) relayBody.classList.toggle('dimmed', nip65Only);
+    const nip65Scope = $('nip65-only-scope');
+    if (nip65Scope) {
+      const acct = (state.accounts || []).find((a) => a.pubkey === state.activePubkey);
+      nip65Scope.textContent = acct ? 'for ' + displayName(acct) : '';
+    }
     $('autozap-toggle').checked = settings.autoZap === true;
     const azMax = Number(settings.autoZapMaxSats) || AUTOZAP_DEFAULT_MAX;
     $('autozap-max').value = String(azMax);
@@ -7800,9 +7812,8 @@
         status.classList.add('done');
         toast('Relay list published', 'success');
         // Offer to switch to NIP-65-only mode if bootstrap relays are still active.
-        const settings = await call({ type: 'SIDECAR_GET_SETTINGS' });
-        if (settings && !settings.nip65Only) {
-          maybeOfferNip65Only();
+        if (!(await nip65OnlyFor(active.pubkey))) {
+          maybeOfferNip65Only(active.pubkey);
         }
       } catch (e) {
         err.textContent = e.message;
@@ -7828,10 +7839,13 @@
   // bootstrap relays. The user's declared relays are now the source of truth;
   // the bootstrap set only added noise (and stale data, as the follow-count bug
   // showed). A one-time confirmation modal — not a silent settings change.
-  let nip65OnlyNudged = false;
-  function maybeOfferNip65Only() {
-    if (nip65OnlyNudged) return;
-    nip65OnlyNudged = true;
+  //
+  // Tracked per pubkey, because the setting is per account: declining for one
+  // identity must not silently swallow the offer for the next one you publish from.
+  const nip65OnlyNudged = new Set();
+  function maybeOfferNip65Only(pubkey) {
+    if (!pubkey || nip65OnlyNudged.has(pubkey)) return;
+    nip65OnlyNudged.add(pubkey);
     openModal((modal) => {
       modal.append(
         h('div', { className: 'setup-modal' }, [
@@ -7842,7 +7856,9 @@
           h('div', { className: 'row-actions' }, [
             h('button', { className: 'secondary', textContent: 'Not now', onclick: closeModal }),
             h('button', { className: 'primary', textContent: 'Use my relays only', onclick: async () => {
-              await call({ type: 'SIDECAR_SET_SETTINGS', settings: { nip65Only: true } });
+              // `pubkey`, not state.activePubkey — the account whose list was just
+              // published is the one this applies to, even if the active one changed.
+              await call({ type: 'SIDECAR_SET_NIP65_ONLY', pubkey, on: true });
               closeModal();
               toast('Now using your NIP-65 relays only', 'success');
             }}),
@@ -10563,7 +10579,7 @@
   // once the account has a declared relay list. The configured set still seeds
   // the initial NIP-65 fetch; this toggle governs everything after that.
   $('nip65-only-toggle').addEventListener('change', async (e) => {
-    await call({ type: 'SIDECAR_SET_SETTINGS', settings: { nip65Only: e.target.checked } });
+    await call({ type: 'SIDECAR_SET_NIP65_ONLY', pubkey: state.activePubkey, on: e.target.checked });
     $('relay-section-body')?.classList.toggle('dimmed', e.target.checked);
   });
 

--- a/styles.css
+++ b/styles.css
@@ -1328,6 +1328,8 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
 
 /* Bootstrap relays section */
 .switch-label { margin-bottom: 10px; }
+/* Names the account the per-account toggle applies to; quieter than the label. */
+.switch-scope { font-weight: 400; color: var(--muted); }
 .relay-section-body { transition: opacity 0.2s ease; }
 .relay-section-body.dimmed { opacity: 0.35; pointer-events: none; }
 #autozap-max-row { margin-top: 10px; }

--- a/styles.css
+++ b/styles.css
@@ -1073,6 +1073,9 @@ button:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(var(--accent-rg
 .stat-mini-no { color: var(--warn); }
 .stat-mini-ok, .stat-mini-no { width: 11px; height: 11px; flex-shrink: 0; }
 .account-stat-dim { color: var(--muted) !important; font-weight: 400 !important; }
+/* A zero that IS a fault (NIP-65 only on, nothing declared) — keeps the bold weight
+   a dimmed zero drops, so it reads as a problem rather than an empty count. */
+.account-stat-warn { color: var(--warn) !important; }
 
 /* Profile link */
 .account-stats-link {


### PR DESCRIPTION
Two related fixes to how Sidecar tracks and reports relay sets per account.

## The toggle was global, and it fails closed

The bootstrap-relay toggle was a single global flag, which is a real bug rather than a preference gap, because the setting fails closed: with it on, `postRelays()` returns only the account's declared write relays and never falls back to bootstrap.

So enabling it for an account that *had* published a relay list left every account *without* one holding an empty publish set — unable to post at all, deterministically, until the flag came back off. Hit in real use, on one of my own accounts. Worth distinguishing from the intermittent Jumble post failures (service-worker eviction): this one never recovers on its own.

Now a pubkey-keyed `nip65OnlyBy` map behind a new `SIDECAR_SET_NIP65_ONLY` message. The merge runs in the background, not the panel, because `SIDECAR_SET_SETTINGS` merges shallowly — a panel sending the whole map would clobber other accounts and two panels racing would lose a write. Not in `CONTENT_OK`, so pages can't reach it. Settings reflects the active account and names it in the label so the scope isn't ambiguous with more than one account.

Two wrong-account bugs fell out of the change and are fixed here too: the post-publish offer wrote `state.activePubkey` while the editor operated on `active.pubkey` (same value today, but that's the display-one/act-on-another shape), and `nip65OnlyNudged` was one session-wide boolean, so declining for one identity permanently swallowed the offer for the next.

No migration for the old global key. It only exists on unreleased 1.9.0 builds, and starting from an empty map means every account falls back to declared + bootstrap — which un-sticks an account already broken by this.

## The overview counted a set it didn't name

Same subject, and it depends on the `nip65OnlyFor()` helper above, so it rides here rather than stacking a second PR.

The Relays stat counted only the declared NIP-65 set. An account that had never published a relay list showed **0** while actively reading and writing through the five bootstrap relays — and 0 reads as broken, not as "using defaults." An account that had published saw a number that didn't match Settings, with nothing on either screen saying the two measure different sets. That mismatch caused real confusion twice while building this.

Declared relays win when they exist; otherwise the block reports the bootstrap count under a **Bootstrap** label. Counts `relayUrls(false)` rather than reusing `readRelayUrls()`, which always appends purplepag.es and would inflate every total by one.

The one case where 0 is correct — NIP-65 only on for an account with nothing declared, so it truly cannot publish — is flagged in `--warn` instead of dimmed, with a title naming both ways out. Still reachable, since Settings lets you turn the setting on for an account that has no list.

## Testing

386/388. The two failures are `search-entity` and `web-comment`, both `Cannot find module 'nostr-tools'`, identical on the base branch — Sidecar vendors nostr-tools rather than installing it. Theme contrast 47/47, which covers the new `--warn` usage.

Needs hands-on: the Bootstrap label on a fresh account, the warn state, and posting from a second account that has no relay list.

🥃 Poured with [Claude Code](https://claude.com/claude-code)