### PR TITLE
Derive the RPC host from sender.url, never the message body

### DIFF
--- a/background.js
+++ b/background.js
@@ -2718,13 +2718,17 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     return true;
   }
 
-  // Page RPC from content script.
-  if (message.type === 'SIDECAR_NOSTR_RPC') {
-    handleNostrRpc(message.method, message.params, message.host, sendResponse, originWindowId);
-    return true;
-  }
-  if (message.type === 'SIDECAR_WEBLN_RPC') {
-    handleWeblnRpc(message.method, message.params, message.host, sendResponse, originWindowId);
+  // Page RPC from content script. The host MUST come from the sender's own URL,
+  // never from the message body — the same rule the payment/card handlers below
+  // state. content.js does send its own location.host today, but if a future
+  // content-script refactor ever forwards a page-influenced host, trusting the
+  // body here would let a page act under another host's trust tier, relax
+  // window, or decrypt grant. Derive it; ignore the body field.
+  if (message.type === 'SIDECAR_NOSTR_RPC' || message.type === 'SIDECAR_WEBLN_RPC') {
+    let rpcHost = '';
+    try { rpcHost = new URL((sender && sender.url) || '').host; } catch (_) {}
+    const fn = message.type === 'SIDECAR_NOSTR_RPC' ? handleNostrRpc : handleWeblnRpc;
+    fn(message.method, message.params, rpcHost, sendResponse, originWindowId);
     return true;
   }
   // "Pay with Sidecar" pill clicked on a page.


### PR DESCRIPTION
Closes #191 (audit E2).

## The finding

`SIDECAR_NOSTR_RPC` and `SIDECAR_WEBLN_RPC` were the only two message handlers that trusted `message.host`, while every sibling — `SIDECAR_IS_CONNECTED`, `SIDECAR_TRY_ZAP_AUTOPAY`, `SIDECAR_PAY_PAGE_INVOICE` — derives the host from `new URL(sender.url).host`, each with a comment saying the host must *never* come from the message body.

Safe today: web pages can't reach `onMessage` at all (no `externally_connectable`), and `content.js` is first-party code that sets `message.host` from its own `location.host`. But the sibling handlers' comments describe exactly the failure this layout invites: a future content-script refactor that forwards a page-influenced host would let a page act under another host's `trusted` tier, relax window, or decrypt grant — silently.

## What changed

Both handlers now derive the host from the sender's URL and ignore the body field, with the same rule comment their siblings carry. The two dispatch blocks collapse into one (they were otherwise identical).

No behavior change for the current content script — `location.host` and `new URL(sender.url).host` agree, ports included.

🍻 Brewed with GLM 5.3 (z.ai)