### PR TITLE
Forget all sites: a one-step exit from the host↔identity records

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,6 +1,6 @@
 # Sidecar Privacy Policy
 
-_Last updated: 2026-07-09_
+_Last updated: 2026-08-16_
 
 Sidecar is a browser extension that acts as a Nostr signer (NIP-07) and a
 Lightning wallet client (Nostr Wallet Connect / NIP-47). It is designed so that
@@ -36,6 +36,16 @@ storage. None of it is transmitted to the developer.
 - **Local activity log** — a capped, on-device history of signing/permission
   events, shown in the Activity tab. It never leaves your device and can be
   cleared at any time.
+- **Site records** — for each site you use: which of your accounts it signs in
+  as, its permission tier (ask / read-only / trusted), and which of your
+  accounts have signed in there. Kept so a returning site doesn't re-ask who
+  you are. These persist until you erase them — "Forget site" per site, or
+  "Forget all sites" in the Activity tab, which also clears the activity log.
+- **Unsent drafts and payment notes** — compose drafts you haven't published,
+  and the counterparties and notes of payments you've made, are stored locally
+  so they survive restarts. Unlike your keys, these are **not encrypted at
+  rest**: someone with access to your device's browser profile data could read
+  them. Forgetting sites or clearing the activity log does not erase drafts.
 
 There is **no account recovery**: if you forget your PIN/passphrase, your data
 cannot be recovered. Back up your nsecs.

--- a/background.js
+++ b/background.js
@@ -2532,6 +2532,19 @@ async function handleControl(message, sendResponse) {
         await clearSiteAccount(message.host);
         result = true;
         break;
+      case 'SIDECAR_FORGET_ALL_SITES':
+        // The bulk "Forget all sites" (Activity tab) — one sweep of every
+        // host↔identity record that pane exists to show: permission tiers for
+        // every account, account bindings, shared-identity history, and the site
+        // rows of the activity log (audit M6/S2 — otherwise these are permanent,
+        // and the site maps are uncapped). Accounts, keys, wallets, and compose
+        // drafts are not touched; the next visit to any site starts from a clean
+        // ask. The log is cleared for ALL accounts, unlike the per-account Clear
+        // history button, because every row in it is a site record.
+        await PERMS.clearAll();
+        await sset({ [SITE_ACCTS_KEY]: {}, [SITE_AUTHZ_KEY]: {}, [ACTIVITY_KEY]: [] });
+        result = true;
+        break;
       // The page-invoice card asks before it appears: is this invoice simply the one
       // for a zap the user already authorized here? Jumble and other Bitcoin Connect
       // clients render a QR rather than calling window.webln, so the card — not the

--- a/permissions.js
+++ b/permissions.js
@@ -77,6 +77,13 @@
     return rootMap;
   }
 
+  // Drop every account's permission set at once — the bulk "Forget all sites"
+  // (Activity tab). Written as an empty map rather than a removal so loadRoot's
+  // shape ({ pubkey: { host: … } }) survives untouched.
+  async function clearAll() {
+    await set({ [PERM_KEY]: {} });
+  }
+
   // 'allow' | 'reject' | 'ask' for a (host, method) given its tier.
   function statusForLevel(level, method) {
     switch (level) {
@@ -102,6 +109,7 @@
     setLevel,
     removeHost,
     clearAccount,
+    clearAll,
     getPermissionStatus,
     getAll: accountMap,
   };

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -191,6 +191,11 @@
           <input type="text" class="filter-input hidden" id="sites-filter" placeholder="Filter by site…" />
           <div id="sites-list" class="list flat"></div>
           <button class="ghost show-more-btn hidden" id="sites-more">Show more</button>
+          <!-- Bulk sibling of each row's "Forget site": erase every site record at
+               once — account pairings, permission tiers, shared-identity history,
+               and the site rows in Recent activity. Built by renderActivity only
+               while any site exists; two-tap inline confirm like the row-level one. -->
+          <div class="row-actions" id="sites-forget-all-wrap"></div>
         </div>
         <div class="setting activity-pane hidden" id="activity-pane-log">
           <input type="text" class="filter-input hidden" id="activity-filter" placeholder="Filter by site…" />

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -5332,6 +5332,49 @@
       renderSites();
     }
 
+    // "Forget all sites" — the bulk sibling of each row's "Forget site". Audit
+    // M6/S2: the bindings, tiers, shared-identity history, and the site rows of
+    // the log are otherwise permanent (and the site maps uncapped), so this is
+    // the one-step way out. Two-tap inline confirm like the row-level forget,
+    // and the confirm names tiers and Recent activity because those are things
+    // people set up or read on purpose and wouldn't expect a bare "forget" to
+    // touch. Rebuilt on every render: a live re-render mid-confirm collapses it
+    // back to the resting button, which loses nothing (no typed input) and keeps
+    // this a single code path.
+    const forgetWrap = $('sites-forget-all-wrap');
+    forgetWrap.innerHTML = '';
+    if (hosts.length) {
+      show(forgetWrap);
+      const buildForgetAll = () => {
+        forgetWrap.innerHTML = '';
+        const btn = h('button', { className: 'ghost', textContent: 'Forget all sites' });
+        btn.addEventListener('click', () => {
+          forgetWrap.innerHTML = '';
+          const yes = h('button', { className: 'mini del-confirm', textContent: 'Forget' });
+          const no = h('button', { className: 'mini ghost', textContent: 'Cancel' });
+          no.addEventListener('click', buildForgetAll);
+          yes.addEventListener('click', async () => {
+            await call({ type: 'SIDECAR_FORGET_ALL_SITES' });
+            sitesShownN = 0;
+            logShownN = 0;
+            renderActivity();
+          });
+          forgetWrap.append(
+            h('span', {
+              className: 'confirm-msg',
+              textContent: 'Forget every site? Pairings, permission tiers, and Recent activity are erased.',
+            }),
+            yes,
+            no
+          );
+        });
+        forgetWrap.append(btn);
+      };
+      buildForgetAll();
+    } else {
+      hide(forgetWrap);
+    }
+
     const list = $('activity-list');
     const activityFilter = $('activity-filter');
     const more = $('activity-more');


### PR DESCRIPTION
Closes the clear-history half of #196 (audit M6/S2). The encrypt-drafts/pay-meta half stays open as its own PR — it has a PIN-change re-keying trap to design around first.

## The finding

The Activity tab could forget sites one row at a time, but the records underneath — account bindings, permission tiers, shared-identity history, and the site rows of the activity log — were permanent otherwise, and the site maps are uncapped. There was no way out short of resetting Sidecar.

## What changed

"Forget all sites" under the Connected sites list: two-tap inline confirm (same idiom as each row's Forget site), then one background sweep of all four maps for every account. The confirm names permission tiers and Recent activity explicitly — those are things people set up or read on purpose, and a bare "forget" shouldn't surprise them. Accounts, keys, wallets, and compose drafts are untouched; sites simply ask again on the next visit.

PRIVACY.md now documents both the site records (and how to erase them) and that drafts/payment notes are not encrypted at rest — the audit's "at minimum."

## Tests

Suite unchanged (two pre-existing vendoring reds). Manual QA: confirm the empty-state hides the button, the confirm collapses on Cancel, and after Forget the sites pane and Recent activity both empty for every account.

🍷 Built with GLM 5.3 (z.ai)
