### PR TITLE
Nostr Archives name search: ask once on first use (#194)

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -63,12 +63,14 @@ Sidecar only talks to services **you choose**:
   otherwise fall back to **nostr.build**. Only the media you choose to attach is
   sent.
 - **@-mention search** — when you type `@` in the composer to mention someone,
-  Sidecar searches your follows locally. If the **Nostr Archives** name index is
-  enabled in Settings (off by default), it also queries that search API so you
-  can find any Nostr user by name, and sends it the public keys of people you
-  follow to resolve names your relays didn't return — so that service sees both
-  what you type and who you follow. Only the mention-search text and those
-  public keys are sent.
+  Sidecar searches your follows locally. The first time you search a name, it
+  offers to also query the **Nostr Archives** name index so you can find any
+  Nostr user by name; nothing is sent there until you agree, and you can change
+  or revoke that answer later in Settings ("Use the Nostr Archives name index").
+  While it is on, Sidecar sends the index the mention-search text and the public
+  keys of people you follow (to resolve names your relays didn't return) — so
+  that service sees both what you type and who you follow. Only that text and
+  those public keys are sent.
 
 Sidecar does not send any of this data to the developer. The services above are
 the only ones it contacts — those you configure (relays, wallet) or invoke by a

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -63,9 +63,12 @@ Sidecar only talks to services **you choose**:
   otherwise fall back to **nostr.build**. Only the media you choose to attach is
   sent.
 - **@-mention search** — when you type `@` in the composer to mention someone,
-  Sidecar searches your follows locally and also queries the **Nostr Archives**
-  search API so you can find any Nostr user by name. Only the text you type in
-  the mention search is sent.
+  Sidecar searches your follows locally. If the **Nostr Archives** name index is
+  enabled in Settings (off by default), it also queries that search API so you
+  can find any Nostr user by name, and sends it the public keys of people you
+  follow to resolve names your relays didn't return — so that service sees both
+  what you type and who you follow. Only the mention-search text and those
+  public keys are sent.
 
 Sidecar does not send any of this data to the developer. The services above are
 the only ones it contacts — those you configure (relays, wallet) or invoke by a

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -66,11 +66,11 @@ Sidecar only talks to services **you choose**:
   Sidecar searches your follows locally. The first time you search a name, it
   offers to also query the **Nostr Archives** name index so you can find any
   Nostr user by name; nothing is sent there until you agree, and you can change
-  or revoke that answer later in Settings ("Use the Nostr Archives name index").
-  While it is on, Sidecar sends the index the mention-search text and the public
-  keys of people you follow (to resolve names your relays didn't return) — so
-  that service sees both what you type and who you follow. Only that text and
-  those public keys are sent.
+  or revoke that answer later from the search bar's scope icon (the globe) or in
+  Settings ("Use the Nostr Archives name index"). While it is on, Sidecar sends
+  the index the mention-search text and the public keys of people you follow
+  (to resolve names your relays didn't return) — so that service sees both what
+  you type and who you follow. Only that text and those public keys are sent.
 
 Sidecar does not send any of this data to the developer. The services above are
 the only ones it contacts — those you configure (relays, wallet) or invoke by a

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -102,6 +102,11 @@
       <div class="search-row">
         <input id="search-input" type="text" spellcheck="false" autocomplete="off"
                placeholder="npub, note, nevent, naddr, or username" />
+        <!-- Scope chip: name search is either your follows (users) or every Nostr
+             name via the Nostr Archives index (globe). Painted by
+             paintSearchModeIcon; click toggles, with the one-time ask when
+             turning global on. -->
+        <button id="search-mode" class="icon-btn search-mode" title="" aria-label="Name search scope"></button>
         <button id="search-close" class="icon-btn search-close" title="Close search" aria-label="Close search">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
         </button>

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -332,7 +332,7 @@
 
       <div class="setting">
         <h3>Global name search</h3>
-        <p class="hint">Typing an @mention can also search a third-party index (api.nostrarchives.com) for any Nostr user, and send it the people you follow so it can fill in names your relays missed. That service then sees both what you type and who you follow — which nothing else reveals together. Off by default; @mentions from your own relays keep working either way.</p>
+        <p class="hint">The first time you search a Nostr name, Sidecar offers to also ask a third-party index (api.nostrarchives.com) that covers every user, and to send it the people you follow so it can fill in names your relays missed. That service then sees both what you type and who you follow — which nothing else reveals together. This switch is that answer; @mentions from your own relays keep working either way.</p>
         <label class="toggle-row"><input type="checkbox" id="na-toggle" /> <span>Use the Nostr Archives name index</span></label>
       </div>
 

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -331,6 +331,12 @@
       </div>
 
       <div class="setting">
+        <h3>Global name search</h3>
+        <p class="hint">Typing an @mention can also search a third-party index (api.nostrarchives.com) for any Nostr user, and send it the people you follow so it can fill in names your relays missed. That service then sees both what you type and who you follow — which nothing else reveals together. Off by default; @mentions from your own relays keep working either way.</p>
+        <label class="toggle-row"><input type="checkbox" id="na-toggle" /> <span>Use the Nostr Archives name index</span></label>
+      </div>
+
+      <div class="setting">
         <h3>Open notes in</h3>
         <p class="hint">Which web client to open your published notes in.</p>
         <select id="client-select">

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -1326,10 +1326,10 @@
     closeSearch();
   }
 
-  function renderSearchResults(items, loading) {
+  function renderSearchResults(items, loading, askEl) {
     const box = $('search-results');
     searchResults = items;
-    if (!items.length && !loading) { box.innerHTML = ''; box.classList.add('hidden'); return; }
+    if (!items.length && !loading && !askEl) { box.innerHTML = ''; box.classList.add('hidden'); return; }
     if (searchIndex >= items.length) searchIndex = items.length - 1;
     box.classList.remove('hidden');
     box.innerHTML = '';
@@ -1347,9 +1347,10 @@
         h('span', { textContent: items.length ? 'Searching more…' : 'Searching Nostr…' }),
       ]));
     }
+    if (askEl) box.append(askEl);
   }
 
