### PR TITLE
Composer: preview the quote inside a quoted note

### DIFF
--- a/sidepanel.js
+++ b/sidepanel.js
@@ -5947,10 +5947,14 @@
     let last = 0;
     let used = 0;
     let truncated = false;
+    // Set after a block-level item: the next text run's leading whitespace
+    // would render under pre-wrap as a blank line stacked on the item's margin.
+    let skipLead = false;
     let m;
     PREVIEW_RE.lastIndex = 0;
     const pushText = (s) => {
       if (!s || truncated) return;
+      if (skipLead) { s = s.replace(/^\s+/, ''); skipLead = false; if (!s) return; }
       if (used + s.length > maxLen) {
         container.append(document.createTextNode(s.slice(0, Math.max(0, maxLen - used)) + '…'));
         truncated = true;
@@ -5958,6 +5962,18 @@
         container.append(document.createTextNode(s));
         used += s.length;
       }
+    };
+    // Media and the quote box are block-level and carry their own margins, so
+    // the newlines an author puts around the ref are padding on top of that —
+    // pre-wrap renders each one as a full empty line between the prose and the
+    // block. Trim the whitespace off the text node before the block and out of
+    // the run after it; the block's margin is the separation. Mentions and
+    // plain links stay inline, which is why only this path trims.
+    const pushBlock = (el) => {
+      const tail = container.lastChild;
+      if (tail && tail.nodeType === Node.TEXT_NODE) tail.textContent = tail.textContent.replace(/\s+$/, '');
+      container.append(el);
+      skipLead = true;
     };
     while ((m = PREVIEW_RE.exec(text)) !== null) {
       if (m.index > last) pushText(text.slice(last, m.index));
@@ -5971,13 +5987,13 @@
           im.className = 'note-media';
           im.referrerPolicy = 'no-referrer';
           im.src = url;
-          container.append(im);
+          pushBlock(im);
         } else if (VID_EXT.test(url)) {
           const v = document.createElement('video');
           v.className = 'note-media';
           v.controls = true;
           v.src = url;
-          container.append(v);
+          pushBlock(v);
         } else {
           const a = document.createElement('a');
           a.href = url; a.target = '_blank'; a.rel = 'noreferrer noopener';
@@ -6004,7 +6020,7 @@
           a.target = '_blank'; a.rel = 'noreferrer noopener';
           a.textContent = 'quoted note…';
           quotes.push({ el: a, bech });
-          container.append(a);
+          pushBlock(a);
         }
       }
       last = PREVIEW_RE.lastIndex;
@@ -6522,9 +6538,22 @@
     const mentions = [];
     const embeds = [];
     let last = 0;
+    let skipLead = false; // see pushBlock in renderNoteText
     let m;
     PREVIEW_RE.lastIndex = 0;
-    const flushText = (s) => { if (s) container.append(document.createTextNode(s)); };
+    const flushText = (s) => {
+      if (!s) return;
+      if (skipLead) { s = s.replace(/^\s+/, ''); skipLead = false; if (!s) return; }
+      container.append(document.createTextNode(s));
+    };
+    // Same pre-wrap blank-line problem as renderNoteText, for this pane's own
+    // block items: embed cards, link cards, media.
+    const pushBlock = (el) => {
+      const tail = container.lastChild;
+      if (tail && tail.nodeType === Node.TEXT_NODE) tail.textContent = tail.textContent.replace(/\s+$/, '');
+      container.append(el);
+      skipLead = true;
+    };
     while ((m = PREVIEW_RE.exec(text)) !== null) {
       if (m.index > last) flushText(text.slice(last, m.index));
       if (m[1]) {
@@ -6534,13 +6563,13 @@
           im.className = 'note-media';
           im.referrerPolicy = 'no-referrer';
           im.src = url;
-          container.append(im);
+          pushBlock(im);
         } else if (VID_EXT.test(url)) {
           const v = document.createElement('video');
           v.className = 'note-media';
           v.controls = true;
           v.src = url;
-          container.append(v);
+          pushBlock(v);
         } else {
           const a = document.createElement('a');
           a.href = url; a.target = '_blank'; a.rel = 'noreferrer noopener';
@@ -6550,7 +6579,7 @@
             const card = document.createElement('a');
             card.className = 'link-card loading';
             card.textContent = 'Loading preview…';
-            container.append(card);
+            pushBlock(card);
             fetchOgMeta(url).then((meta) => renderLinkCard(card, url, meta));
           }
         }
