### PR TITLE
Harden three low-risk paths: https-only LNURL callbacks, SSRF-guarded QR fetch, ncryptsec logn cap

### DIFF
--- a/background.js
+++ b/background.js
@@ -1990,7 +1990,14 @@ function ensureJsQR() {
 }
 async function invoiceFromQrImage(srcUrl) {
   if (!srcUrl) throw new Error('No image to read');
-  const blob = await (await fetch(srcUrl)).blob();
+  // The SW fetch is CORS-exempt, so the right-clicked image URL passes the same
+  // SSRF guard as every other server-side fetch (see safeFetchUrl). Without this,
+  // a crafted image URL pointing at an internal service turns "decode this QR"
+  // into a private-network probe. A URL the guard rejects fails the pay, exactly
+  // like any other unreadable QR.
+  const safe = safeFetchUrl(srcUrl);
+  if (!safe) throw new Error('Not a readable image URL');
+  const blob = await (await fetch(safe)).blob();
   const bmp = await createImageBitmap(blob);
   const canvas = new OffscreenCanvas(bmp.width, bmp.height);
   const ctx = canvas.getContext('2d');

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -3669,18 +3669,50 @@
     });
   }
 
+  // Read the scrypt logn byte out of an ncryptsec WITHOUT decrypting — a partial
+  // bech32 read of the first two payload bytes (version, logn). Returns null when
+  // the string doesn't decode that far; full validity stays nip49.decrypt's job.
+  const NCRYPTSEC_CHARSET = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l';
+  function ncryptsecLogn(ncryptsec) {
+    const s = String(ncryptsec || '');
+    const sep = s.lastIndexOf('1');
+    if (sep < 1) return null;
+    let acc = 0, bits = 0;
+    for (const ch of s.slice(sep + 1)) {
+      const v = NCRYPTSEC_CHARSET.indexOf(ch);
+      if (v < 0) return null;
+      acc = (acc << 5) | v;
+      bits += 5;
+      if (bits >= 16) return (acc >> (bits - 16)) & 0xff; // second byte = logn
+    }
+    return null;
+  }
+
   // Decrypt a NIP-49 ncryptsec string to an nsec, so the rest of the import path
   // (SIDECAR_ADD_ACCOUNT, decodeSecret) never has to know ncryptsec exists. Throws
   // a friendly message on a bad password or malformed string. Off-thread: the
   // scrypt inside is the worker's whole reason to exist (see nip49()).
   async function decryptNcryptsec(ncryptsec, password) {
+    // Cost-byte pre-check. nip49.js is a hash-pinned vendored build, so the bound
+    // can't live inside decrypt() — but logn is just a byte in the pasted string,
+    // and a crafted one (24 → 16GB of scrypt) burns that memory in the worker
+    // before the AEAD ever gets a chance to reject the key: off-thread saved the
+    // panel's responsiveness, not the browser from an OOM. NIP-49's own table
+    // tops out at 22 (4GiB); > 20 (1GiB) matches no known client, and real keys
+    // are 16–18. A null (undecodable here) falls through — nip49.decrypt is
+    // still the validity gate, this only caps the work we'll attempt.
+    if (ncryptsecLogn(ncryptsec) > 20) {
+      throw new Error('Incorrect password, or not a valid ncryptsec key.');
+    }
     let sk;
     try {
       sk = await nip49('decrypt', [ncryptsec, password]);
+      // nsecEncode inside the try too: a decrypt that returns wrong-length bytes
+      // would otherwise throw nostr-tools' raw error at the user.
+      return NT.nip19.nsecEncode(sk);
     } catch (_) {
       throw new Error('Incorrect password, or not a valid ncryptsec key.');
     }
-    return NT.nip19.nsecEncode(sk);
   }
 
   // ---- reading a key out of a QR image (the printable backup sheet) ----
@@ -10856,6 +10888,11 @@
       throw new Error('Amount must be ' + Math.ceil(meta.minSendable / 1000) + '–' + Math.floor(meta.maxSendable / 1000) + ' sats');
     }
     const cb = new URL(meta.callback);
+    // The callback URL is chosen by whoever runs the lightning-address domain —
+    // an http:// one sends the payment request (and its amount/comment) in
+    // cleartext and is trivially swapped by a MITM. LNURL-pay callbacks are
+    // https in practice, so refuse anything else.
+    if (cb.protocol !== 'https:') throw new Error('Lightning address returned an insecure callback URL');
     cb.searchParams.set('amount', String(msats));
     if (comment && meta.commentAllowed > 0) cb.searchParams.set('comment', comment.slice(0, meta.commentAllowed));
     const res = await (await fetch(cb.toString())).json();

