### PR TITLE
Gate the raw NWC string: metadata + worker-side backup crypto, sidepanel-only client build

### DIFF
--- a/background.js
+++ b/background.js
@@ -2693,14 +2693,70 @@ async function handleControl(message, sendResponse) {
         closeSwNwc(); // rebuild against the new connection on next use
         result = { ok: true };
         break;
-      case 'SIDECAR_GET_NWC':
+      case 'SIDECAR_GET_NWC': {
+        // The raw connection string, for building the in-memory wallet client.
+        // The side panel is the one legitimate consumer — it ends up holding the
+        // parsed secret inside that client no matter what, so restricting by
+        // sender buys nothing there — but no OTHER extension page has any reason
+        // to see the string: display code uses SIDECAR_NWC_META, backup code uses
+        // the SIDECAR_NWC_BACKUP_* helpers below, and human-visible export goes
+        // through SIDECAR_REVEAL_NWC's PIN step-up.
+        if (typeof sender.url !== 'string' || sender.url !== chrome.runtime.getURL('sidepanel.html')) {
+          throw new Error('Not allowed from this context');
+        }
         result = { connection: await KS.getNwc(message.pubkey) };
         break;
+      }
       case 'SIDECAR_REVEAL_NWC': {
         // Export the raw connection string — always step-up PIN, even while
         // unlocked. Locked + verified PIN unlocks (see stepUpPin).
         await stepUpPin(message.pin);
         result = { connection: await KS.getNwc(message.pubkey) };
+        break;
+      }
+      case 'SIDECAR_NWC_META': {
+        // Metadata-only view of the stored connection: presence + lightning
+        // address. Never returns the string itself (see SIDECAR_GET_NWC above).
+        const connection = await KS.getNwc(message.pubkey);
+        let lud16 = null;
+        if (connection) {
+          try {
+            const q = connection.split('?')[1];
+            const v = q && new URLSearchParams(q).get('lud16');
+            lud16 = v && v.includes('@') ? v.trim() : null;
+          } catch (_) {}
+        }
+        result = { has: !!connection, lud16 };
+        break;
+      }
+      case 'SIDECAR_NWC_BACKUP_CIPHERTEXT': {
+        // Relay backup, step 1: encrypt the stored connection to its own account.
+        // Runs here so the raw string never crosses to a page just to be
+        // re-encrypted. NIP-44 only, no NIP-04 fallback: this is a spendable
+        // secret, and silently downgrading the encryption because the first
+        // attempt errored is the wrong failure mode — let the caller surface
+        // the error instead.
+        if (KS.isLocked()) throw new Error('Keystore is locked');
+        const pk = await KS.getActivePubkey();
+        const connection = await KS.getNwc(pk);
+        if (!connection) throw new Error('No wallet connected to back up');
+        result = {
+          ciphertext: await SIGNER.perform('nip44.encrypt', { pubkey: pk, plaintext: connection }, await KS.getPrivkey(pk), pk),
+          algo: 'nip44',
+        };
+        break;
+      }
+      case 'SIDECAR_NWC_BACKUP_MATCHES': {
+        // Relay backup, step 2: does a backup ciphertext decrypt to the stored
+        // connection? Compared here so the string stays in the worker. `has`
+        // lets the caller distinguish "no local wallet" (unknown) from a real
+        // mismatch (stale).
+        if (KS.isLocked()) throw new Error('Keystore is locked');
+        const pk = await KS.getActivePubkey();
+        const m = message.nip === 4 ? 'nip04.decrypt' : 'nip44.decrypt';
+        const backed = await SIGNER.perform(m, { pubkey: pk, ciphertext: message.ciphertext }, await KS.getPrivkey(pk), pk);
+        const connection = await KS.getNwc(pk);
+        result = { has: !!connection, matches: !!connection && String(backed || '').trim() === connection.trim() };
         break;
       }
       case 'SIDECAR_HAS_NWC':

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -3430,8 +3430,8 @@
 
       // Wallet: two mini badges — connected and backed up — each with a
       // colored check or X so the state reads at a glance.
-      call({ type: 'SIDECAR_GET_NWC' }).then(async ({ connection }) => {
-        if (!connection) {
+      call({ type: 'SIDECAR_NWC_META' }).then(async ({ has }) => {
+        if (!has) {
           const link = h('button', { className: 'account-stat-add-link', textContent: 'Add wallet →' });
           link.addEventListener('click', () => {
             const tab = document.querySelector('.tab[data-tab="wallet"]');
@@ -5656,8 +5656,8 @@
   async function maybeSuggestLud16(container, active, content) {
     let walletAddr = null;
     try {
-      const { connection } = await call({ type: 'SIDECAR_GET_NWC' });
-      walletAddr = connection ? parseNwcLud16(connection) : null;
+      const { lud16 } = await call({ type: 'SIDECAR_NWC_META' });
+      walletAddr = lud16 || null;
     } catch (_) {}
     if (!walletAddr) return; // no wallet address to sync
     if (state.activePubkey !== active.pubkey) return; // account switched during await
@@ -7980,20 +7980,20 @@
   async function nwcBackupState() {
     const ev = await fetchBackupEvent(NWC_BACKUP_DTAG);
     if (!ev) return { state: 'none' };
-    let connection = '';
-    try {
-      connection = (await call({ type: 'SIDECAR_GET_NWC' })).connection || '';
-    } catch (_) {}
-    if (!connection) return { state: 'unknown', at: ev.created_at };
+    // Presence comes from the metadata view; the decrypt-and-compare runs in the
+    // service worker (SIDECAR_NWC_BACKUP_MATCHES) so the raw connection string
+    // never crosses to a page just to be compared against the backup.
+    let has = false;
+    try { has = !!(await call({ type: 'SIDECAR_NWC_META' })).has; } catch (_) {}
+    if (!has) return { state: 'unknown', at: ev.created_at };
     try {
       const scheme = (ev.tags.find((x) => x[0] === 'encryption') || [])[1];
-      const backed = await call({
-        type: 'SIDECAR_OWNER_DECRYPT',
+      const { matches } = await call({
+        type: 'SIDECAR_NWC_BACKUP_MATCHES',
         ciphertext: ev.content,
         nip: scheme === 'nip04' ? 4 : 44,
       });
-      const same = String(backed || '').trim() === connection.trim();
-      return { state: same ? 'current' : 'stale', at: ev.created_at };
+      return { state: matches ? 'current' : 'stale', at: ev.created_at };
     } catch (_) {
       return { state: 'unknown', at: ev.created_at };
     }
@@ -8017,18 +8017,10 @@
   };
 
   async function backupNwcToRelays() {
-    const { connection } = await call({ type: 'SIDECAR_GET_NWC' });
-    if (!connection) throw new Error('No wallet connected to back up');
-    // No NIP-04 fallback: this is a spendable secret, and silently downgrading the
-    // encryption because the first attempt errored is the wrong failure mode — let
-    // the caller surface the error instead.
-    let ciphertext;
-    try {
-      ciphertext = await call({ type: 'SIDECAR_OWNER_ENCRYPT', plaintext: connection, nip: 44 });
-    } catch (e) {
-      throw new Error('Could not encrypt the backup (NIP-44): ' + (e && e.message ? e.message : 'unknown error'));
-    }
-    const algo = 'nip44';
+    // The encryption runs in the service worker against the stored string, so
+    // the raw connection never crosses to a page just to be re-encrypted. No
+    // NIP-04 fallback there either — see the worker-side rationale.
+    const { ciphertext, algo } = await call({ type: 'SIDECAR_NWC_BACKUP_CIPHERTEXT' });
     const event = {
       kind: 30078,
       created_at: Math.floor(Date.now() / 1000),
@@ -9575,9 +9567,8 @@
   }
   async function getLightningAddress() {
     try {
-      const { connection } = await call({ type: 'SIDECAR_GET_NWC' });
-      const fromNwc = connection && parseNwcLud16(connection);
-      if (fromNwc) return fromNwc;
+      const { lud16 } = await call({ type: 'SIDECAR_NWC_META' });
+      if (lud16) return lud16;
     } catch (_) {}
     try {
       const { content } = await fetchActiveProfile();

--- a/test/nwc-backup-state.test.js
+++ b/test/nwc-backup-state.test.js
@@ -32,7 +32,10 @@ const CONN = 'nostr+walletconnect://b889ff5b1513b641e2a139f661a661364979c5beee91
 const OTHER = 'nostr+walletconnect://a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90?relay=wss%3A%2F%2Frelay.other&secret=0f0e0d0c0b0a09080706050403020100';
 
 // Builds a context where fetchBackupEvent and call() are stubs, so the state
-// machine is exercised without relays or a keystore.
+// machine is exercised without relays or a keystore. The stubs mirror the
+// service worker's side of the contract: presence comes from SIDECAR_NWC_META,
+// and SIDECAR_NWC_BACKUP_MATCHES does the decrypt-and-compare worker-side, so
+// only the boolean ever crosses back.
 function harness({ event, connection, decrypt, getNwcThrows }) {
   const calls = [];
   const ctx = {
@@ -41,13 +44,16 @@ function harness({ event, connection, decrypt, getNwcThrows }) {
     fetchBackupEvent: async () => (event === undefined ? null : event),
     call: async (msg) => {
       calls.push(msg);
-      if (msg.type === 'SIDECAR_GET_NWC') {
+      if (msg.type === 'SIDECAR_NWC_META') {
         if (getNwcThrows) throw new Error('locked');
-        return { connection };
+        return { has: !!connection };
       }
-      if (msg.type === 'SIDECAR_OWNER_DECRYPT') {
-        if (typeof decrypt === 'function') return decrypt(msg);
-        return decrypt;
+      if (msg.type === 'SIDECAR_NWC_BACKUP_MATCHES') {
+        const backed = typeof decrypt === 'function' ? decrypt(msg) : decrypt;
+        return {
+          has: !!connection,
+          matches: !!connection && String(backed || '').trim() === String(connection).trim(),
+        };
       }
       throw new Error('unexpected call ' + msg.type);
     },
@@ -145,7 +151,7 @@ test('a same-wallet string differing only in query order reports "stale"', async
 test('an nip04 tag decrypts with nip 4, not 44', async () => {
   const { ctx, calls } = harness({ event: evt('C', 'nip04'), connection: CONN, decrypt: CONN });
   await ctx.nwcBackupState();
-  const dec = calls.find((c) => c.type === 'SIDECAR_OWNER_DECRYPT');
+  const dec = calls.find((c) => c.type === 'SIDECAR_NWC_BACKUP_MATCHES');
   assert.equal(dec.nip, 4, 'older backups were NIP-04 and must stay readable');
 });
 
@@ -153,15 +159,29 @@ test('nip44 is used for a nip44 tag and for a missing tag', async () => {
   for (const algo of ['nip44', undefined]) {
     const { ctx, calls } = harness({ event: evt('C', algo), connection: CONN, decrypt: CONN });
     await ctx.nwcBackupState();
-    assert.equal(calls.find((c) => c.type === 'SIDECAR_OWNER_DECRYPT').nip, 44,
+    assert.equal(calls.find((c) => c.type === 'SIDECAR_NWC_BACKUP_MATCHES').nip, 44,
       'algo tag ' + String(algo));
   }
 });
 
-test('the ciphertext handed to decrypt is the event content', async () => {
+test('the ciphertext handed to the comparison is the event content', async () => {
   const { ctx, calls } = harness({ event: evt('ABC123', 'nip44'), connection: CONN, decrypt: CONN });
   await ctx.nwcBackupState();
-  assert.equal(calls.find((c) => c.type === 'SIDECAR_OWNER_DECRYPT').ciphertext, 'ABC123');
+  assert.equal(calls.find((c) => c.type === 'SIDECAR_NWC_BACKUP_MATCHES').ciphertext, 'ABC123');
+});
+
+// ---- raw-string containment ----------------------------------------------------
+
+test('the raw connection string is never requested by the panel — compare runs worker-side', async () => {
+  // The whole point of moving decrypt-and-compare into the service worker: the
+  // string never crosses a message boundary for this check. If a refactor
+  // reintroduces a raw-string fetch here, it has to come with a reason.
+  const { ctx, calls } = harness({ event: evt(), connection: CONN, decrypt: CONN });
+  await ctx.nwcBackupState();
+  assert.ok(!calls.some((c) => c.type === 'SIDECAR_GET_NWC' || c.type === 'SIDECAR_REVEAL_NWC'));
+  for (const c of calls) {
+    assert.ok(!('connection' in c) && !('plaintext' in c), 'call carried key material: ' + c.type);
+  }
 });
 
 // ---- the labels ----------------------------------------------------------------


### PR DESCRIPTION
Closes #189 (audit M1). One deliberate scope note up front, then the change.

## The finding

`SIDECAR_GET_NWC` returned the decrypted NWC connection string — spend authority for the wallet, held raw outside every budget gate — to **any extension page** while unlocked, with no PIN step-up. One line below it, `SIDECAR_REVEAL_NWC` demands a step-up for the exact same data, with a comment saying it must *always* require one. The gap existed to defend against XSS in an extension page: any page (prompt, welcome, scan-qr included) could silently request the string.

## What changed

- **`SIDECAR_NWC_META`** — presence + lightning address, parsed worker-side. Never returns the string. The three display-only call sites (account-overview wallet badges, lud16 sync suggestion, `getLightningAddress`) now use it.
- **`SIDECAR_NWC_BACKUP_CIPHERTEXT`** — the relay backup's encrypt-to-self now runs in the worker against the stored string; `backupNwcToRelays` never sees plaintext.
- **`SIDECAR_NWC_BACKUP_MATCHES`** — the backup-freshness decrypt-and-compare also runs worker-side; only the boolean crosses back. `nwcBackupState` keeps its exact four-state contract.
- **`SIDECAR_GET_NWC`** still returns the raw string, but now **only to the side panel** (`sender.url === runtime.getURL('sidepanel.html')`) — the one legitimate consumer, since it holds the parsed secret inside its in-memory wallet client regardless. Every other extension page gets a hard error.
- `SIDECAR_REVEAL_NWC` (human export) unchanged: always PIN step-up.

## Scope note — why GET_NWC still exists

The issue's checklist said "raw string strictly behind REVEAL's step-up." The remaining consumer is `ensureNwc()`, which builds the panel's wallet client — and it's called from the **background balance poll timer**, so a PIN-per-load prompt would fire modals from nowhere. Restricting by sender closes the actual gap: XSS in prompt/welcome/scan-qr can no longer reach the string, and XSS in the side panel already had equal power through the built client. The full fix — moving all wallet ops worker-side so the panel never holds the string — is a wallet-view refactor out of scope here, and this PR removes every *other* reason a page had to touch it.

## Tests

- `nwc-backup-state.test.js` rewritten against the worker-side contract, plus a new containment test pinning that the panel never requests the raw string for the backup check.
- Full suite: 390/392 — the two failures are the pre-existing vendoring reds (`search-entity`, `web-comment`), red on main before this.

🍹 Poured with GLM 5.3 (z.ai)