@@ -6566,7 +6595,7 @@
         } else if (d && (d.type === 'note' || d.type === 'nevent' || d.type === 'naddr')) {
           const card = h('div', { className: 'note-embed loading', textContent: 'Loading nostr event…' });
           embeds.push({ el: card, ref: embedRef(d) });
-          container.append(card);
+          pushBlock(card);
         } else {
           flushText(bech);
         }

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -5943,6 +5943,7 @@
   // further down the note can't leak past the ellipsis.
   function renderNoteText(container, text, maxLen) {
     const mentions = [];
+    const quotes = [];
     let last = 0;
     let used = 0;
     let truncated = false;
@@ -5993,12 +5994,16 @@
           if (pubkey) mentions.push({ el: span, pubkey });
           container.append(span);
         } else {
-          // Nested note/nevent/naddr ref — link out rather than recurse into
-          // another embed card inside this one.
+          // Nested note/nevent/naddr ref — one level down only: a truncated
+          // link-out preview (see resolveQuotePreviews), never a second full
+          // embed card. Quoting a note that quotes a note is common, and the
+          // old plain "quoted note" link showed nothing of what's inside.
           const a = document.createElement('a');
+          a.className = 'quote-inline loading';
           a.href = 'https://njump.me/' + bech;
           a.target = '_blank'; a.rel = 'noreferrer noopener';
-          a.textContent = 'quoted note';
+          a.textContent = 'quoted note…';
+          quotes.push({ el: a, bech });
           container.append(a);
         }
       }
@@ -6006,6 +6011,91 @@
     }
     if (last < text.length) pushText(text.slice(last));
     resolveMentions(mentions);