-  function updateSearchAc() {
+  async function updateSearchAc() {
     const raw = $('search-input').value.trim();
     // An identifier resolves on Enter; there is nothing to suggest for it. Same
     // for a complete NIP-05 — that's a lookup, not a search.
@@ -1363,13 +1364,14 @@
 
     let follows = [];
     let globals = [];
-    let globalPending = naAvailable();
+    let globalPending = false;
+    let askEl = null; // the one-time Nostr Archives ask, while the setting is unset
     const paint = () => {
       if (seq !== searchAcSeq) return;
       const seen = new Set(follows.map((c) => c.pubkey));
       const merged = follows.slice();
       for (const g of globals) { if (!seen.has(g.pubkey)) { seen.add(g.pubkey); merged.push(g); } }
-      renderSearchResults(merged.slice(0, 8), globalPending);
+      renderSearchResults(merged.slice(0, 8), globalPending, askEl);
     };
 
     const cached = (followListCache && followListPubkey === state.activePubkey) ? followListCache : null;
@@ -1383,7 +1385,15 @@
       }).catch(() => {});
     }
 
-    if (globalPending) {
+    // The global slot is tri-state too (see the NA block): decided-on searches,
+    // decided-off shows nothing, never-asked shows the one-time ask where the
+    // spinner would be. Answering re-enters here with the decision written.
+    if (!naAvailable()) return;
+    const na = await naSetting();
+    if (seq !== searchAcSeq) return;
+    if (na === true) {
+      globalPending = true;
+      paint();
       if (searchAcTimer) clearTimeout(searchAcTimer);
       searchAcTimer = setTimeout(async () => {
         const res = await naSuggest(raw);
@@ -1392,6 +1402,9 @@
         globalPending = false;
         paint();
       }, 250);
+    } else if (na !== false) {
+      askEl = naAskEl((on) => { naDecide(on).then(updateSearchAc); });
+      paint();
     }
   }
 
@@ -4548,7 +4561,7 @@
     $('paybutton-toggle').checked = settings.showPayButton !== false; // default on
     $('clienttag-toggle').checked = settings.showClientTag !== false; // default on
     $('datasync-toggle').checked = settings.confirmDataSync === true; // default off (auto-allow)
-    $('na-toggle').checked = settings.nostrArchives === true; // default off (privacy: follow-list disclosure)
+    $('na-toggle').checked = settings.nostrArchives === true; // tri-state: unset and false both render off (privacy: follow-list disclosure)
     $('pinbalance-toggle').checked = settings.pinBalanceBar === true; // default off
     // Populate from the shared list on first open, then select the saved currency.
     const fiatSel = $('fiat-select');
@@ -5340,18 +5353,45 @@
   // didn't return. Best-effort: any error or rate-limit falls back to relay data.
   // Approved endpoints only.
   //
-  // OPT-IN (Settings → "Use the Nostr Archives name index", default off). Both
-  // endpoints disclose something the relays never see together: suggest sends
-  // what you're typing in the composer, metadata sends your follow list in
-  // 500-pubkey chunks — a new centralized observer that can correlate sessions
-  // by IP. That trade is the user's call, so without the setting both return
-  // empty and mention search stays relay-only. Reads storage directly rather
-  // than via call() so autocomplete keystrokes can't wake the service worker.
+  // OPT-IN, asked ONCE on first use (#194). Both endpoints disclose something the
+  // relays never see together: suggest sends what you're typing in the composer,
+  // metadata sends your follow list in 500-pubkey chunks — a new centralized
+  // observer that can correlate sessions by IP. That trade is the user's call, so
+  // the first time a name search would fire, the dropdown carries a one-time ask
+  // (see naAskEl) instead of the spinner; either answer is remembered, and the
+  // Settings toggle ("Use the Nostr Archives name index") is the only way back.
+  // Tri-state: undefined = never asked, true/false = decided. Reads storage
+  // directly rather than via call() so autocomplete keystrokes can't wake the SW.
   const NA_BASE = 'https://api.nostrarchives.com';
-  function naEnabled() {
+  function naSetting() {
     return new Promise((resolve) =>
       chrome.storage.local.get('sidecar_settings', (r) =>
-        resolve(((r && r.sidecar_settings) || {}).nostrArchives === true)));
+        resolve(((r && r.sidecar_settings) || {}).nostrArchives)));
+  }
+  async function naEnabled() { return (await naSetting()) === true; }
+  // Either button on the ask writes the decision — a click may wake the service
+  // worker, unlike the read above.
+  async function naDecide(on) {
+    try { await call({ type: 'SIDECAR_SET_SETTINGS', settings: { nostrArchives: on } }); } catch (_) {}
+  }
+  // The ask itself, rendered where the search spinner would sit in whichever
+  // surface fired first — the composer's @-mention dropdown or the topbar search
+  // box. mousedown + preventDefault like the result rows: a plain click would
+  // blur the composer first and close the dropdown before the decision lands.
+  // onDecided(on) re-runs the host surface's update, which now sees a decision.
+  function naAskEl(onDecided) {
+    const row = h('div', { className: 'na-ask' });
+    row.append(h('p', {
+      className: 'na-ask-text',
+      textContent: 'Also search every Nostr name? This uses a third-party index (api.nostrarchives.com) that sees what you type and who you follow.',
+    }));
+    const yes = h('button', { className: 'na-ask-yes', type: 'button', textContent: 'Search everyone' });
+    const no = h('button', { className: 'na-ask-no', type: 'button', textContent: 'Just my follows' });
+    const pick = (on) => (e) => { e.preventDefault(); e.stopPropagation(); onDecided(on); };
+    yes.addEventListener('mousedown', pick(true));
+    no.addEventListener('mousedown', pick(false));
+    row.append(h('div', { className: 'na-ask-actions' }, [yes, no]));
+    return row;
   }
   const isHex64 = (s) => typeof s === 'string' && /^[0-9a-f]{64}$/i.test(s);
   let naCooldownUntil = 0; // epoch ms; a 429 backs us off until this time
@@ -6362,9 +6402,11 @@
 
     // `loading` shows a "Searching Nostr…" footer while the global lookup runs,
     // and keeps the dropdown open even when there are no local matches yet.