--- a/test/ncryptsec-logn.test.js
+++ b/test/ncryptsec-logn.test.js
@@ -1,0 +1,133 @@
+'use strict';
+
+// Unit coverage for the ncryptsec logn cap in sidepanel.js.
+//
+// nip49.js is a hash-pinned vendored build (CI enforces scripts/vendor-hashes.sha256),
+// so the scrypt cost bound can't live inside its decrypt(). Instead decryptNcryptsec
+// pre-reads the logn byte with ncryptsecLogn() and refuses to hand nip49 a string
+// whose scrypt would allocate more than ~1GiB. A pasted string is attacker-controlled
+// input; it must not be able to burn that memory in the NIP-49 worker (or, on the
+// no-worker fallback, freeze the panel) before the AEAD ever rejects the key.
+//
+// decryptNcryptsec is async since the worker change (#195): scrypt runs off-thread
+// via nip49(). The vm sandbox has no Worker global, so nip49() takes its documented
+// sync fallback and calls window.SidecarNip49.decrypt on a microtask — the same
+// code path a browser hits when workers are unavailable.
+//
+// The test vectors here are hand-built bech32 payloads (version 2 + logn + slack)
+// with NO valid checksum — ncryptsecLogn doesn't check one (that's nip49.decrypt's
+// job), which is exactly what lets the cap be tested without real keys.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const ROOT = path.join(__dirname, '..');
+const source = fs.readFileSync(path.join(ROOT, 'sidepanel.js'), 'utf8');
+
+function lift(pattern, label) {
+  const m = source.match(pattern);
+  if (!m) throw new Error('Could not find ' + label + ' in sidepanel.js');
+  return m[0];
+}
+
+// Build `ncryptsec1` + the 5-bit words encoding [version=2, logn] (+ slack bits),
+// checksum deliberately garbage.
+const CHARSET = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l';
+function fakeNcryptsec(logn) {
+  const bits = (2 << 8 | logn).toString(2).padStart(16, '0') + '0'.repeat(15);
+  let words = '';
+  for (let i = 0; i < bits.length; i += 5) words += CHARSET[parseInt(bits.slice(i, i + 5), 2)];
+  return 'ncryptsec1' + words;
+}
+
+// A context where nip49.decrypt (via the sync fallback) and NT.nip19.nsecEncode
+// are observable stubs.
+function harness({ decryptResult, decryptThrows } = {}) {
+  const decryptCalls = [];
+  const ctx = {
+    NT: {
+      nip19: {
+        nsecEncode: (bytes) => {
+          if (!bytes || bytes.length !== 32) throw new Error('invalid key slice length');
+          return 'nsec1' + Array.from(bytes, (b) => b.toString(16)).join('');
+        },
+      },
+    },
+    window: {
+      SidecarNip49: {
+        decrypt: (s, p) => {
+          decryptCalls.push({ s, p });
+          if (decryptThrows) throw new Error('bad ciphertext');
+          return decryptResult;
+        },
+      },
+    },
+  };
+  vm.createContext(ctx);
+  vm.runInContext(
+    lift(/let nip49Worker = null;[\s\S]*?nip49Worker\.postMessage\(\{ id, op, args \}\);\n    \}\);\n  \}/, 'nip49 worker helper') + '\n' +
+    lift(/const NCRYPTSEC_CHARSET = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l';[\s\S]*?\n    return null;\n  \}/, 'ncryptsecLogn') + '\n' +
+    lift(/async function decryptNcryptsec\(ncryptsec, password\) \{[\s\S]*?\n  \}/, 'decryptNcryptsec') + '\n' +
+    'globalThis.ncryptsecLogn = ncryptsecLogn;' +
+    'globalThis.decryptNcryptsec = decryptNcryptsec;',
+    ctx
+  );
+  return { ctx, decryptCalls };
+}
+
+const OK_KEY = new Uint8Array(32).fill(7);
+const FRIENDLY = /Incorrect password, or not a valid ncryptsec key\./;
+
+// ---- the byte reader ------------------------------------------------------------
+
+test('ncryptsecLogn reads the second payload byte out of hand-built vectors', () => {
+  const { ctx } = harness();
+  for (const logn of [10, 16, 18, 20, 21, 24, 255]) {
+    assert.equal(ctx.ncryptsecLogn(fakeNcryptsec(logn)), logn, 'logn ' + logn);
+  }
+});
+
+test('ncryptsecLogn returns null for junk — validity stays nip49.decrypt\'s job', () => {
+  const { ctx } = harness();
+  // Undecodable (no separator, non-charset chars, too short) → null. A non-ncryptsec
+  // hrp with valid charset data (e.g. an nsec) DOES decode — fine, callers route
+  // only /^ncryptsec1/ strings here, and a high byte there would just be rejected.
+  for (const junk of ['', null, undefined, 'ncryptsec', 'ncryptsec1', 'ncryptsec1q!zry9x8', 'ncryptsec1qpz']) {
+    assert.equal(ctx.ncryptsecLogn(junk), null, JSON.stringify(junk));
+  }
+});
+
+// ---- the cap --------------------------------------------------------------------
+
+test('a crafted logn > 20 is rejected before scrypt — nip49.decrypt is never called', async () => {
+  const { ctx, decryptCalls } = harness({ decryptResult: OK_KEY });
+  for (const logn of [21, 24, 30, 255]) {
+    await assert.rejects(ctx.decryptNcryptsec(fakeNcryptsec(logn), 'pw'), FRIENDLY, 'logn ' + logn);
+  }
+  assert.equal(decryptCalls.length, 0, 'the memory burn happens in decrypt — it must not be reached');
+});
+
+test('logn 20 and below still reach nip49.decrypt', async () => {
+  const { ctx, decryptCalls } = harness({ decryptResult: OK_KEY });
+  for (const logn of [10, 16, 20]) {
+    await ctx.decryptNcryptsec(fakeNcryptsec(logn), 'pw');
+  }
+  assert.equal(decryptCalls.length, 3);
+});
+
+// ---- the friendly-error contract --------------------------------------------------
+
+test('a decrypt failure still maps to the friendly message', async () => {
+  const { ctx } = harness({ decryptThrows: true });
+  await assert.rejects(ctx.decryptNcryptsec(fakeNcryptsec(16), 'pw'), FRIENDLY);
+});
+
+test('a wrong-length key from decrypt surfaces the friendly message, not nostr-tools\' raw error', async () => {
+  // nsecEncode must live INSIDE the try — a malformed key length used to throw
+  // nostr-tools' "invalid key slice length" straight at the user.
+  const { ctx } = harness({ decryptResult: new Uint8Array(2) });
+  await assert.rejects(ctx.decryptNcryptsec(fakeNcryptsec(16), 'pw'), FRIENDLY);
+});