+    resolveQuotePreviews(quotes);
+  }
+
+  // Fill the one-level-down quote previews renderNoteText collects: fetch the
+  // quoted event and show @author + a snippet. Deliberately NOT renderEmbedCard
+  // — this stays read-only and shallow, and quoteSnippet strips nested refs, so
+  // a quote-of-a-quote-of-a-quote can't fan out into more fetches.
+  async function resolveQuotePreviews(quotes) {
+    for (const { el, bech } of quotes) {
+      let d = null;
+      try { d = NT.nip19.decode(bech); } catch (_) {}
+      const ref = d ? embedRef(d) : null;
+      let ev = null;
+      if (ref) {
+        try {
+          const relays = [...new Set([...(await relayUrls(false)), ...(ref.relays || [])])];
+          ev = await Promise.race([
+            poolGet(relays, ref.filter),
+            new Promise((r) => setTimeout(() => r(null), 6000)),
+          ]);
+        } catch (_) {}
+      }
+      el.classList.remove('loading');
+      if (!ev) {
+        el.textContent = 'quoted note'; // not found — today's plain link-out
+        continue;
+      }
+      const who = h('span', {
+        className: 'mention',
+        textContent: '@' + shortNpub(NT.nip19.npubEncode(ev.pubkey)),
+      });
+      // The text lives in its own clamped element (the <a> can't clamp once it
+      // also holds a thumbnail), media gets a small thumb below it, and an
+      // invoice becomes a quiet caption under everything — it's metadata about
+      // the note, not prose, and inline it read as a sentence placed above the
+      // image it follows in the content (zap receipts are image + invoice and
+      // nothing else).
+      const content = String(ev.content || '');
+      const hasInvoice = /\bln(?:bc|tb)[0-9a-z]+\b/i.test(content);
+      const text = h('div', { className: 'quote-inline-text' }, [who]);
+      const snip = quoteSnippet(content);
+      const img = firstQuoteImage(content);
+      if (snip) text.append(document.createTextNode(' ' + snip));
+      else if (!img && !hasInvoice) text.append(document.createTextNode(' (no text)'));
+      const kids = [text];
+      if (img) {
+        const im = document.createElement('img');
+        im.className = 'quote-inline-thumb';
+        im.referrerPolicy = 'no-referrer';
+        im.src = img;
+        im.onerror = () => im.remove();
+        kids.push(im);
+      }
+      if (hasInvoice) kids.push(h('div', { className: 'quote-inline-meta', textContent: '⚡ invoice' }));
+      el.replaceChildren(...kids);
+      fetchPreviewProfile(ev.pubkey).then((p) => {
+        if (p && p.name) who.textContent = '@' + p.name;
+      });
+    }
+  }
+
+  // Snippet text for a nested quote: plain text only. nostr entity refs and bare
+  // URLs are stripped rather than rendered — a 63-char nevent or a long link
+  // would otherwise be the entire snippet — and a BOLT11 invoice is stripped
+  // outright too: the raw string is hundreds of characters of bech32 no human
+  // can read, and resolveQuotePreviews shows a quiet "⚡ invoice" caption for
+  // the whole note instead of a marker pretending to be prose. Returns '' when
+  // nothing readable remains; the caller decides the placeholder.
+  function quoteSnippet(text) {
+    const s = String(text || '')
+      .replace(/(?:nostr:)?(?:npub1|nprofile1|note1|nevent1|naddr1)[0-9a-z]+/gi, '')
+      .replace(/ln(?:bc|tb)[0-9a-z]+/gi, '')
+      .replace(/https?:\/\/\S+/g, '')
+      .replace(/\s+/g, ' ')
+      .trim();
+    if (!s) return '';
+    return s.length > 140 ? s.slice(0, 140).trimEnd() + '…' : s;
+  }
+
+  // First image URL in a nested quote's content, for the small thumbnail.
+  // Video stays out of the interim preview — a playable element inside a link
+  // inside an embed is a tangle, and posters aren't in the content string.
+  function firstQuoteImage(text) {
+    const urls = String(text || '').match(/https?:\/\/[^\s]+/g) || [];
+    return urls.find((u) => IMG_EXT.test(u)) || null;
   }
 
   function renderAbout(container, text) {

--- a/styles.css
+++ b/styles.css
@@ -1702,6 +1702,37 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
   background: linear-gradient(150deg, var(--velvet-1), var(--velvet-2));
 }
 .note-embed.loading, .note-embed.embed-missing { color: var(--faint); font-size: 12px; }
+/* Truncated preview of a quote inside a quoted note (renderNoteText →
+   resolveQuotePreviews) — one level down only, never a second full embed card.
+   Reads as an inset excerpt: hairline left rule + well fill, the text clamped
+   to two lines (quoteSnippet's hard cap is the backstop, this is the visual
+   cut) with an optional small thumbnail under it and an optional invoice
+   caption under everything — a quoted zap receipt is an image and an invoice
+   and nothing else, and the invoice is metadata about the note, not prose, so
+   it captions below rather than sitting in the text line above the image it
+   follows in the content.
+   It IS a link out to njump, styled like .link-card: inherit color, no
+   underline — the snippet is for reading, the click is the escape hatch. */
+.quote-inline {
+  display: block; margin: 6px 0 2px; padding: 7px 10px;
+  border-left: 2px solid var(--border-strong); border-radius: 0 8px 8px 0;
+  background: rgba(var(--well-rgb), 0.4);
+  font-size: 12px; line-height: 1.45; color: var(--text-2);
+  text-decoration: none;
+}
+.quote-inline-text {
+  display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
+}
+.quote-inline-thumb {
+  display: block; margin-top: 6px; max-width: 100%; max-height: 64px;
+  object-fit: cover; border-radius: 6px; border: 1px solid var(--border);
+}
+/* Gold at invoice weight is the wallet's "this is money" color; here it's a
+   quiet attribute line, so --muted — the caption says the note CONTAINS an
+   invoice, it isn't asking for payment. */
+.quote-inline-meta { margin-top: 6px; color: var(--muted); font-size: 11.5px; }
+.quote-inline:hover { border-left-color: var(--gold-soft); color: var(--text); }
+.quote-inline.loading { color: var(--faint); }
 .embed-head { display: flex; align-items: center; gap: 8px; margin-bottom: 6px; }
 .embed-av { width: 26px; height: 26px; border-radius: 50%; overflow: hidden; flex-shrink: 0; background: linear-gradient(180deg, var(--av-from), var(--av-to)); border: 1px solid var(--border); }
 .embed-av img { width: 100%; height: 100%; object-fit: cover; display: block; }