-    function renderAcResults(items, ctx, loading) {
+    // `askEl` is the one-time Nostr Archives ask standing in for that footer
+    // while the setting is unset (see the NA block).
+    function renderAcResults(items, ctx, loading, askEl) {
       acResults = items;
-      if (!acResults.length && !loading) { closeAcDropdown(); return; }
+      if (!acResults.length && !loading && !askEl) { closeAcDropdown(); return; }
       acIndex = Math.max(0, Math.min(acIndex, Math.max(0, acResults.length - 1)));
       if (!acDropdown) {
         acDropdown = h('div', { className: 'ac-dropdown' });
@@ -6390,6 +6432,7 @@
           h('span', { textContent: acResults.length ? 'Searching more…' : 'Searching Nostr…' }),
         ]));
       }
+      if (askEl) acDropdown.append(askEl);
     }
 
     // Two async sources feed the dropdown: your follow list (instant from
@@ -6407,28 +6450,36 @@
       const matchFollows = (list) => list.filter((c) => c.name && c.name.toLowerCase().includes(q));
       let followMatches = [];
       let globals = [];
-      let globalPending = willSearchGlobal;
+      let globalPending = false;
+      let askEl = null; // the one-time Nostr Archives ask, while the setting is unset
       const paint = () => {
         if (seq !== acSeq) return;
         const seen = new Set(followMatches.map((c) => c.pubkey));
         const merged = followMatches.slice();
         for (const g of globals) { if (!seen.has(g.pubkey)) { seen.add(g.pubkey); merged.push(g); } }
-        renderAcResults(merged.slice(0, 8), ctx, globalPending);
+        renderAcResults(merged.slice(0, 8), ctx, globalPending, askEl);
       };
 
       // Follows: use the cache synchronously if present; otherwise load in the
       // background and repaint when ready (no await here).
       const cached = (followListCache && followListPubkey === state.activePubkey) ? followListCache : null;
       if (cached) followMatches = matchFollows(cached);
-      paint(); // instant feedback: local matches (maybe none) + spinner if searching
+      paint(); // instant feedback: local matches (maybe none)
       if (!cached) {
         getFollowList().then((list) => { if (seq === acSeq) { followMatches = matchFollows(list); paint(); } });
       }
 
       // Global search across all of Nostr so you can tag people you don't
       // follow. Debounced; best-effort — a failure/rate-limit just clears the
-      // spinner and leaves the follow matches.
-      if (willSearchGlobal) {
+      // spinner and leaves the follow matches. With the Nostr Archives setting
+      // still unset, the spinner's slot carries the one-time ask instead;
+      // answering it re-enters here with the decision written.
+      if (!willSearchGlobal) return;
+      const na = await naSetting();
+      if (seq !== acSeq) return;
+      if (na === true) {
+        globalPending = true;
+        paint();
         if (acSuggestTimer) clearTimeout(acSuggestTimer);
         acSuggestTimer = setTimeout(async () => {
           const res = await naSuggest(ctx.query);
@@ -6437,6 +6488,9 @@
           globalPending = false;
           paint();
         }, 250);
+      } else if (na !== false) {
+        askEl = naAskEl((on) => { naDecide(on).then(updateAcDropdown); });
+        paint();
       }
     }
 

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -1216,8 +1216,44 @@
     $('search-bar').classList.remove('hidden');
     $('search-btn').setAttribute('aria-expanded', 'true');
     setSearchStatus('');
+    paintSearchModeIcon();
     $('search-input').focus();
   }
+
+  // Scope chip next to the search input: shows whether a name search runs
+  // locally (your follows, users icon) or globally (Nostr Archives index,
+  // globe icon), and is the always-available way to flip it. Unset counts as
+  // local — nothing is sent while it's unset, so that's the honest display.
+  // Clicking toward global shows the same one-time ask the dropdown shows,
+  // because that click is the disclosure moment; clicking back to local is
+  // immediate — that direction only ever withholds data.
+  function paintSearchModeIcon() {
+    naSetting().then((on) => {
+      const btn = $('search-mode');
+      const global = on === true;
+      btn.classList.toggle('global', global);
+      btn.replaceChildren(icon(global ? 'globe' : 'users'));
+      const title = global
+        ? 'Searching every Nostr name (Nostr Archives index) — click to search only your follows'
+        : 'Searching only your follows — click to also search every Nostr name';
+      btn.title = title;
+      btn.setAttribute('aria-label', title);
+    });
+  }
+  $('search-mode').addEventListener('click', async () => {
+    if ((await naSetting()) === true) {
+      await naDecide(false);
+      paintSearchModeIcon();
+      updateSearchAc();
+      return;
+    }
+    renderSearchResults([], false, naAskEl((decided) => {
+      naDecide(decided).then(() => {
+        paintSearchModeIcon();
+        updateSearchAc();
+      });
+    }));
+  });
 
   // A NIP-19 string, with or without a nostr: prefix or a web wrapper pasted
   // around it (njump.me/npub1…, primal.net/p/npub1… and friends all end in the
@@ -10707,6 +10743,7 @@
 
   $('na-toggle').addEventListener('change', async (e) => {
     naSetSettingMemo(e.target.checked); // keep this document's ask/gate in sync with the write
+    paintSearchModeIcon(); // the scope chip shows the same answer
     await call({ type: 'SIDECAR_SET_SETTINGS', settings: { nostrArchives: e.target.checked } });
   });
 

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -5360,18 +5360,35 @@
   // the first time a name search would fire, the dropdown carries a one-time ask
   // (see naAskEl) instead of the spinner; either answer is remembered, and the
   // Settings toggle ("Use the Nostr Archives name index") is the only way back.
-  // Tri-state: undefined = never asked, true/false = decided. Reads storage
-  // directly rather than via call() so autocomplete keystrokes can't wake the SW.
+  // Tri-state: undefined = never asked, true/false = decided. The first read
+  // hits storage directly rather than via call() so autocomplete keystrokes
+  // can't wake the SW; after that it's memoized (see below).
   const NA_BASE = 'https://api.nostrarchives.com';
+  // Tri-state memo. Reading storage on every keystroke left a gap where the
+  // ask blinked out of the dropdown — and with no follow matches the box
+  // closed outright for the duration of the read. With the memo the ask paints
+  // in the same frame as the follow matches. Every writer updates the memo too
+  // (naDecide, the Settings toggle listener), and both live in this document,
+  // so it cannot drift from what's stored.
+  let naSettingMemo;
+  let naSettingLoaded = false;
   function naSetting() {
+    if (naSettingLoaded) return Promise.resolve(naSettingMemo);
     return new Promise((resolve) =>
-      chrome.storage.local.get('sidecar_settings', (r) =>
-        resolve(((r && r.sidecar_settings) || {}).nostrArchives)));
+      chrome.storage.local.get('sidecar_settings', (r) => {
+        naSettingLoaded = true;
+        naSettingMemo = ((r && r.sidecar_settings) || {}).nostrArchives;
+        resolve(naSettingMemo);
+      }));
   }
