### PR TITLE
WebLN reads need consent, not just an unlocked keystore

### DIFF
--- a/background.js
+++ b/background.js
@@ -1353,9 +1353,30 @@ function invoiceSats(bolt11) {
   return Math.round(Number(digits) * FACTOR[mult]);
 }
 
-// Open an unlock-only popup for low-risk wallet reads when the keystore is locked.
-async function weblnUnlockGate(host, method, pubkey, originWindowId) {
-  if (!KS.isLocked()) return;
+// ---- WebLN read consent ----
+// Balance, node info, and invoice creation used to run with NO consent moment
+// whenever the keystore was unlocked: the old gate only checked unlock, so any
+// page — including one never approved at any tier — could silently read the
+// wallet balance, and the first call bound the host to the account, so no prompt
+// could ever appear later either. Reads now ask once per (host, account) and the
+// approval is remembered for the rest of the session. Session storage (not a
+// Map, not local): survives SW eviction, dies with the browser, and lockKeystore
+// clears it — an unlock is not consent to spend the whole session's reads.
+// Trusted sites stay silent, matching how the tier treats every other method.
+const WEBLN_READ_METHODS = new Set(['getInfo', 'getBalance', 'makeInvoice']);
+const WEBLN_READ_GRANT_KEY = 'sidecar_webln_read_grants';
+async function hasWeblnReadGrant(host, pubkey) {
+  const m = (await sgetSession(WEBLN_READ_GRANT_KEY))[WEBLN_READ_GRANT_KEY] || {};
+  return !!m[host + '|' + pubkey];
+}
+async function grantWeblnRead(host, pubkey) {
+  const m = (await sgetSession(WEBLN_READ_GRANT_KEY))[WEBLN_READ_GRANT_KEY] || {};
+  m[host + '|' + pubkey] = 1;
+  await ssetSession({ [WEBLN_READ_GRANT_KEY]: m });
+}
+async function weblnReadGate(host, method, pubkey, originWindowId) {
+  if ((await PERMS.getLevel(pubkey, host)) === 'trusted') return;
+  if (await hasWeblnReadGrant(host, pubkey)) return;
   const st = await KS.getState();
   const acct = st.accounts.find((a) => a.pubkey === pubkey);
   const decision = await openPrompt({
@@ -1364,12 +1385,14 @@ async function weblnUnlockGate(host, method, pubkey, originWindowId) {
     method: 'webln.' + method,
     npub: self.NostrTools.nip19.npubEncode(pubkey),
     accountName: (acct && acct.name) || '',
-        accountPicture: (acct && acct.picture) || '',
-    needUnlock: true,
-    needApproval: false,
+    accountPicture: (acct && acct.picture) || '',
+    needUnlock: KS.isLocked(),
+    needApproval: true,
   }, originWindowId);
   if (decision.action === 'reject') throw new Error('You rejected this request');
+  if (decision.action === 'trust') await PERMS.setLevel(pubkey, host, 'trusted');
   if (KS.isLocked()) throw new Error('Keystore is locked');
+  await grantWeblnRead(host, pubkey);
 }
 
 async function handleWeblnRpc(method, params, host, sendResponse, originWindowId) {
@@ -1400,7 +1423,7 @@ async function handleWeblnRpc(method, params, host, sendResponse, originWindowId
 
     let result;
     if (method === 'getInfo') {
-      await weblnUnlockGate(host, method, pubkey, originWindowId);
+      await weblnReadGate(host, method, pubkey, originWindowId);
       const c = await getSwNwc(pubkey);
       const info = (await c.getInfo()) || {};
       result = {
@@ -1409,12 +1432,12 @@ async function handleWeblnRpc(method, params, host, sendResponse, originWindowId
         supports: ['lightning'],
       };
     } else if (method === 'getBalance') {
-      await weblnUnlockGate(host, method, pubkey, originWindowId);
+      await weblnReadGate(host, method, pubkey, originWindowId);
       const c = await getSwNwc(pubkey);
       const b = await c.getBalance();
       result = { balance: msatToSat(b && b.balance), currency: 'sats' };
     } else if (method === 'makeInvoice') {
-      await weblnUnlockGate(host, method, pubkey, originWindowId);
+      await weblnReadGate(host, method, pubkey, originWindowId);
       const c = await getSwNwc(pubkey);
       const sats = parseInt(params && params.amount, 10);
       if (!sats || sats < 1) throw new Error('A positive amount is required to make an invoice');
@@ -2089,6 +2112,10 @@ async function lockKeystore(auto = false) {
   // Same reasoning for pending zap requests: they authorize a payment to go out with
   // no prompt, so a locked keystore must not leave any of them spendable.
   ZAPREQ.clear().catch(() => {});
+  // And the WebLN read grants: they are consent to query the wallet, which only
+  // means anything while unlocked. Clearing them means the next balance read
+  // after a re-unlock asks again.
+  chrome.storage.session.remove(WEBLN_READ_GRANT_KEY, () => void chrome.runtime.lastError);
   // Tell any open panel/popup to drop to the unlock screen immediately — otherwise
   // it keeps showing whatever was open (e.g. the composer) and only discovers the
   // lock on its next action, which then fails with a "locked" error. `auto` marks an

--- a/prompt.js
+++ b/prompt.js
@@ -407,6 +407,10 @@
       els.decryptNote.textContent =
         'Allowing lets ' + data.host + ' read wallet info from Sidecar for the rest of this session.';
       els.decryptNote.classList.remove('hidden');
+      // The grant covers the session, so the button can't claim "once" — label
+      // and note must agree. A pure unlock later in init() still relabels to
+      // "Unlock & continue", which is also right (there's nothing to allow).
+      els.allow.textContent = 'Allow this session';
     }
 
     // Shared-identity confirm: this host is signed in with more than one of your

--- a/prompt.js
+++ b/prompt.js
@@ -399,6 +399,16 @@
       els.decryptNote.classList.remove('hidden');
     }
 
+    // Same honesty for WebLN reads: one Allow covers this site's balance/info/
+    // invoice reads for the rest of the session (until Sidecar locks), not just
+    // the request in front of you. Sites legitimately poll the balance, so a
+    // once-per-read prompt would be noise — but the broader grant must be said.
+    if (data.method === 'webln.getBalance' || data.method === 'webln.getInfo' || data.method === 'webln.makeInvoice') {
+      els.decryptNote.textContent =
+        'Allowing lets ' + data.host + ' read wallet info from Sidecar for the rest of this session.';
+      els.decryptNote.classList.remove('hidden');
+    }
+
     // Shared-identity confirm: this host is signed in with more than one of your
     // accounts, so make the "who's posting" choice explicit and relabel the
     // switcher for the signing (not login) context. This confirms on EVERY

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -491,6 +491,13 @@
 
       <div id="approval-preview" class="card hidden"></div>
 
+      <!-- Scope-of-consent note: some Allows cover more than the request on screen —
+           a decrypt burst covers about a minute, a WebLN read covers the session.
+           Same element, placement (just under the preview card), and wording as the
+           popup's #decrypt-note; approvals render in BOTH surfaces and must tell the
+           same story. Toggled by renderConsentNote in sidepanel.js. -->
+      <div id="approval-consent-note" class="shared-note hidden"></div>
+
       <div id="approval-unlock" class="hidden stack">
         <label for="approval-pin">Enter your PIN to unlock</label>
         <input type="password" id="approval-pin" autocomplete="off" maxlength="32" />

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -11125,6 +11125,29 @@
     acct.parentNode.insertBefore(note, acct);
   }
 
+  // Scope-of-consent note: some Allows are broader than the single request on
+  // screen. A decrypt Allow covers a burst for about a minute (so a client can
+  // load an inbox without a prompt per message), and a WebLN-read Allow covers
+  // the rest of the session (the gate lives in background.js). The popup says
+  // this under its preview card; the panel's approval card must say it too —
+  // approvals render in BOTH surfaces, and only the popup had the notes. Wording
+  // matches prompt.js exactly so the two never drift into different stories.
+  function renderConsentNote(data) {
+    const note = $('approval-consent-note');
+    if (!note) return;
+    if (data.method === 'nip04.decrypt' || data.method === 'nip44.decrypt') {
+      note.textContent =
+        'Allowing lets ' + data.host + ' decrypt your messages for about a minute — enough to load a conversation or inbox without asking for each one.';
+    } else if (data.method === 'webln.getBalance' || data.method === 'webln.getInfo' || data.method === 'webln.makeInvoice') {
+      note.textContent =
+        'Allowing lets ' + data.host + ' read wallet info from Sidecar for the rest of this session.';
+    } else {
+      hide(note);
+      return;
+    }
+    show(note);
+  }
+
   // Disable/enable the approval prompt's Allow once + Trust this site while a
   // destructive overwrite is unacknowledged. Reject is deliberately left alone — the
   // safe way out must never be gated. The class on the footer dims the pair so they
@@ -11316,6 +11339,9 @@
     renderSharedNote(data);
 
     renderApprovalPreview(data);
+
+    // After the preview so the note sits just under it, mirroring prompt.html.
+    renderConsentNote(data);
 
     $('approval-error').textContent = '';
     $('approval-pin-error').textContent = '';

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -11400,7 +11400,13 @@
         allow.textContent = 'Unlock & continue';
         hide(trust);
       } else {
-        allow.textContent = 'Allow once';
+        // WebLN reads grant the rest of the session (the consent note under the
+        // preview says so) — the button can't claim "once" when it means "until
+        // Sidecar locks". Mirrors the payment relabel just above.
+        allow.textContent =
+          data.method === 'webln.getBalance' || data.method === 'webln.getInfo' || data.method === 'webln.makeInvoice'
+            ? 'Allow this session'
+            : 'Allow once';
         show(trust);
       }
     }


### PR DESCRIPTION
Closes #190 (audit M2).

## The finding

`weblnUnlockGate` only checked *unlock* — a consent gate that never asks for consent. While the keystore was unlocked (the normal state during browsing), any webpage — including one never approved at any tier — could call `window.webln.enable()` then `getBalance()` and silently learn the wallet balance, node alias, and wallet node pubkey. Worse, the first call silently bound the host to the active account, so no prompt could ever appear later either. `sendPayment` was already properly gated and is untouched.

## What changed

- **`weblnReadGate` replaces `weblnUnlockGate`** for `getInfo` / `getBalance` / `makeInvoice`:
  - **trusted sites stay silent** — the tier already allows everything, reads included
  - **otherwise: one prompt per (host, account)**, "wants to see your wallet balance / wallet info / create a Lightning invoice" (`METHOD_LABELS` entries already existed for exactly these)
  - the approval is remembered for the **rest of the session** — sites legitimately poll balance, so once-per-read would be signer-flood noise. Stored in `chrome.storage.session`: survives SW eviction, dies with the browser
  - **`lockKeystore` clears the grants** — an unlock is not consent to spend a whole session's reads, so the first read after a re-unlock asks again
- **"Trust this site" on a read prompt sets the tier**, exactly as on every other approval surface — that's the documented way to make a site stop asking, permanently.
- **The prompt says what Allow covers** ("read wallet info from Sidecar for the rest of this session") — the same honesty the decrypt-burst note gives for its 60s window.
- `enable()`/`isEnabled()` unchanged: they're the WebLN availability signal, carry no data, and rejecting them would break wallet detection for well-behaved sites.

## Both approval surfaces say it

The consent note landed only in the popup (prompt.js). Approvals render in **two** places — the popup when the panel is closed, the sidepanel's inline approval card when it's open — and the panel had *neither* note: not the new WebLN read text, not the older decrypt-burst text. The follow-up commit adds `#approval-consent-note` to the panel card, in the same spot the popup puts it (just under the preview card), with the exact same wording for both kinds, rendered by `renderConsentNote` from `showApproval()`. Styled with the dormant `.shared-note` rule from #89. The Allow button follows suit: read prompts now say **"Allow this session"** instead of "Allow once", on both surfaces — a button that promises less than the grant is a small lie in the wrong direction.

## Why session-grant rather than per-call ask

Same reasoning the codebase already states for decrypt-burst coalescing: one decision per real consent moment, scoped to host+account, bounded in time. Here the bound is the session instead of 60s because balance reads recur for as long as the site is open — a 60s window would just re-prompt mid-browsing-session, training reflex-approval.

## Tests

Full suite 389/391 on this branch (the two failures are the pre-existing vendoring reds, red on main). No webln unit harness existed before; the gate is prompt-mediated so it's covered by manual QA — worth checking on a getzone/getwally-style site: first `getBalance` prompts, Allow covers subsequent reads, lock+unlock re-prompts, trusted sites never prompt. Also check the same prompt in the **sidepanel** (panel open): the note appears under the preview card on both surfaces.

🥂 Toasted with GLM 5.3 (z.ai)