--- a/test/quote-snippet.test.js
+++ b/test/quote-snippet.test.js
@@ -1,0 +1,92 @@
+'use strict';
+
+// Unit coverage for the text side of the nested quote preview in sidepanel.js
+// (renderNoteText → resolveQuotePreviews): quoteSnippet and firstQuoteImage.
+// The whole point of the snippet is what it DOESN'T include — a 63-char nevent,
+// a bare URL, or a several-hundred-char BOLT11 invoice would each eat the entire
+// two-line clamp. Invoices are stripped outright, not marked inline: the caller
+// (resolveQuotePreviews) renders a "⚡ invoice" caption BELOW the thumbnail, so
+// the marker must not also appear in the prose. firstQuoteImage picks the
+// thumbnail: a quoted zap receipt is often an image + invoice with no prose.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const source = fs.readFileSync(path.join(__dirname, '..', 'sidepanel.js'), 'utf8');
+function lift(pattern, label) {
+  const m = source.match(pattern);
+  if (!m) throw new Error('Could not find ' + label + ' in sidepanel.js');
+  return m[0];
+}
+const ctx = {};
+vm.createContext(ctx);
+vm.runInContext(
+  // The REAL IMG_EXT, lifted — a local mirror could drift from sidepanel.js and
+  // the tests would keep passing against the wrong regex.
+  lift(/const IMG_EXT = [^;]+;/, 'IMG_EXT') + '\n' +
+  lift(/function quoteSnippet\(text\) \{[\s\S]*?\n  \}/, 'quoteSnippet') + '\n' +
+  lift(/function firstQuoteImage\(text\) \{[\s\S]*?\n  \}/, 'firstQuoteImage') + '\n' +
+  'globalThis.quoteSnippet = quoteSnippet;' +
+  'globalThis.firstQuoteImage = firstQuoteImage;',
+  ctx
+);
+
+// ---- quoteSnippet ------------------------------------------------------------
+
+test('plain text passes through untouched', () => {
+  assert.equal(ctx.quoteSnippet('just words'), 'just words');
+});
+
+test('nostr entity refs are stripped, with or without the nostr: prefix', () => {
+  const nevent = 'nevent1' + 'q'.repeat(60);
+  const npub = 'npub1' + '0'.repeat(58);
+  assert.equal(ctx.quoteSnippet('hello nostr:' + nevent + ' world'), 'hello world');
+  assert.equal(ctx.quoteSnippet('see ' + npub + ' there'), 'see there');
+});
+
+test('BOLT11 invoices are stripped entirely — the caption is the caller\'s job', () => {
+  const invoice = 'lnbc100u1p4gr5w4pp535270wj65pvw0p650h5ph262eklrax9tss8qd4me9pcrgymj4pus';
+  assert.equal(ctx.quoteSnippet('ping ' + invoice), 'ping');
+  // Testnet variant too, and an invoice-only note leaves nothing in the prose.
+  assert.equal(ctx.quoteSnippet('lntb100u1' + 'q'.repeat(80)), '');
+});
+
+test('bare URLs are stripped too — a long link would eat the whole clamp', () => {
+  assert.equal(ctx.quoteSnippet('look https://example.com/a/very/long/path here'), 'look here');
+});
+
+test('whitespace is collapsed to single spaces', () => {
+  assert.equal(ctx.quoteSnippet('a\n\n  b\t\tc'), 'a b c');
+});
+
+test('over-140-char text is hard-capped with an ellipsis', () => {
+  const out = ctx.quoteSnippet('x'.repeat(200));
+  assert.equal(out.length, 141); // 140 + the ellipsis
+  assert.ok(out.endsWith('…'));
+});
+
+test('nothing readable left returns empty string — the caller picks the placeholder', () => {
+  assert.equal(ctx.quoteSnippet('nostr:nevent1' + 'q'.repeat(60)), '');
+  assert.equal(ctx.quoteSnippet('https://blossom.example.com/x.jpg'), '');
+  // Image + invoice with no prose: both stripped, '' back — the caller shows
+  // the thumbnail and the ⚡ caption, so '(no text)' must not appear.
+  assert.equal(ctx.quoteSnippet('https://blossom.example.com/x.jpg \nlnbc100u1' + 'q'.repeat(80)), '');
+  assert.equal(ctx.quoteSnippet(''), '');
+  assert.equal(ctx.quoteSnippet(null), '');
+});
+
+// ---- firstQuoteImage -----------------------------------------------------------
+
+test('firstQuoteImage returns the first image URL in the content', () => {
+  const content = 'https://example.com/page\nhttps://blossom.primal.net/abc.jpg';
+  assert.equal(ctx.firstQuoteImage(content), 'https://blossom.primal.net/abc.jpg');
+});
+
+test('firstQuoteImage skips non-image URLs and returns null when there are none', () => {
+  assert.equal(ctx.firstQuoteImage('see https://example.com/now'), null);
+  assert.equal(ctx.firstQuoteImage(''), null);
+  assert.equal(ctx.firstQuoteImage(null), null);
+});