+  function naSetSettingMemo(on) { naSettingLoaded = true; naSettingMemo = on; }
   async function naEnabled() { return (await naSetting()) === true; }
   // Either button on the ask writes the decision — a click may wake the service
-  // worker, unlike the read above.
+  // worker, unlike the read above. The memo is set first, optimistically: if
+  // the write somehow fails, showing the ask again right after a deliberate
+  // "Just my follows" would be worse than re-asking next session.
   async function naDecide(on) {
+    naSetSettingMemo(on);
     try { await call({ type: 'SIDECAR_SET_SETTINGS', settings: { nostrArchives: on } }); } catch (_) {}
   }
   // The ask itself, rendered where the search spinner would sit in whichever
@@ -5381,6 +5398,10 @@
   // onDecided(on) re-runs the host surface's update, which now sees a decision.
   function naAskEl(onDecided) {
     const row = h('div', { className: 'na-ask' });
+    // The whole ask swallows mousedown, not just its buttons: a mousedown on
+    // the paragraph is still a focus grab that blurs the composer, and its
+    // blur handler closes the dropdown — withdrawing a question mid-read.
+    row.addEventListener('mousedown', (e) => e.preventDefault());
     row.append(h('p', {
       className: 'na-ask-text',
       textContent: 'Also search every Nostr name? This uses a third-party index (api.nostrarchives.com) that sees what you type and who you follow.',
@@ -6509,7 +6530,14 @@
       } else if (e.key === 'Escape') { e.preventDefault(); closeAcDropdown(); }
     });
 
-    editor.addEventListener('blur', () => setTimeout(closeAcDropdown, 150));
+    // A pending one-time ask is a consent question, not search chrome: focus
+    // moving away (a click elsewhere in the panel, another window) must not
+    // withdraw it before it's answered. Escape still dismisses, and an
+    // unanswered ask simply returns on the next @-keystroke.
+    editor.addEventListener('blur', () => setTimeout(() => {
+      if (acDropdown && acDropdown.querySelector('.na-ask')) return;
+      closeAcDropdown();
+    }, 150));
 
     return {
       wrap,
@@ -10673,6 +10701,7 @@
   });
 
   $('na-toggle').addEventListener('change', async (e) => {
+    naSetSettingMemo(e.target.checked); // keep this document's ask/gate in sync with the write
     await call({ type: 'SIDECAR_SET_SETTINGS', settings: { nostrArchives: e.target.checked } });
   });
 

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -1347,7 +1347,9 @@
         h('span', { textContent: items.length ? 'Searching more…' : 'Searching Nostr…' }),
       ]));
     }
-    if (askEl) box.append(askEl);
+    // Above the results, same as the composer dropdown: this box caps and scrolls
+    // too, and an appended ask vanished under the fold once matches rendered.
+    if (askEl) box.prepend(askEl);
   }
 
   async function updateSearchAc() {
@@ -6453,7 +6455,10 @@
           h('span', { textContent: acResults.length ? 'Searching more…' : 'Searching Nostr…' }),
         ]));
       }
-      if (askEl) acDropdown.append(askEl);
+      // The ask goes ABOVE the results: the box caps at 200px and scrolls, and
+      // appended last it landed below the fold as soon as matches rendered —
+      // withdrawn from view exactly when results populated, unread.
+      if (askEl) acDropdown.prepend(askEl);
     }
 
     // Two async sources feed the dropdown: your follow list (instant from

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -4548,6 +4548,7 @@
     $('paybutton-toggle').checked = settings.showPayButton !== false; // default on
     $('clienttag-toggle').checked = settings.showClientTag !== false; // default on
     $('datasync-toggle').checked = settings.confirmDataSync === true; // default off (auto-allow)
+    $('na-toggle').checked = settings.nostrArchives === true; // default off (privacy: follow-list disclosure)
     $('pinbalance-toggle').checked = settings.pinBalanceBar === true; // default off
     // Populate from the shared list on first open, then select the saved currency.
     const fiatSel = $('fiat-select');
@@ -5337,8 +5338,21 @@
   // Global username search + bulk metadata, used to (A) find people to @mention
   // who aren't in your follow list and (B) resolve follow-list names the relays
   // didn't return. Best-effort: any error or rate-limit falls back to relay data.
-  // See docs/username-search-plan.md. Approved endpoints only.
+  // Approved endpoints only.
+  //
+  // OPT-IN (Settings → "Use the Nostr Archives name index", default off). Both
+  // endpoints disclose something the relays never see together: suggest sends
+  // what you're typing in the composer, metadata sends your follow list in
+  // 500-pubkey chunks — a new centralized observer that can correlate sessions
+  // by IP. That trade is the user's call, so without the setting both return
+  // empty and mention search stays relay-only. Reads storage directly rather
+  // than via call() so autocomplete keystrokes can't wake the service worker.
   const NA_BASE = 'https://api.nostrarchives.com';
+  function naEnabled() {
+    return new Promise((resolve) =>
+      chrome.storage.local.get('sidecar_settings', (r) =>
+        resolve(((r && r.sidecar_settings) || {}).nostrArchives === true)));
+  }
   const isHex64 = (s) => typeof s === 'string' && /^[0-9a-f]{64}$/i.test(s);
   let naCooldownUntil = 0; // epoch ms; a 429 backs us off until this time
   const naAvailable = () => Date.now() >= naCooldownUntil;
