### PR TITLE
1.9.0: version bump, changelog, and What's new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ Release practice: the latest release's highlights are also summarized in-app, in
 guide's **What's new** section (`help.html#whats-new`, linked from Settings → Updates).
 Update that section alongside this file as part of every release.
 
+## [1.9.0] — 2026-08-14
+
+### Added
+- **A printable backup sheet for a new key.** After you've set a name, picture and bio, Sidecar offers a one-page PDF holding the key it just generated — styled as an old-fashioned telegram, set in Courier, generated entirely in the browser with no library and no network call. The nsec is on it twice: as selectable text you can copy, and as a QR you can scan back in. A serial derived from the npub (`NP-AEH2ZW-CQ4NWX`) lets you tell one sheet from another, and match a sheet to an identity, without revealing anything secret. The tinted paper stock is an optional content group set to off for printing, so it looks like a telegram on screen without flooding a printer with ink; the border carries the color instead. Dismissible — it interrupts once, at the only moment the key is new and unsaved. (#175)
+- **Import a key by scanning the backup sheet.** Four ways in, because the sheet is only useful if it reads back: upload a photo or screenshot of it, upload the PDF itself, paste an image straight from the clipboard, or scan the sheet live with your camera. The camera runs in its own popup window rather than the side panel — a side panel can't surface a camera permission prompt, so the button there would have failed silently forever. Decoding happens locally; nothing is uploaded. (#182, #183)
+- **Account overview.** A collapsible drawer under the active account showing what's actually configured for it: following count, unread alerts, relay count, NIP-05, Lightning address, and whether a wallet is connected *and* backed up. Each unset field links to the part of the guide that explains what it is and why you'd want it, rather than just reporting a blank. (#173)
+- **Bootstrap relays can be turned off, per account.** Sidecar seeds a small default relay set so a brand-new key can reach the network at all. Once you've published your own relay list from the Profile tab, Sidecar offers to stop using the defaults for that account and read and publish only through the relays you declared. Set per account, not globally — see below for why that distinction is load-bearing. (#173, #186)
+- **A way out of a payment that looks stuck.** A zap that hasn't confirmed after 15 seconds now offers to stop waiting, instead of leaving you watching a spinner for the full timeout. Stopping only stops *watching*: the payment is still in flight, and the card says so rather than claiming it failed. (#180)
+- **`relay-doctor`, a NIP-65 auditor for the command line.** Checks a relay set for liveness and for whether it will actually deliver — a relay that accepts your connection but refuses your events, or serves reads but not writes, looks healthy in every client and quietly costs you posts. Reports healthy / gated / auth-gated / not-serving / down per relay, plus size and mailbox-deliverability advisories. No dependencies, and it never handles a private key. Documented in `docs/relay-doctor.md`.
+- **Three additions to the app directory** — Circl, SatsList's official mark, and a proper tile for Nostr Archives.
+
+### Fixed
+- **The wallet no longer dies on a dropped connection.** The NWC client cached a pool whose socket had closed, and nostr-tools defaults `enableReconnect` to false, so once that socket died the client reused the corpse forever — every payment and balance check failed until the service worker happened to be evicted and rebuilt it. Recovery was accidental, which is why it read as intermittent. Reconnect is now on, and a request that publishes nothing is named as a lost connection rather than a silent wallet. (#178, #185)
+- **NIP-65 only was a single global switch, and it fails closed.** With it on, publishing uses only the account's declared write relays and never falls back to the defaults — correct for an account that has published a relay list, and fatal for one that hasn't. Turning it on for one identity left every other identity with an empty publish set, unable to post at all, deterministically, until it came back off. Now stored per account. (#186)
+- **The overview's relay count didn't say which relays it counted.** It reported only the declared NIP-65 set, so an account that had never published a relay list showed `0` while reading and writing perfectly well through the bootstrap relays — and `0` reads as broken, not as "using defaults." An account that *had* published saw a number that didn't match Settings, with nothing on either screen explaining that the two measure different sets. The count now names its source, and the one case where zero is genuinely a fault is flagged as one. (#186)
+
+### Changed
+- **The help guide's navigation is a dropdown.** The section list had grown long enough to push the guide's actual content below the fold. Sections now collapse into a menu in the guide's own visual style, with Nostr apps and Wallets kept outside it as the two destinations people arrive looking for. (#173)
+- **The wallet quick-start points at the wallet directory.** With no wallet connected, the route to the full list of options was buried below the Rizful quick-start; it now sits in the same card. (#173)
+- **Store packages no longer carry `docs/`.** Release guides, store descriptions and internal notes were being zipped into the uploaded build.
+
 ## [1.8.0] — 2026-08-12
 
 ### Added

--- a/help.html
+++ b/help.html
@@ -382,6 +382,17 @@
          linked below. -->
     <section class="guide-section" id="whats-new">
       <h2>What's new</h2>
+      <p class="whatsnew-version">Version 1.9.0</p>
+      <ul class="whatsnew-list">
+        <li><strong>A printable backup sheet for a new key.</strong> Create a key and Sidecar offers you a one-page PDF of it, styled as an old-fashioned telegram. Your nsec is on it as text you can copy and as a QR you can scan back in, alongside a serial number that lets you tell one sheet from another without revealing anything secret. Print it and store it where you keep passports. It's built on your own machine — nothing is sent anywhere.</li>
+        <li><strong>Import a key by scanning that sheet.</strong> Four ways in: upload a photo of the sheet, upload the PDF itself, paste an image from your clipboard, or scan it live with your camera. Everything is decoded on your machine.</li>
+        <li><strong>Account overview.</strong> A drawer under your account showing what's actually set up for it — who you follow, unread alerts, your relays, your NIP-05 and Lightning address, and whether your wallet is connected <em>and</em> backed up. Anything missing links to the part of this guide that explains it.</li>
+        <li><strong>Your relays, if you want them.</strong> Sidecar starts you on a small default set so a brand-new key can reach the network. Once you publish your own relay list, it offers to step back and use only yours — for that account, so a second identity that hasn't published one yet still works.</li>
+        <li><strong>A way out of a stuck payment.</strong> A zap that hasn't confirmed after 15 seconds now offers to stop waiting instead of leaving you on a spinner. It stops the waiting, not the payment, and says so.</li>
+        <li><strong>The wallet survives a dropped connection.</strong> If the connection to your wallet died, Sidecar kept reusing it — every payment and balance check failed until something else happened to reset it, which is why it felt random. It now reconnects.</li>
+        <li><strong>A shorter help menu.</strong> The section list had grown long enough to push the guide itself off the screen; it's a dropdown now.</li>
+        <li><strong>New apps in the directory</strong> — Circl, plus proper icons for SatsList and Nostr Archives.</li>
+      </ul>
       <p class="whatsnew-version">Version 1.8.0</p>
       <ul class="whatsnew-list">
         <li><strong>New theme: Bauhaus.</strong> Flat planes of primary color, black rule lines, and a Futura-lineage display face — the school's own geometric sans. White walls keep it unmistakably separate from Art Deco. Six themes now, in Settings → Theme.</li>

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Sidecar | A Classy Nostr Signer",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "minimum_chrome_version": "114",
   "description": "A multi-account NIP-07 Nostr signer with a built-in Lightning wallet, in your browser sidebar.",
   "permissions": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sidecar-nostr-signer",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "A multi-account NIP-07 nostr signer with a built-in Lightning wallet, in your browser sidebar",
   "scripts": {
     "dev": "echo 'Load this folder as an unpacked extension at chrome://extensions'",


### PR DESCRIPTION
Closes the release-prep half of #181.

- `package.json` and `manifest.json` → **1.9.0**
- `CHANGELOG.md` → a `[1.9.0]` entry
- `help.html#whats-new` → a matching user-facing block, per the practice noted at the top of the changelog

## One thing worth checking

The changelog range is `8861f96..HEAD`, **not** `main..HEAD`. PR #173 — account overview drawer, bootstrap relay toggle, help nav redesign — merged to `main` *after* the 1.8.0 version bump and appears nowhere in the 1.8.0 entry. It is unreleased, so it belongs in 1.9.0. Cutting the changelog from `main` would have silently dropped a whole PR of user-facing work from the release notes.

## Why this blocks #184

`release/1.9.0` still said 1.8.0 in all four places. Merging #184 to `main` before this would have put 1.9.0 code on `main` stamped with the version already live on both stores — two different builds under one version number.

## Still outstanding for the release

- `docs/release-1.9.0-guide.md` and the Chrome Web Store description (per the usual practice; not in this PR since the store copy always wants a read-through first)
- Manual QA in #177, and #180

Tests 389/391 — the two failures are `search-entity` and `web-comment`, both `Cannot find module 'nostr-tools'`, identical on the base branch.

🍹 Shaken with [Claude Code](https://claude.com/claude-code)