--- a/test/quote-snippet.test.js
+++ b/test/quote-snippet.test.js
@@ -90,3 +90,89 @@ test('firstQuoteImage skips non-image URLs and returns null when there are none'
   assert.equal(ctx.firstQuoteImage(''), null);
   assert.equal(ctx.firstQuoteImage(null), null);
 });
+
+// ---- renderNoteText glue whitespace ------------------------------------------------
+// The renderer's containers (.embed-body / .preview-body) are white-space:
+// pre-wrap, so every \n the author put around a block-level item (media, the
+// quote box) rendered as a full empty line stacked on the item's own margins —
+// the "extra space between items" in the composer preview. pushBlock trims the
+// whitespace off the text node before a block and out of the run after it;
+// inline refs (mentions, plain links) keep their separating spaces, and
+// paragraph breaks inside one prose run survive. The real renderNoteText runs
+// here against a minimal DOM shim; nip19.decode is stubbed to null so every
+// nostr ref takes the quote-inline branch.
+
+function makeContainer() {
+  const kids = [];
+  return { kids, append: (...k) => { kids.push(...k); }, get lastChild() { return kids[kids.length - 1] || null; } };
+}
+
+const rctx = {
+  Node: { TEXT_NODE: 3 },
+  document: {
+    createElement: (tag) => ({ nodeType: 1, tag }),
+    createTextNode: (textContent) => ({ nodeType: 3, textContent }),
+  },
+  h: (tag) => ({ nodeType: 1, tag }),
+  NT: { nip19: { decode: () => null } },
+  resolveMentions: () => {},
+  resolveQuotePreviews: () => {},
+};
+vm.createContext(rctx);
+vm.runInContext(
+  lift(/const IMG_EXT = [^;]+;/, 'IMG_EXT') + '\n' +
+  lift(/const VID_EXT = [^;]+;/, 'VID_EXT') + '\n' +
+  lift(/const PREVIEW_RE = [^;]+;/, 'PREVIEW_RE') + '\n' +
+  lift(/  function renderNoteText\(container, text, maxLen\) \{[\s\S]*?\n  \}/, 'renderNoteText') + '\n' +
+  'globalThis.renderNoteText = renderNoteText;',
+  rctx
+);
+
+const NEVENT = 'nostr:nevent1' + 'q'.repeat(60);
+const render = (text) => {
+  const c = makeContainer();
+  rctx.renderNoteText(c, text, 280);
+  return c.kids;
+};
+
+test('newlines around a quote box and media render as no text nodes at all', () => {
+  // The screenshot case: prose, nested quote ref, badge image URL, newline
+  // separators. Before the fix this produced two blank lines (one after the
+  // prose, one between the quote box and the image) on top of the margins.
+  const kids = render('Badge Master\n\n' + NEVENT + ' \nhttps://blossom.example.com/badge.png');
+  assert.equal(kids.length, 3);
+  assert.equal(kids[0].nodeType, 3);
+  assert.equal(kids[0].textContent, 'Badge Master'); // trailing \n\n trimmed
+  assert.equal(kids[1].tag, 'a');
+  assert.equal(kids[1].className, 'quote-inline loading');
+  assert.equal(kids[2].tag, 'img');
+  assert.ok(!kids.some((k) => k.nodeType === 3 && !k.textContent.trim()), 'no whitespace-only text nodes');
+});
+
+test('glue between two block items disappears entirely', () => {
+  const kids = render(NEVENT + ' \nhttps://blossom.example.com/x.jpg');
+  assert.equal(kids.length, 2);
+  assert.equal(kids[0].tag, 'a');
+  assert.equal(kids[1].tag, 'img');
+});
+
+test('trailing whitespace after a final block item is dropped', () => {
+  const kids = render('words\n' + NEVENT + '\n\n');
+  assert.equal(kids.length, 2);
+  assert.equal(kids[0].textContent, 'words');
+  assert.equal(kids[1].tag, 'a');
+});
+
+test('spaces around inline links are kept — words must not glue to the link', () => {
+  const kids = render('see https://example.com/page now');
+  assert.equal(kids.length, 3);
+  assert.equal(kids[0].textContent, 'see ');
+  assert.equal(kids[1].tag, 'a');
+  assert.equal(kids[2].textContent, ' now');
+});
+
+test('paragraph breaks inside a prose run survive — that is the author\'s structure', () => {
+  const kids = render('one\n\ntwo');
+  assert.equal(kids.length, 1);
+  assert.equal(kids[0].textContent, 'one\n\ntwo');
+});


