### PR TITLE
Decrypt approvals: name what Trust means for your DMs

### DIFF
--- a/prompt.js
+++ b/prompt.js
@@ -394,8 +394,19 @@
     // decrypting, so the signer isn't hammered with one prompt per message — be
     // upfront that "Allow" here is broader than a single message.
     if (data.method === 'nip04.decrypt' || data.method === 'nip44.decrypt') {
-      els.decryptNote.textContent =
+      let text =
         'Allowing lets ' + data.host + ' decrypt your messages for about a minute — enough to load a conversation or inbox without asking for each one.';
+      // Audit K4: decrypt is the sharpest edge of the Trust tier — a trusted site
+      // silently reads every future DM until revoked. Say so on the one screen
+      // where both choices sit side by side, but only while the Trust button is
+      // actually visible (the pure-unlock and shared-identity paths below hide
+      // it; naming a button that isn't there is its own confusion). Identical
+      // condition and sentence as the sidepanel's renderConsentNote — keep the
+      // two surfaces in step.
+      if (!(data.needUnlock && !data.needApproval) && !data.sharedIdentity) {
+        text += ' Trust this site and it can read your messages without asking, until you revoke.';
+      }
+      els.decryptNote.textContent = text;
       els.decryptNote.classList.remove('hidden');
     }
 

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -11136,8 +11136,17 @@
     const note = $('approval-consent-note');
     if (!note) return;
     if (data.method === 'nip04.decrypt' || data.method === 'nip44.decrypt') {
-      note.textContent =
+      let text =
         'Allowing lets ' + data.host + ' decrypt your messages for about a minute — enough to load a conversation or inbox without asking for each one.';
+      // Audit K4: decrypt is the sharpest edge of the Trust tier — a trusted site
+      // silently reads every future DM until revoked. Only while the Trust button
+      // is visible in showApproval (pure-unlock and shared-identity hide it;
+      // decrypts never batch). Identical condition and sentence as prompt.js —
+      // keep the two surfaces in step.
+      if (!(data.needUnlock && !data.needApproval) && !data.sharedIdentity) {
+        text += ' Trust this site and it can read your messages without asking, until you revoke.';
+      }
+      note.textContent = text;
     } else if (data.method === 'webln.getBalance' || data.method === 'webln.getInfo' || data.method === 'webln.makeInvoice') {
       note.textContent =
         'Allowing lets ' + data.host + ' read wallet info from Sidecar for the rest of this session.';


### PR DESCRIPTION
Closes #197 (audit K4).

## The finding

"Trust this site" returns `allow` for every method including `nip04.decrypt`/`nip44.decrypt` — a trusted site silently reads every future DM, forever, until revoked. Standard signer semantics, but the sharpest edge of the tier, and nothing in the UI ever said it.

## The decision

Keep the semantics, disclose the edge. Re-asking for every DM on trusted sites would diverge from what "Trust" means across the signer ecosystem and punish the chat clients the tier exists for; a full trust-confirmation step would tax every grant to warn about one method. So the disclosure lands on the one screen where both choices sit side by side.

## What changed

The decrypt-burst consent note now also says what the OTHER button does — same sentence, same condition, on both surfaces (popup `#decrypt-note`, sidepanel `#approval-consent-note`), kept in step by comments on both sides. The caveat shows only while the Trust button is actually on screen; naming a button that isn't there is its own confusion.

Stacked on #201, which gave the sidepanel its consent-note element — merge that first.

## Tests

Suite unchanged (two pre-existing vendoring reds). Manual QA: a DM thread with the panel open and closed — caveat present with Trust visible, absent on a shared-identity host (where Trust hides).

🍶 Sipped with GLM 5.3 (z.ai)
