### PR TITLE
Declare externally_connectable denied

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -61,6 +61,7 @@
       "all_frames": false
     }
   ],
+  "externally_connectable": {},
   "browser_specific_settings": {
     "gecko": {
       "id": "sidecar@sidecar.top",

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -73,6 +73,10 @@ build_zip() {
     } else {
       delete m.side_panel;
       delete m.minimum_chrome_version;
+      // externally_connectable is Chrome-schema only (Firefox never supported
+      // it and defaults to deny anyway); drop it so the AMO validator does not
+      // flag an unrecognized manifest key in the Firefox zip.
+      delete m.externally_connectable;
       // sidePanel is a Chrome-only permission; drop it so the AMO
       // validator does not flag an unrecognized permission in the Firefox zip.
       if (Array.isArray(m.permissions)) {


### PR DESCRIPTION
Closes #193 (sub-issue of the security-audit umbrella #199).

One manifest line, plus the packaging note the issue asked to check.

## The change

`"externally_connectable": {}` in manifest.json.

Today the "no web page and no extension can message us" posture is *implicit*: it holds because the manifest never declares the key and background.js never registers `onMessageExternal`/`onConnectExternal`. That's correct but fragile — it rests on nobody adding an external handler in some future refactor. Declaring the empty object makes it structural:

- **no `matches`** → no web page can `runtime.sendMessage` us, ever
- **no `ids`** → no other extension can either (this is the part the absent key doesn't give you — with the key absent, *every* extension can connect; declaring it without `ids` revokes that)

Per the Chrome docs: an empty/unspecified `ids` means "no extensions or apps can connect"; an empty/unspecified `matches` means "no web pages can connect." Verified against [the manifest docs](https://developer.chrome.com/docs/extensions/reference/manifest/externally-connectable) before writing this.

Sidecar has no reason for any other extension to message it — the NIP-07 bridge is a content script, not an extension-to-extension channel — so nothing is lost.

## Firefox packaging (the issue's second checkbox)

`externally_connectable` is Chrome-schema only; Firefox never implemented it and already denies external connections by default. Keeping it in the AMO zip would just earn an unrecognized-manifest-key flag from the validator, so `scripts/package.sh` now drops it from the Firefox build alongside `side_panel` and `minimum_chrome_version` — same rule the script already follows for every other store-specific key.

Both transforms simulated against the new manifest before pushing: Chrome zip carries the empty object, Firefox zip carries neither it nor the other browser's keys.

## Tests

Manifest-only change; the suite is untouched (397 tests, 395 pass, 2 known reds — same pair as main).

🍸 Stirred with GLM 5.3 (z.ai)