### PR DESCRIPTION
Quoting a note that itself quotes a note showed only a bare "quoted note" link in the composer preview — nothing of what was inside. The preview now goes one level down.

The card shows `@author` plus up to two lines of snippet (`quoteSnippet` strips nested nostr refs, bare URLs and BOLT11 invoices — any of the three would eat the entire clamp), a small thumbnail when the quoted note is media, and a quiet "⚡ invoice" caption under everything. A quoted zap receipt is an image and an invoice and nothing else: stripping both from the prose made those previews read as raw invoice strings, so the image comes back as a thumbnail and the invoice captions below as metadata instead of sitting in the text line. The card stays a link out to njump, and a fetch that fails or times out falls back to today's plain link.

One level down only — deliberately not `renderEmbedCard`: no second full card, no recursion, and `quoteSnippet` strips nested refs, so a quote-of-a-quote-of-a-quote can't fan out into more fetches.

The second commit is a follow-up on the same pane: the preview containers are `white-space: pre-wrap`, so the newlines an author puts between prose, refs and media rendered as full empty lines stacked on the items' margins (worst case: two blank lines between the quote box and the image below it). `pushBlock` trims whitespace around block items only — mentions and links keep their separating spaces, and paragraph breaks inside a prose run survive.

Tests: `test/quote-snippet.test.js` covers `quoteSnippet`/`firstQuoteImage` as pure functions and runs the real `renderNoteText` against a DOM shim, including the case that motivated the spacing fix. 426 tests, 424 pass locally — the two known `nostr-tools` reds are green on CI.

Manual check: quote a note that quotes a note. A zap receipt is the good case (image + invoice, no prose).

🍹 Blended with GLM 5.3 (z.ai)