### PR DESCRIPTION
Closes #192 (sub-issue of the security-audit umbrella #199).

Three small independent patches — the cheapest risk reduction in the audit.

## 1. LNURL callback must be https (N4)

`meta.callback` in `lnAddressToInvoice` is chosen by whoever runs the lightning-address domain, and an `http://` callback was followed as-is: the payment request (amount, comment) goes out in cleartext and a MITM can swap the returned invoice. LNURL-pay callbacks are https in practice, so anything else is now refused with a clear error.

## 2. QR-image fetch through the SSRF guard (N3)

The service worker's fetch is CORS-exempt, and `invoiceFromQrImage` fetched the right-clicked image URL raw — unlike the OG-preview path, which already routes through `safeFetchUrl`. A crafted image URL pointing at an internal service (or cloud metadata) turned "decode this QR" into a private-network probe. The fetch now goes through the same guard; a URL it rejects fails the pay, exactly like any other unreadable QR.

Note: a `data:` image URL is also refused by the guard (it's non-http(s)). No known client puts a payable BOLT11 QR in a data-URL `<img>` — they render canvas/SVG, which never reaches this menu — so the trade wasn't worth widening the guard for.

## 3. ncryptsec logn cap (K3)

`nip49.js` trusts the `logn` byte from the pasted string, and `logn` is just a byte — a crafted ncryptsec with `logn: 24` asks noble's scrypt for ~16GB of memory, burned in the NIP-49 worker before the AEAD ever rejects the key. Off-thread saved the panel's responsiveness, not the browser from an OOM. (This branch is rebased onto #195's worker change: `decryptNcryptsec` is now async, and the cap runs before the `await`.)

`nip49.js` is a hash-pinned vendored build (CI enforces `scripts/vendor-hashes.sha256`), so the bound can't live inside `decrypt()`. Instead `decryptNcryptsec` pre-reads the logn byte with a ~15-line partial bech32 decode and rejects `> 20` (1GiB, ~2s — the top of NIP-49's own table is 22; no known client emits above 18; Sidecar writes 16). Undecodable strings fall through — `nip49.decrypt` remains the validity gate; this only caps the work we'll attempt.

Also moves `nsecEncode` inside the try block, so a decrypt that returns wrong-length bytes surfaces the friendly "Incorrect password, or not a valid ncryptsec key." message instead of nostr-tools' raw throw.

## Tests

New `test/ncryptsec-logn.test.js` (6 tests): the byte reader against hand-built bech32 vectors, the cap rejecting logn 21–255 **without ever calling nip49.decrypt**, logn ≤ 20 still passing through, and the friendly-error contract for both decrypt failures and malformed key length. The harness lifts the real `nip49()` helper from sidepanel.js too — the vm sandbox has no `Worker` global, so the tests run the shipped no-worker fallback (sync `window.SidecarNip49.decrypt` on a microtask), and every throw is asserted as a rejection now that `decryptNcryptsec` is async.

Full suite: 412 tests, 410 pass (the 2 reds are the known `nostr-tools`-not-installed pair on main: `search-entity`, `web-comment`).

🥃 Shaken with GLM 5.3 (z.ai)
