### PR TITLE
Land the Low/Info hygiene batch from the security audit (#198)

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,14 @@
+Sidecar
+Copyright (c) Sidecar contributors
+
+This product includes software developed by third parties:
+
+jsqr.js is a byte-exact copy of dist/jsQR.js from the jsQR package
+(jsqr@1.4.0, https://github.com/cozmo/jsQR), Copyright the jsQR authors,
+licensed under the Apache License, Version 2.0. The bundle itself carries
+no license header — it is vendored byte-exact (its SHA-256 is pinned in
+scripts/vendor-hashes.sha256), so this file is the attribution notice.
+Apache-2.0: http://www.apache.org/licenses/LICENSE-2.0
+
+The other vendored bundles and their licenses are listed in VENDOR.md
+(nostr-tools and nip49: Unlicense; qrcode-generator: MIT).

--- a/VENDOR.md
+++ b/VENDOR.md
@@ -51,7 +51,10 @@ The build is verified against the NIP-49 spec test vector
 ## Updating
 
 1. Edit the version pins at the top of `scripts/update-vendor.sh`.
-2. Run the script; review the diff of the regenerated bundles.
+2. Run the script. With new pins it refuses the resulting hash change on the
+   first run (leaving the tree untouched) — re-run it with
+   `--accept-hash-change` to write the new bundles and hashes, then review
+   the diff of the regenerated bundles.
 3. Update the version/hash table above to match `scripts/vendor-hashes.sha256`.
 4. Commit the bundles, the hash file, and this table together — CI fails if
    the files and the hash file ever disagree.

--- a/background.js
+++ b/background.js
@@ -1320,8 +1320,10 @@ async function handleNostrRpc(method, params, host, sendResponse, originWindowId
 //
 // Module-level and never persisted on purpose — writing it to storage would leave
 // a key recoverable from disk or surviving a crash, which is the whole thing we're
-// avoiding. Time-boxed so an unclaimed scan (window closed, user walked away)
-// can't sit in memory; the panel polls and claims it exactly once.
+// avoiding. Single-use (claim clears it), cleared on lock, and TTL-checked at claim
+// time. An unclaimed scan (window closed, user walked away) does sit in SW memory
+// until the worker is evicted — no timer runs while idle — which is the accepted
+// trade for not keeping an alarm alive for a 90-second hand-off.
 const QR_SECRET_TTL_MS = 90000;
 let qrSecret = null; // { value, at } | null
 let swNwc = null; // { client, pubkey }

--- a/crypto.js
+++ b/crypto.js
@@ -2,8 +2,10 @@
 //
 // Derives an AES-GCM key from the user's PIN/passphrase via PBKDF2, and uses it to
 // encrypt/decrypt the 32-byte nostr private keys (and the NWC connection string) at
-// rest. The derived CryptoKey is non-extractable and never leaves WebCrypto; only the
-// decrypted private-key bytes are sensitive in-memory material.
+// rest. The derived CryptoKey is deliberately extractable: it is raw-exported into
+// memory-only chrome.storage.session so an unlocked key survives service-worker
+// eviction without ever touching disk (see deriveKey below). Nothing encrypted with
+// it is written anywhere but chrome.storage.local.
 //
 // Loaded as a classic script: in the service worker via importScripts('crypto.js')
 // (attaches to `self`), in pages via <script src="crypto.js"> (attaches to `window`).

--- a/crypto.js
+++ b/crypto.js
@@ -58,7 +58,8 @@
     };
   }
 
-  // Derive a non-extractable AES-GCM key from a PIN/passphrase and a KDF descriptor.
+  // Derive the AES-GCM key from a PIN/passphrase and a KDF descriptor.
+  // Deliberately extractable — see the file header and the flag below.
   async function deriveKey(pin, kdf) {
     const baseKey = await subtle.importKey('raw', utf8(pin), 'PBKDF2', false, ['deriveKey']);
     return subtle.deriveKey(

--- a/scripts/update-vendor.sh
+++ b/scripts/update-vendor.sh
@@ -6,7 +6,15 @@
 # registry.npmjs.org. The fourth (nip49.js) is built here, reproducibly, from
 # pinned packages — nostr-tools' prebuilt browser bundle doesn't export nip49.
 #
-# Requires: bash, curl, tar, node/npm (npm is used with --ignore-scripts only).
+# Two gates before anything in the repo is touched:
+#   1. Each tarball's sha512 is checked against the registry's dist.integrity
+#      for the pinned version, before it is extracted.
+#   2. The finished bundles are staged and hash-compared against the committed
+#      scripts/vendor-hashes.sha256. An unexpected change aborts the run with
+#      the tree untouched; after a deliberate version bump, re-run with
+#      --accept-hash-change to record the new hashes.
+#
+# Requires: bash, curl, tar, openssl, node/npm (npm is used with --ignore-scripts only).
 # See VENDOR.md for the provenance table and verification instructions.
 set -euo pipefail
 
@@ -15,25 +23,43 @@ JSQR_VERSION=1.4.0
 QRCODE_GENERATOR_VERSION=2.0.4
 ESBUILD_VERSION=0.28.1
 
+ACCEPT_HASH_CHANGE=0
+[ "${1:-}" = "--accept-hash-change" ] && ACCEPT_HASH_CHANGE=1
+
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 WORK="$(mktemp -d)"
+STAGE="$WORK/stage"
 trap 'rm -rf "$WORK"' EXIT
-cd "$WORK"
 
-fetch() { # fetch <package> <version> → extracted to $WORK/<package>/
+fetch() { # fetch <package> <version> → verified tarball extracted to $WORK/<package>/
+  local want actual
+  want="$(npm view "$1@$2" dist.integrity | tr -d '"')"
+  if [ -z "$want" ]; then
+    echo "Could not read dist.integrity for $1@$2 from the npm registry." >&2
+    exit 1
+  fi
   curl -fsSL "https://registry.npmjs.org/$1/-/$1-$2.tgz" -o "$1.tgz"
+  actual="sha512-$(openssl dgst -sha512 -binary "$1.tgz" | openssl base64 -A)"
+  if [ "$actual" != "$want" ]; then
+    echo "Integrity mismatch for the $1@$2 tarball — not extracting it:" >&2
+    echo "  registry: $want" >&2
+    echo "  download: $actual" >&2
+    exit 1
+  fi
   mkdir -p "$1"
   tar xzf "$1.tgz" -C "$1" --strip-components=1
 }
 
-echo "Fetching official npm artifacts…"
+cd "$WORK"
+echo "Fetching official npm artifacts (each tarball verified against registry dist.integrity)…"
 fetch nostr-tools "$NOSTR_TOOLS_VERSION"
 fetch jsqr "$JSQR_VERSION"
 fetch qrcode-generator "$QRCODE_GENERATOR_VERSION"
 
-cp nostr-tools/lib/nostr.bundle.js "$ROOT/nostr-tools.js"
-cp jsqr/dist/jsQR.js "$ROOT/jsqr.js"
-cp qrcode-generator/dist/qrcode.js "$ROOT/qrcode-generator.js"
+mkdir -p "$STAGE"
+cp nostr-tools/lib/nostr.bundle.js "$STAGE/nostr-tools.js"
+cp jsqr/dist/jsQR.js "$STAGE/jsqr.js"
+cp qrcode-generator/dist/qrcode.js "$STAGE/qrcode-generator.js"
 
 echo "Building nip49.js (reproducible: pinned nostr-tools + esbuild; nostr-tools"
 echo "pins its own deps exactly, so the whole input set is deterministic)…"
@@ -44,10 +70,29 @@ npm install --ignore-scripts --no-audit --no-fund --save-exact \
   "nostr-tools@$NOSTR_TOOLS_VERSION" "esbuild@$ESBUILD_VERSION" >/dev/null
 printf 'export * from "nostr-tools/nip49";\n' > entry.js
 npx esbuild entry.js --bundle --format=iife --global-name=SidecarNip49 \
-  --outfile="$ROOT/nip49.js"
+  --outfile="$STAGE/nip49.js"
+
+# Hash the staged bundles with bare filenames (the shape CI verifies from the
+# repo root), then gate on a diff against what's committed.
+cd "$STAGE"
+sha256sum nostr-tools.js nip49.js jsqr.js qrcode-generator.js > "$WORK/vendor-hashes.new"
+if [ -f "$ROOT/scripts/vendor-hashes.sha256" ] &&
+   ! diff -u "$ROOT/scripts/vendor-hashes.sha256" "$WORK/vendor-hashes.new"; then
+  if [ "$ACCEPT_HASH_CHANGE" -ne 1 ]; then
+    echo
+    echo "Refusing to overwrite the vendored bundles: their hashes changed." >&2
+    echo "Nothing in the repo was modified." >&2
+    echo
+    echo "If this follows a deliberate version bump above, re-run with:" >&2
+    echo "  scripts/update-vendor.sh --accept-hash-change" >&2
+    exit 1
+  fi
+  echo "Hash change accepted (--accept-hash-change); recording the new hashes."
+fi
 
 cd "$ROOT"
-sha256sum nostr-tools.js nip49.js jsqr.js qrcode-generator.js > scripts/vendor-hashes.sha256
+cp "$WORK/vendor-hashes.new" scripts/vendor-hashes.sha256
+cp "$STAGE/nostr-tools.js" "$STAGE/nip49.js" "$STAGE/jsqr.js" "$STAGE/qrcode-generator.js" .
 echo
 echo "Vendored bundles refreshed. Recorded hashes:"
 cat scripts/vendor-hashes.sha256

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -421,6 +421,9 @@
             <input type="text" id="relay-input" placeholder="wss://relay.example.com" />
             <button class="secondary" id="relay-add">Add</button>
           </div>
+          <!-- Shown while any bootstrap relay is ws:// — same advisory as the
+               Profile tab's NIP-65 editor. Hidden by renderSettings. -->
+          <p class="hint warn hidden" id="relay-ws-warn">A ws:// relay is unencrypted — fine for a local or Tor relay, but anything on the open internet should be wss://.</p>
         </div>
       </div>
 

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -4960,6 +4960,10 @@
       row.append(h('div', { className: 'item-actions' }, [rm]));
       rlist.append(row);
     });
+    // Same ws:// advisory as the Profile tab's NIP-65 editor, and for the same
+    // reason: warn, don't reject — local and Tor relays are legitimate ws:// users.
+    // Toggled here rather than in the Add handler so removals clear it too.
+    $('relay-ws-warn').classList.toggle('hidden', !Object.keys(relays).some((url) => url.startsWith('ws://')));
   }
 
   // Currencies offered for the fiat leg of the balance display. One list feeds BOTH
@@ -5992,6 +5996,8 @@
           const v = document.createElement('video');
           v.className = 'note-media';
           v.controls = true;
+          // Same host-privacy reason the img branch gives: no referrer to media hosts.
+          v.referrerPolicy = 'no-referrer';
           v.src = url;
           pushBlock(v);
         } else {
@@ -6568,6 +6574,8 @@
           const v = document.createElement('video');
           v.className = 'note-media';
           v.controls = true;
+          // Same host-privacy reason the img branch gives: no referrer to media hosts.
+          v.referrerPolicy = 'no-referrer';
           v.src = url;
           pushBlock(v);
         } else {
@@ -7886,8 +7894,11 @@
 
   // ---- wallet (NWC) backup to relays — NIP-78, encrypted to self ----
   // Mirrors zap.cooking: the connection string is a spendable secret, so it is
-  // encrypted to the account's own key (NIP-44, NIP-04 fallback) and stored as a
-  // replaceable kind:30078 record that can be restored on another device.
+  // encrypted to the account's own key with NIP-44 and stored as a replaceable
+  // kind:30078 record that can be restored on another device. NIP-04 only, never
+  // written (deprecated crypto; the follow/mute-list backup keeps its fallback for
+  // the 65KB-event cap, which doesn't apply to a ~200-char string) — old NIP-04
+  // backups are still READ (see nwcBackupState).
   const NWC_BACKUP_DTAG = 'sidecar:nwc-backup';
 
   // Compare the backup against the wallet actually connected — don't just detect
@@ -7950,14 +7961,16 @@
   async function backupNwcToRelays() {
     const { connection } = await call({ type: 'SIDECAR_GET_NWC' });
     if (!connection) throw new Error('No wallet connected to back up');
-    let ciphertext, algo;
+    // No NIP-04 fallback: this is a spendable secret, and silently downgrading the
+    // encryption because the first attempt errored is the wrong failure mode — let
+    // the caller surface the error instead.
+    let ciphertext;
     try {
       ciphertext = await call({ type: 'SIDECAR_OWNER_ENCRYPT', plaintext: connection, nip: 44 });
-      algo = 'nip44';
-    } catch (_) {
-      ciphertext = await call({ type: 'SIDECAR_OWNER_ENCRYPT', plaintext: connection, nip: 4 });
-      algo = 'nip04';
+    } catch (e) {
+      throw new Error('Could not encrypt the backup (NIP-44): ' + (e && e.message ? e.message : 'unknown error'));
     }
+    const algo = 'nip44';
     const event = {
       kind: 30078,
       created_at: Math.floor(Date.now() / 1000),
@@ -8343,7 +8356,12 @@
     let relayList = [];
 
     function updateWarn() {
-      if (!relayList.some((r) => r.write)) {
+      // ws:// first: it's the one of these three that leaks plaintext to the network,
+      // and it can arrive from a PUBLISHED list as easily as from the input below —
+      // this check covers both, which is why it doesn't live in the Add handler.
+      if (relayList.some((r) => r.url.startsWith('ws://'))) {
+        warn.textContent = 'A ws:// relay is unencrypted — fine for a local or Tor relay, but anything on the open internet should be wss://.';
+      } else if (!relayList.some((r) => r.write)) {
         warn.textContent = 'No write relays selected — other apps may not find your new notes.';
       } else if (!relayList.some((r) => r.read)) {
         warn.textContent = 'No read relays selected — you may not see replies or mentions here.';
@@ -9503,6 +9521,18 @@
       });
     } catch (_) { return false; }
   }
+  // A ws:// relay in an NWC string means every wallet command and response —
+  // including pay requests — crosses that hop in cleartext. Legitimate for a wallet
+  // on localhost or behind Tor, so warn in the console rather than reject.
+  function warnIfInsecureNwcRelay(connection) {
+    try {
+      const q = connection.split('?')[1];
+      if (!q) return;
+      if (new URLSearchParams(q).getAll('relay').some((r) => String(r).trim().startsWith('ws://'))) {
+        console.warn('Sidecar: this NWC connection uses an unencrypted ws:// relay — wallet commands will cross that hop in cleartext.');
+      }
+    } catch (_) {}
+  }
   async function getLightningAddress() {
     try {
       const { connection } = await call({ type: 'SIDECAR_GET_NWC' });
@@ -9717,6 +9747,7 @@
     if (!nwcUri.startsWith('nostr+walletconnect://')) {
       throw new Error('Rizful did not return a wallet connection.');
     }
+    warnIfInsecureNwcRelay(nwcUri);
     const addr = data && typeof data.lightning_address === 'string' ? data.lightning_address.trim() : '';
     return { nwcUri, lightningAddress: addr && addr.includes('@') ? addr : parseNwcLud16(nwcUri) };
   }
@@ -9845,6 +9876,7 @@
       primalNotice.classList.add('hidden');
       if (!conn) return (err.textContent = 'Paste a connection string.');
       if (!conn.startsWith('nostr+walletconnect://')) return (err.textContent = "That doesn't look like an NWC string.");
+      warnIfInsecureNwcRelay(conn);
       if (isPrimalNwc(conn)) {
         err.textContent = '';
         primalNotice.classList.remove('hidden');

--- a/test/rizful-exchange.test.js
+++ b/test/rizful-exchange.test.js
@@ -27,10 +27,11 @@ function lift(pattern, label) {
 }
 
 // Build a context with a stubbed fetch. `respond` returns { ok, status, json, text }.
-function harness(respond) {
+// `warn` receives console.warn output from the lifted code (the ws:// relay advisory).
+function harness(respond, warn = () => {}) {
   const calls = [];
   const ctx = {
-    console,
+    console: { warn },
     // A vm context inherits no globals. parseNwcLud16 uses URLSearchParams, and
     // without it here its try/catch swallows a ReferenceError and returns null —
     // which looks exactly like "this URI has no lud16".
@@ -51,6 +52,7 @@ function harness(respond) {
   vm.runInContext(
     lift(/const RIZFUL_ORIGIN = [\s\S]*?const RIZFUL_EXCHANGE_URL = [^\n]+/, 'Rizful URLs') + '\n' +
     lift(/function parseNwcLud16\(connection\)\s*\{[\s\S]*?\n  \}/, 'parseNwcLud16') + '\n' +
+    lift(/function warnIfInsecureNwcRelay\(connection\)\s*\{[\s\S]*?\n  \}/, 'warnIfInsecureNwcRelay') + '\n' +
     lift(/async function rizfulExchangeCode\(code, pubkey\)\s*\{[\s\S]*?\n  \}/, 'rizfulExchangeCode') + '\n' +
     'globalThis.rizfulExchangeCode = rizfulExchangeCode;' +
     'globalThis.RIZFUL_EXCHANGE_URL = RIZFUL_EXCHANGE_URL;',
@@ -163,4 +165,24 @@ test('no address anywhere is not an error — the wallet still connects', async 
 test('the exchange endpoint is on rizful.com over https', async () => {
   const { ctx } = harness(() => ({ json: { nwc_uri: NWC } }));
   assert.match(ctx.RIZFUL_EXCHANGE_URL, /^https:\/\/rizful\.com\//);
+});
+
+// ---- ws:// relay advisory -------------------------------------------------------
+// Warn, don't refuse: a ws:// relay is legitimate for a wallet on localhost or
+// behind Tor, but the user should be able to find the warning in the console.
+
+test('a ws:// relay in the returned URI logs the cleartext warning', async () => {
+  const warns = [];
+  const insecure = 'nostr+walletconnect://abc123?relay=ws%3A%2F%2Frelay.example&secret=deadbeef';
+  const { ctx } = harness(() => ({ json: { nwc_uri: insecure } }), (m) => warns.push(m));
+  await ctx.rizfulExchangeCode('CODE-1', PUBKEY);
+  assert.equal(warns.length, 1);
+  assert.match(warns[0], /ws:\/\/ relay/);
+});
+
+test('a wss:// relay stays quiet — the warning is only for cleartext', async () => {
+  const warns = [];
+  const { ctx } = harness(() => ({ json: { nwc_uri: NWC } }), (m) => warns.push(m));
+  await ctx.rizfulExchangeCode('CODE-1', PUBKEY);
+  assert.equal(warns.length, 0);
 });


### PR DESCRIPTION
Closes #198 (checklist: K5, K6, N6, T1, T2, N2, S4 — all seven items).

## Comment honesty

**K5 — crypto.js.** The file header claimed "the derived CryptoKey is
non-extractable and never leaves WebCrypto," which is false two lines below
`deriveKey`'s face: the key is created extractable on purpose, raw-exported,
and parked in memory-only `chrome.storage.session` so an unlocked key survives
service-worker eviction without ever touching disk. The header now says that
instead of the thing the code doesn't do.

**K6 — background.js.** The scanned-key comment promised the QR secret was
"time-boxed so an unclaimed scan can't sit in memory." There is no timer — the
TTL is only checked when the panel claims it. Rewritten to describe the real
guarantees (single-use, cleared on lock, TTL at claim) and state the accepted
trade: an unclaimed scan sits in SW memory until the worker is evicted, which
beats keeping an alarm alive for a 90-second hand-off.

## Privacy hardening

**N6 — video referrer.** Both renderer video branches (renderNoteText and
renderNotePreview) now set `referrerPolicy = 'no-referrer'`, matching the img
branches beside them and the compose thumbnails (which already set it for the
Blossom-host reason). This closes the two reader-side gaps.

**N2 — ws:// relay warnings.** Warn, never reject — a local or Tor relay is a
legitimate ws:// user, so refusal would break real setups. Three surfaces:

- NIP-65 editor: new first-priority branch in `updateWarn()`. Placed there, not
  in the Add handler, so a ws:// relay arriving from a *published* list is
  caught too, not just a typed one.
- Settings bootstrap relays: a `#relay-ws-warn` hint under the Add row, toggled
  in `renderSettings()` so removing the last ws:// relay clears it. Same
  message text on both surfaces.
- NWC connect: `warnIfInsecureNwcRelay()` logs a console warning at both entry
  points (paste path and the Rizful exchange) when the string's `relay` param
  is `ws://`. It reuses the `URLSearchParams` parsing `isPrimalNwc` already
  does, so encoded (`ws%3A%2F%2F`) and raw forms both work.

**S4 — NWC backup encryption.** `backupNwcToRelays()` no longer falls back to
NIP-04 when NIP-44 encryption fails. The rationale for the follow/mute-list
backup's fallback (65KB event cap) doesn't apply to a ~200-char string, this is
a spendable secret, and silently downgrading encryption because the first
attempt errored is the wrong failure mode — the error is now surfaced to the
caller. Reading old NIP-04 backups is unchanged (`nwcBackupState` still
decrypts both), so nothing written before this becomes unrestorable.

## Supply chain

**T1 — update-vendor.sh.** Two gates, both before anything in the repo is
touched:

1. Each tarball's sha512 is checked against the registry's `dist.integrity`
   for the pinned version, *before* extraction.
2. Bundles are built into a staging dir and hash-compared against the
   committed `vendor-hashes.sha256`. An unexpected diff aborts with the tree
   untouched; a deliberate version bump is recorded by re-running with
   `--accept-hash-change`. VENDOR.md's Updating section now says so.

**T2 — jsQR NOTICE.** jsqr.js is Apache-2.0 but carries zero license text
(webpack UMD, no header), and it's vendored byte-exact so we can't add one.
Root `NOTICE` file carries the attribution instead. Upstream's own LICENSE is
the bare Apache-2.0 text with no copyright line filled in, so the notice
attributes "the jsQR authors" rather than inventing a year or a name.

## Tests

428 total, 426 pass locally — the two known local reds (`search-entity`,
`web-comment`, missing nostr-tools module locally; green on CI). New coverage:
the ws:// NWC advisory (warns on ws://, silent on wss://) in
`test/rizful-exchange.test.js`, whose harness now lifts the new helper and
captures `console.warn`. `bash -n` on the vendor script, `node --check` on all
touched JS, and `sha256sum -c scripts/vendor-hashes.sha256` (bundles untouched
by this PR) all pass.

Manual check worth doing on this build: add a `ws://localhost:8008` relay in
Settings → Bootstrap relays and watch the hint appear (and disappear on
Remove); same in the Profile tab's relay list editor.

🍾 Popped with GLM 5.3 (z.ai)