@@ -5351,6 +5365,7 @@
   // Global username search → [{pubkey, name, picture}]. Returns [] on any failure.
   async function naSuggest(query) {
     if (!query || query.length < 2 || !naAvailable()) return [];
+    if (!(await naEnabled())) return [];
     try {
       const resp = await fetch(NA_BASE + '/v1/search/suggest?q=' + encodeURIComponent(query) + '&limit=8', {
         signal: AbortSignal.timeout(5000),
@@ -5375,6 +5390,7 @@
     const out = new Map();
     const ids = [...new Set((pubkeys || []).filter(isHex64).map((p) => p.toLowerCase()))];
     if (!ids.length || !naAvailable()) return out;
+    if (!(await naEnabled())) return out;
     for (let i = 0; i < ids.length; i += 500) {
       const chunk = ids.slice(i, i + 500);
       try {
@@ -10600,6 +10616,10 @@
 
   $('datasync-toggle').addEventListener('change', async (e) => {
     await call({ type: 'SIDECAR_SET_SETTINGS', settings: { confirmDataSync: e.target.checked } });
+  });
+
+  $('na-toggle').addEventListener('change', async (e) => {
+    await call({ type: 'SIDECAR_SET_SETTINGS', settings: { nostrArchives: e.target.checked } });
   });
 
   $('pinbalance-toggle').addEventListener('change', async (e) => {

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -1230,9 +1230,7 @@
   function paintSearchModeIcon() {
     naSetting().then((on) => {
       const btn = $('search-mode');
-      const global = on === true;
-      btn.classList.toggle('global', global);
-      btn.replaceChildren(icon(global ? 'globe' : 'users'));
+      btn.replaceChildren(icon(on === true ? 'globe' : 'users'));
       const title = global
         ? 'Searching every Nostr name (Nostr Archives index) — click to search only your follows'
         : 'Searching only your follows — click to also search every Nostr name';

--- a/styles.css
+++ b/styles.css
@@ -601,11 +601,10 @@ button:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(var(--accent-rg
   box-shadow: 0 0 0 3px var(--focus-ring, rgba(203, 161, 78, 0.16));
 }
 .search-close { flex-shrink: 0; }
-/* Scope chip: users = your follows only (muted), globe = every Nostr name via
-   the Nostr Archives index (gold = on). Click toggles; turning global on runs
-   the one-time ask. */
+/* Scope chip: users = your follows only, globe = every Nostr name via the
+   Nostr Archives index. The glyph carries the distinction; it keeps the
+   standard icon-button color like the rest of the row. */
 .search-mode { flex-shrink: 0; }
-.search-mode.global { color: var(--gold); }
 /* Suggestion list. Reuses .ac-item/.ac-loading from the composer's @-mention
    dropdown, but sits in flow rather than absolutely positioned — the search bar
    is already a drop-down, so a second floating layer would just clip. */

--- a/styles.css
+++ b/styles.css
@@ -1657,11 +1657,14 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
 .ac-spinner { width: 14px; height: 14px; flex-shrink: 0; border-radius: 50%; border: 2px solid var(--border-strong); border-top-color: var(--lav); animation: ac-spin 0.7s linear infinite; }
 @keyframes ac-spin { to { transform: rotate(360deg); } }
 
-/* One-time Nostr Archives ask, rendered in the spinner's slot of either
-   autocomplete surface (composer dropdown, topbar search results). Divider on
-   top only when result rows precede it — with no rows it's the whole box. */
+/* One-time Nostr Archives ask, rendered at the TOP of either autocomplete
+   surface (composer dropdown, topbar search results) — first, because both
+   boxes cap their height and scroll, and an ask appended after the rows sank
+   below the fold the moment results rendered, withdrawn from view unread.
+   Divider below only when result rows follow it — with no rows the ask is the
+   whole box. */
 .na-ask { padding: 9px 12px 10px; }
-.na-ask:not(:first-child) { border-top: 1px solid var(--border); }
+.na-ask:not(:last-child) { border-bottom: 1px solid var(--border); }
 .na-ask-text { margin: 0 0 8px; font-size: 12px; line-height: 1.45; color: var(--muted); text-align: left; }
 .na-ask-actions { display: flex; gap: 6px; }
 /* Yes carries the accent (it's the more interesting answer and the one the

--- a/styles.css
+++ b/styles.css
@@ -1656,6 +1656,27 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
 .ac-loading { display: flex; align-items: center; gap: 9px; padding: 9px 12px; font-size: 12.5px; color: var(--muted); }
 .ac-spinner { width: 14px; height: 14px; flex-shrink: 0; border-radius: 50%; border: 2px solid var(--border-strong); border-top-color: var(--lav); animation: ac-spin 0.7s linear infinite; }
 @keyframes ac-spin { to { transform: rotate(360deg); } }
+
+/* One-time Nostr Archives ask, rendered in the spinner's slot of either
+   autocomplete surface (composer dropdown, topbar search results). Divider on
+   top only when result rows precede it — with no rows it's the whole box. */
+.na-ask { padding: 9px 12px 10px; }
+.na-ask:not(:first-child) { border-top: 1px solid var(--border); }
+.na-ask-text { margin: 0 0 8px; font-size: 12px; line-height: 1.45; color: var(--muted); text-align: left; }
+.na-ask-actions { display: flex; gap: 6px; }
+/* Yes carries the accent (it's the more interesting answer and the one the
+   disclosure is about), No stays quiet — a coin-flip styling would make
+   "Just my follows" look like the reluctant fallback rather than a real choice.
+   --accent-fill / --btn-primary-text so light themes restyle it like every
+   other accent button. */
+.na-ask-actions button {
+  flex: 1; padding: 7px 8px; border-radius: 8px; cursor: pointer;
+  font-family: inherit; font-size: 12px; font-weight: 600; white-space: nowrap;
+  transition: filter 0.12s;
+}
+.na-ask-actions button:hover { filter: brightness(1.08); }
+.na-ask-yes { background: var(--accent-fill, var(--gold)); border: 1px solid var(--accent-fill, var(--gold)); color: var(--btn-primary-text, #1a0d33); }
+.na-ask-no { background: transparent; border: 1px solid var(--border-strong); color: var(--muted); }
 .compose-preview {
   min-height: 120px; max-height: 46vh; overflow-y: auto;
   border: 1px solid var(--border); border-radius: 10px; padding: 12px;

--- a/styles.css
+++ b/styles.css
@@ -601,6 +601,11 @@ button:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(var(--accent-rg
   box-shadow: 0 0 0 3px var(--focus-ring, rgba(203, 161, 78, 0.16));
 }
 .search-close { flex-shrink: 0; }
+/* Scope chip: users = your follows only (muted), globe = every Nostr name via
+   the Nostr Archives index (gold = on). Click toggles; turning global on runs
+   the one-time ask. */
+.search-mode { flex-shrink: 0; }
+.search-mode.global { color: var(--gold); }
 /* Suggestion list. Reuses .ac-item/.ac-loading from the composer's @-mention
    dropdown, but sits in flow rather than absolutely positioned — the search bar
    is already a drop-down, so a second floating layer would just clip. */

--- a/test/na-optin.test.js
+++ b/test/na-optin.test.js
@@ -1,0 +1,96 @@
+'use strict';
+
+// Unit coverage for the Nostr Archives opt-in gate (audit issue #194).
+//
+// naSuggest and naMetadata disclose data the relays never see together — what
+// you type in the composer, and your follow list in chunks. Both are opt-in via
+// the "Use the Nostr Archives name index" setting (default off), and the pin
+// that matters is: with the setting off, NO fetch happens at all. Falling back
+// to empty is what keeps mention search relay-only, silently and safely.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const ROOT = path.join(__dirname, '..');
+const source = fs.readFileSync(path.join(ROOT, 'sidepanel.js'), 'utf8');
+
+function lift(pattern, label) {
+  const m = source.match(pattern);
+  if (!m) throw new Error('Could not find ' + label + ' in sidepanel.js');
+  return m[0];
+}
+
+function harness({ enabled }) {
+  const fetchCalls = [];
+  const ctx = {
+    NA_BASE: 'https://api.nostrarchives.test',
+    console,
+    AbortSignal: { timeout: (ms) => ms },
+    Date,
+    chrome: {
+      storage: {
+        local: { get: (key, cb) => cb({ sidecar_settings: { nostrArchives: enabled } }) },
+      },
+    },
+    fetch: async (url, opts) => {
+      fetchCalls.push({ url: String(url), opts });
+      return { ok: true, status: 200, headers: { get: () => null }, json: async () => ({}) };
+    },
+  };
+  vm.createContext(ctx);
+  vm.runInContext(
+    lift(/const isHex64 = \(s\) =>[\s\S]*?\n  /, 'isHex64') + '\n' +
+    lift(/let naCooldownUntil = 0;[\s\S]*?const naAvailable[^\n]*\n/, 'cooldown helpers') + '\n' +
+    lift(/function naEnabled\(\) \{[\s\S]*?\n  \}/, 'naEnabled') + '\n' +
+    lift(/async function naSuggest\(query\) \{[\s\S]*?\n  \}/, 'naSuggest') + '\n' +
+    lift(/async function naMetadata\(pubkeys\) \{[\s\S]*?\n  \}/, 'naMetadata') + '\n' +
+    'globalThis.naSuggest = naSuggest; globalThis.naMetadata = naMetadata;',
+    ctx
+  );
+  return { ctx, fetchCalls };
+}
+
+test('setting off (the default): suggest sends nothing and returns empty', async () => {
+  const { ctx, fetchCalls } = harness({ enabled: false });
+  // (length, not deepEqual against a host-realm [] — cross-vm realm arrays
+  // never compare reference-equal)
+  assert.equal((await ctx.naSuggest('alice')).length, 0);
+  assert.equal(fetchCalls.length, 0, 'no request may leave the panel with the index off');
+});
+
+test('setting off: metadata sends nothing — the follow list stays private', async () => {
+  const { ctx, fetchCalls } = harness({ enabled: false });
+  const out = await ctx.naMetadata(['a'.repeat(64), 'b'.repeat(64)]);
+  assert.equal(out.size, 0);
+  assert.equal(fetchCalls.length, 0);
+});
+
+test('setting on: suggest queries the API', async () => {
+  const { ctx, fetchCalls } = harness({ enabled: true });
+  await ctx.naSuggest('alice');
+  assert.equal(fetchCalls.length, 1);
+  assert.ok(fetchCalls[0].url.includes('/v1/search/suggest'), fetchCalls[0].url);
+});
+
+test('setting on: metadata posts the pubkey chunk', async () => {
+  const { ctx, fetchCalls } = harness({ enabled: true });
+  await ctx.naMetadata(['a'.repeat(64)]);
+  assert.equal(fetchCalls.length, 1);
+  assert.ok(fetchCalls[0].url.includes('/v1/profiles/metadata'));
+  assert.deepEqual(JSON.parse(fetchCalls[0].opts.body).pubkeys, ['a'.repeat(64)]);
+});
+
+test('the gate reads the nostrArchives key, defaulting to off when unset', async () => {
+  // No nostrArchives key at all (every existing user until they touch the toggle):
+  // chrome.storage returns an object without it — naEnabled must resolve false.
+  const ctx = { chrome: { storage: { local: { get: (k, cb) => cb({ sidecar_settings: {} }) } } } };
+  vm.createContext(ctx);
+  vm.runInContext(
+    lift(/function naEnabled\(\) \{[\s\S]*?\n  \}/, 'naEnabled') + 'globalThis.naEnabled = naEnabled;',
+    ctx
+  );
+  assert.equal(await ctx.naEnabled(), false);
+});

--- a/test/na-optin.test.js
+++ b/test/na-optin.test.js
@@ -3,10 +3,11 @@
 // Unit coverage for the Nostr Archives opt-in gate (audit issue #194).
 //
 // naSuggest and naMetadata disclose data the relays never see together — what
-// you type in the composer, and your follow list in chunks. Both are opt-in via
-// the "Use the Nostr Archives name index" setting (default off), and the pin
-// that matters is: with the setting off, NO fetch happens at all. Falling back
-// to empty is what keeps mention search relay-only, silently and safely.
+// you type in the composer, and your follow list in chunks. The setting is
+// tri-state: undefined = never asked (a one-time ask renders in the dropdown on
+// first use), true/false = decided. The pin that matters is: with the setting
+// unset OR off, NO fetch happens at all — the ask is the only enabler. Falling
+// back to empty is what keeps mention search relay-only until then.
 
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
@@ -44,16 +45,30 @@ function harness({ enabled }) {
   vm.runInContext(
     lift(/const isHex64 = \(s\) =>[\s\S]*?\n  /, 'isHex64') + '\n' +
     lift(/let naCooldownUntil = 0;[\s\S]*?const naAvailable[^\n]*\n/, 'cooldown helpers') + '\n' +
-    lift(/function naEnabled\(\) \{[\s\S]*?\n  \}/, 'naEnabled') + '\n' +
+    lift(/function naSetting\(\) \{[\s\S]*?\n  \}/, 'naSetting') + '\n' +
+    lift(/async function naEnabled\(\) \{[^\n]*\n/, 'naEnabled') + '\n' +
     lift(/async function naSuggest\(query\) \{[\s\S]*?\n  \}/, 'naSuggest') + '\n' +
     lift(/async function naMetadata\(pubkeys\) \{[\s\S]*?\n  \}/, 'naMetadata') + '\n' +
-    'globalThis.naSuggest = naSuggest; globalThis.naMetadata = naMetadata;',
+    'globalThis.naSuggest = naSuggest; globalThis.naMetadata = naMetadata; globalThis.naSetting = naSetting; globalThis.naEnabled = naEnabled;',
     ctx
   );
   return { ctx, fetchCalls };
 }
 
-test('setting off (the default): suggest sends nothing and returns empty', async () => {
+test('setting unset (never asked): suggest sends nothing — the ask is the only enabler', async () => {
+  const { ctx, fetchCalls } = harness({ enabled: undefined });
+  assert.equal((await ctx.naSuggest('alice')).length, 0);
+  assert.equal(fetchCalls.length, 0, 'no request may leave the panel before the one-time ask is answered');
+});
+
+test('setting unset (never asked): metadata sends nothing — the follow list stays private', async () => {
+  const { ctx, fetchCalls } = harness({ enabled: undefined });
+  const out = await ctx.naMetadata(['a'.repeat(64), 'b'.repeat(64)]);
+  assert.equal(out.size, 0);
+  assert.equal(fetchCalls.length, 0);
+});
+
+test('setting off: suggest sends nothing and returns empty', async () => {
   const { ctx, fetchCalls } = harness({ enabled: false });
   // (length, not deepEqual against a host-realm [] — cross-vm realm arrays
   // never compare reference-equal)
@@ -83,14 +98,18 @@ test('setting on: metadata posts the pubkey chunk', async () => {
   assert.deepEqual(JSON.parse(fetchCalls[0].opts.body).pubkeys, ['a'.repeat(64)]);
 });
 
-test('the gate reads the nostrArchives key, defaulting to off when unset', async () => {
-  // No nostrArchives key at all (every existing user until they touch the toggle):
-  // chrome.storage returns an object without it — naEnabled must resolve false.
+test('the gate reads the nostrArchives key tri-state: unset is not enabled', async () => {
+  // No nostrArchives key at all (every existing user until they answer the ask):
+  // chrome.storage returns an object without it — naSetting must resolve
+  // undefined, and naEnabled must resolve false.
   const ctx = { chrome: { storage: { local: { get: (k, cb) => cb({ sidecar_settings: {} }) } } } };
   vm.createContext(ctx);
   vm.runInContext(
-    lift(/function naEnabled\(\) \{[\s\S]*?\n  \}/, 'naEnabled') + 'globalThis.naEnabled = naEnabled;',
+    lift(/function naSetting\(\) \{[\s\S]*?\n  \}/, 'naSetting') + '\n' +
+    lift(/async function naEnabled\(\) \{[^\n]*\n/, 'naEnabled') + '\n' +
+    'globalThis.naSetting = naSetting; globalThis.naEnabled = naEnabled;',
     ctx
   );
+  assert.equal(await ctx.naSetting(), undefined);
   assert.equal(await ctx.naEnabled(), false);
 });

--- a/test/na-optin.test.js
+++ b/test/na-optin.test.js
@@ -45,11 +45,14 @@ function harness({ enabled }) {
   vm.runInContext(
     lift(/const isHex64 = \(s\) =>[\s\S]*?\n  /, 'isHex64') + '\n' +
     lift(/let naCooldownUntil = 0;[\s\S]*?const naAvailable[^\n]*\n/, 'cooldown helpers') + '\n' +
+    lift(/let naSettingMemo;[\s\S]*?let naSettingLoaded = false;\n/, 'memo state') + '\n' +
     lift(/function naSetting\(\) \{[\s\S]*?\n  \}/, 'naSetting') + '\n' +
+    lift(/function naSetSettingMemo\(on\) \{[^\n]*\n/, 'naSetSettingMemo') + '\n' +
     lift(/async function naEnabled\(\) \{[^\n]*\n/, 'naEnabled') + '\n' +
+    lift(/async function naDecide\(on\) \{[\s\S]*?\n  \}/, 'naDecide') + '\n' +
     lift(/async function naSuggest\(query\) \{[\s\S]*?\n  \}/, 'naSuggest') + '\n' +
     lift(/async function naMetadata\(pubkeys\) \{[\s\S]*?\n  \}/, 'naMetadata') + '\n' +
-    'globalThis.naSuggest = naSuggest; globalThis.naMetadata = naMetadata; globalThis.naSetting = naSetting; globalThis.naEnabled = naEnabled;',
+    'globalThis.naSuggest = naSuggest; globalThis.naMetadata = naMetadata; globalThis.naSetting = naSetting; globalThis.naEnabled = naEnabled; globalThis.naDecide = naDecide;',
     ctx
   );
   return { ctx, fetchCalls };
@@ -105,11 +108,43 @@ test('the gate reads the nostrArchives key tri-state: unset is not enabled', asy
   const ctx = { chrome: { storage: { local: { get: (k, cb) => cb({ sidecar_settings: {} }) } } } };
   vm.createContext(ctx);
   vm.runInContext(
+    lift(/let naSettingMemo;[\s\S]*?let naSettingLoaded = false;\n/, 'memo state') + '\n' +
     lift(/function naSetting\(\) \{[\s\S]*?\n  \}/, 'naSetting') + '\n' +
+    lift(/function naSetSettingMemo\(on\) \{[^\n]*\n/, 'naSetSettingMemo') + '\n' +
     lift(/async function naEnabled\(\) \{[^\n]*\n/, 'naEnabled') + '\n' +
     'globalThis.naSetting = naSetting; globalThis.naEnabled = naEnabled;',
     ctx
   );
   assert.equal(await ctx.naSetting(), undefined);
   assert.equal(await ctx.naEnabled(), false);
+});
+
+test('answering the ask yes is the enabler end-to-end: decide(true), then suggest fetches', async () => {
+  // Storage still reports unset (the write goes through the worker, absent
+  // here); the memo naDecide sets is what lets the search proceed. This pins
+  // the wiring from the ask's button to the gate without a DOM.
+  const { ctx, fetchCalls } = harness({ enabled: undefined });
+  assert.equal(fetchCalls.length, 0);
+  await ctx.naDecide(true);
+  await ctx.naSuggest('alice');
+  assert.equal(fetchCalls.length, 1, 'after deciding yes, the search must fire without a reload');
+});
+
+test('answering the ask no keeps the gate closed, even though storage was never consulted again', async () => {
+  const { ctx, fetchCalls } = harness({ enabled: undefined });
+  await ctx.naDecide(false);
+  assert.equal((await ctx.naSuggest('alice')).length, 0);
+  assert.equal((await ctx.naMetadata(['a'.repeat(64)])).size, 0);
+  assert.equal(fetchCalls.length, 0, 'deciding no must seal the gate via the memo, not just storage');
+});
+
+test('the memo serves later reads without going back to storage', async () => {
+  const { ctx } = harness({ enabled: true });
+  let reads = 0;
+  const orig = ctx.chrome.storage.local.get;
+  ctx.chrome.storage.local.get = (k, cb) => { reads++; return orig(k, cb); };
+  await ctx.naSetting();
+  await ctx.naSetting();
+  await ctx.naSetting();
+  assert.equal(reads, 1, 'storage is read once; every keystroke after that is synchronous');
 });


### PR DESCRIPTION
Closes #194 (sub-issue of the security-audit umbrella #199).

## What was leaking

Two panel-side calls to `api.nostrarchives.com` ran with no user awareness:

- **`naSuggest`** fired from ordinary compose-box typing (`@ali…`) — sends the partial name to a third-party search API.
- **`naMetadata`** POSTed up-to-500-pubkey chunks of the user's **entire follow list** to resolve names/pictures the relays didn't return.

Relays already see follow-list fetches, but this added a *centralized* observer that would otherwise see nothing — correlatable across sessions by IP. For a user with a sensitive follow set, opening the mention autocomplete disclosed their graph to one company with zero UI indication.

## The fix: ask once, on first use

The setting is tri-state (`undefined` = never asked, `true`/`false` = decided):

- The first time a name search would hit the index — the composer's @-mention dropdown or the topbar search box — the spinner's slot carries a one-time ask instead: *"Also search every Nostr name? This uses a third-party index (api.nostrarchives.com) that sees what you type and who you follow."* with **Search everyone** / **Just my follows**.
- Either answer is final. Answering re-runs that surface's update, which now sees a decision: "yes" proceeds straight to the debounced search, "no" never asks again.
- **Settings → "Use the Nostr Archives name index"** is the way to change the answer later; unset and false both render the toggle unchecked.

### Nothing is sent before the answer

`naSuggest` and `naMetadata` stay internally gated on `nostrArchives === true`, so with the setting unset — every existing user until they answer — both return empty with no fetch. Both endpoints keep the existing fallback on any API failure or rate-limit, so mention search stays relay-only in every failure mode.

### The ask holds still until answered

Two ways it could vanish mid-read, both fixed:

- The composer's **blur** handler used to close the @-mention dropdown 150ms after any focus loss — a click elsewhere in the panel, another window, even the ask's own paragraph took the question away. A pending ask now survives blur (Escape still dismisses it, and unanswered it simply returns on the next @-keystroke); the whole ask area also swallows mousedown so clicking its text can't blur the composer in the first place.
- Each keystroke used to paint once **before** the setting's storage read resolved, so the ask blinked out on every key — and with no follow matches the box closed outright until the read landed. The tri-state is memoized after its first read, so the ask paints in the same frame as everything else. Both writers (`naDecide`, the Settings toggle) update the memo, and both live in this document, so it cannot drift from storage — and typing still never wakes the service worker.

## PRIVACY.md

Rewritten for the ask flow: nothing goes to the index until you agree, the answer can be changed or revoked in Settings, and while it's on the index sees the mention-search text plus your follows' public keys. (The old text was also inaccurate before this change — it claimed only the typed text was sent when `naMetadata` was already posting follow-list pubkeys.)

## Tests

`test/na-optin.test.js` grows to 10. The pins: with the setting **unset (never asked)**, neither endpoint fetches at all — the ask is the only enabler — plus the same with it off; the on-path hits for both endpoints; the tri-state read (missing key → `undefined` → not enabled); `naDecide(true)` enables end-to-end through the memo and `naDecide(false)` seals the gate; and storage is read exactly once, so every keystroke after the first is synchronous.

Full suite: 401 tests, 399 pass (2 known reds on main: `search-entity`, `web-comment` — `nostr-tools` not installed for tests).

## Reviewing

The ask renders in two places (the two-approval-UIs rule, dropdown edition): the composer's @-mention dropdown and the topbar search box. In each, type two characters with the setting untouched — the ask should appear where the "Searching Nostr…" spinner would sit, stay put while typing continues (no blinking), and survive clicking elsewhere in the panel. Answer either way and the box should immediately reflect the decision without a reload; the Settings toggle should match the answer given.


### Why it disappeared a second time (and the fix)

Even with blur and memoization fixed, the ask still "vanished when results populated" — because nothing was removing it. Both autocomplete boxes cap their height and scroll (`.ac-dropdown` 200px, `.search-results` 232px), and the ask was **appended after** the result rows: the moment follow-list matches rendered, the rows filled the visible box and pushed the unanswered ask below the scroll fold — present in the DOM, invisible on screen, no click or keystroke involved. The ask now renders **above** the results (`prepend`, both surfaces), with the divider moved from its top to its bottom, so it stays pinned at the top of the box while results render (and scroll) beneath it.


## Scope chip in the search bar

The mode is now visible before you type: a chip beside the search input — **users** for follows-only, **globe** when the Nostr Archives index is on. The glyph carries the distinction; it keeps the standard icon-button color like the rest of the row. Click toggles it, asymmetrically on purpose:

- **Toward global** shows the same one-time ask the dropdown shows (with the setting already decided, the disclosure text) — that click is the consent moment, so it carries the confirmation step.
- **Toward local** is immediate, no confirm: that direction only ever withholds data. The icon flips and the visible results re-run without the index.
- **Unset renders as local** — which is what it is, since nothing is sent while unset — and the chip's tooltip says what clicking would do.

The chip repaints when the Settings toggle changes, so the two controls can't disagree, and PRIVACY.md's revoke path now names both.

🍸 Mixed with GLM 5.3 (z.ai)

