### PR TITLE
Encrypt compose drafts and payment notes under the keystore key

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -43,9 +43,12 @@ storage. None of it is transmitted to the developer.
   "Forget all sites" in the Activity tab, which also clears the activity log.
 - **Unsent drafts and payment notes** — compose drafts you haven't published,
   and the counterparties and notes of payments you've made, are stored locally
-  so they survive restarts. Unlike your keys, these are **not encrypted at
-  rest**: someone with access to your device's browser profile data could read
-  them. Forgetting sites or clearing the activity log does not erase drafts.
+  so they survive restarts, **encrypted at rest** under the same PIN-derived
+  key that protects your keys: readable only while Sidecar is unlocked, and
+  unreadable from the browser profile alone. Drafts saved by an earlier
+  version are migrated to the encrypted store on first access after update
+  (the old plaintext copy is removed once the encrypted one is written).
+  Forgetting sites or clearing the activity log does not erase drafts.
 
 There is **no account recovery**: if you forget your PIN/passphrase, your data
 cannot be recovered. Back up your nsecs.

--- a/background.js
+++ b/background.js
@@ -202,6 +202,56 @@ async function logActivity(entry) {
   await sset({ [ACTIVITY_KEY]: cur });
 }
 
+// ---- encrypted local stores (drafts, payment metadata) — audit M5/S1 ----
+// These two used to sit in chrome.storage.local as plaintext anyone with the
+// profile could read. They now live as { v: 1, enc: {iv, ct} } envelopes sealed
+// with the keystore's notes key (see keystore.js — one blob that changePin
+// re-wraps). All reads and writes route through here, so the panel never touches
+// key material, and while LOCKED the answer is simply "nothing" — the composer
+// and wallet history are unreachable locked anyway, and a locked fallback to the
+// legacy plaintext would keep the exposure this exists to close.
+const CRYPTO = self.SidecarCrypto;
+const SECRET_STORES = {
+  drafts: { v1: 'sidecar_drafts_enc', legacy: 'sidecar_compose_drafts' },
+  paymeta: { v1: 'sidecar_pay_meta_enc', legacy: 'sidecar_pay_meta' },
+};
+async function secretGet(name) {
+  const cfg = SECRET_STORES[name];
+  if (!cfg) throw new Error('Unknown secret store');
+  if (KS.isLocked()) return null;
+  const key = await KS.getNotesKey();
+  if (!key) return null;
+  const rec = (await sget(cfg.v1))[cfg.v1];
+  if (rec && rec.enc) {
+    try {
+      return JSON.parse(await CRYPTO.decryptString(key, rec.enc));
+    } catch (_) {
+      // Corrupt envelope: never delete it (a future build may recover it), but a
+      // still-present legacy copy means the migration's remove never landed —
+      // fall back to it rather than showing the user an empty draft over data
+      // that still exists. Data beats the exposure edge case here.
+      const legacy = (await sget(cfg.legacy))[cfg.legacy];
+      if (legacy && Object.keys(legacy).length) return legacy;
+      return null;
+    }
+  }
+  // No envelope yet: migrate the legacy plaintext exactly once — the encrypted
+  // copy is written (and confirmed) BEFORE the plaintext is removed.
+  const legacy = (await sget(cfg.legacy))[cfg.legacy];
+  if (!legacy || !Object.keys(legacy).length) return {};
+  await secretPut(name, legacy);
+  await chrome.storage.local.remove(cfg.legacy);
+  return legacy;
+}
+async function secretPut(name, value) {
+  const cfg = SECRET_STORES[name];
+  if (!cfg) throw new Error('Unknown secret store');
+  if (KS.isLocked()) throw new Error('Sidecar is locked');
+  const key = await KS.getNotesKey();
+  const enc = await CRYPTO.encryptString(key, JSON.stringify(value || {}));
+  await sset({ [cfg.v1]: { v: 1, enc } });
+}
+
 // ---- debug log (dev builds only) ----
 // An in-memory ring buffer for the dev bug button's debug panel — separate
 // from the user-facing Activity log above (which tracks signed events/
@@ -2596,6 +2646,15 @@ async function handleControl(message, sendResponse) {
         result = [];
         break;
       }
+      // Encrypted local stores (drafts, pay-meta). Extension-page only by virtue
+      // of the sender gate — a web page must never read or plant either.
+      case 'SIDECAR_SECRET_GET':
+        result = await secretGet(message.store);
+        break;
+      case 'SIDECAR_SECRET_SET':
+        await secretPut(message.store, message.value);
+        result = true;
+        break;
       // ---- QR scan hand-off (see the qrSecret notes above) ----
       case 'SIDECAR_OPEN_QR_SCANNER': {
         // Its own window, NOT the shared approval popup — reusing popupWindowId

--- a/keystore.js
+++ b/keystore.js
@@ -200,7 +200,39 @@
     for (const bytes of unlocked.values()) C.wipe(bytes);
     unlocked.clear();
     derivedKey = null;
+    notesKey = null;
     await sessClear();
+  }
+
+  // ---- notes key: envelope key for the encrypted local stores (drafts, pay-meta) ----
+  // A random 32-byte key, stored ONLY wrapped under the current derived key.
+  // background.js seals those stores with it, so a PIN change re-wraps one small
+  // blob instead of re-encrypting every draft — and there is exactly one place
+  // (changePin below) where the old derived key dies, which is where the re-wrap
+  // lives, in the same storage write as the re-keyed vault. Miss that one spot
+  // and every draft and payment note becomes ciphertext nobody can open.
+  const NOTES_KEY = 'sidecar_notes_key';
+  let notesKey = null;
+  async function getNotesKey() {
+    if (notesKey) return notesKey;
+    if (!derivedKey) return null; // locked: no envelope operations at all
+    const rec = (await get(NOTES_KEY))[NOTES_KEY];
+    if (rec && rec.enc) {
+      // A corrupt/undecryptable wrap must PROPAGATE, not be replaced — generating
+      // a fresh key here would orphan the wrapped one and silently destroy every
+      // draft it still protects. Callers catch and treat the store as unreadable.
+      const raw = await C.decryptBytes(derivedKey, rec.enc);
+      notesKey = await C.importKeyRaw(C.bytesToBase64(raw));
+      C.wipe(raw);
+      return notesKey;
+    }
+    // First use: generate and wrap. Its own single write, so there is no
+    // partial-write window to close here.
+    const raw = C.randomBytes(32);
+    notesKey = await C.importKeyRaw(C.bytesToBase64(raw));
+    await set({ [NOTES_KEY]: { v: 1, enc: await C.encryptBytes(derivedKey, raw) } });
+    C.wipe(raw);
+    return notesKey;
   }
 
   // Verify a PIN without changing lock state — used to "step up" before sensitive
@@ -420,7 +452,18 @@
     }
     store.kdf = kdf;
     store.verifier = await C.makeVerifier(newKey);
-    await set({ [STORE_KEY]: store });
+    // Re-wrap the notes key (drafts/pay-meta envelope) while oldKey is still in
+    // hand, and land it in the SAME write as the re-keyed vault — two writes
+    // would leave a window where the vault survived a crash but the notes key
+    // didn't, taking every draft and payment note with it.
+    const write = { [STORE_KEY]: store };
+    const notesRec = (await get(NOTES_KEY))[NOTES_KEY];
+    if (notesRec && notesRec.enc) {
+      const raw = await C.decryptBytes(oldKey, notesRec.enc);
+      write[NOTES_KEY] = { v: 1, enc: await C.encryptBytes(newKey, raw) };
+      C.wipe(raw);
+    }
+    await set(write);
     derivedKey = newKey; // stay unlocked
     await persistSession(newKey);
     return getState();
@@ -497,6 +540,11 @@
     // derived key and rewrites the whole store. Losing this write, or interleaving
     // it with another, is how a vault ends up keyed to a PIN nobody has.
     changePin: serialized(changePin),
+    // Envelope key for the encrypted local stores (drafts/pay-meta); null when
+    // locked. Never a raw export — callers get the CryptoKey itself. Serialized:
+    // its first-use wrap-write must not interleave with changePin's re-wrap, or a
+    // wrap keyed to the old PIN could land after the vault moved to the new one.
+    getNotesKey: serialized(getNotesKey),
     // expose the derived key getter for sibling modules (e.g. NWC string encryption)
     _getDerivedKey: () => derivedKey,
   };

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -7073,31 +7073,37 @@
     };
   }
 
-  // ---- composer draft autosave (per account, in chrome.storage.local) ----
+  // ---- composer draft autosave (per account, encrypted at rest) ----
+  // Routed through the background's secret store (audit M5/S1): the draft text
+  // never sits in chrome.storage.local as plaintext. Read-modify-write of the
+  // whole map, same shape the old direct-storage version had — the 400ms save
+  // debounce is the only concurrency limiter either way.
   function loadComposeDraft(pubkey) {
-    return new Promise((res) => {
-      chrome.storage.local.get('sidecar_compose_drafts', (r) => {
-        const all = (r && r.sidecar_compose_drafts) || {};
-        res(all[pubkey] || null);
-      });
-    });
+    return call({ type: 'SIDECAR_SECRET_GET', store: 'drafts' })
+      .then((all) => (all && all[pubkey]) || null)
+      .catch(() => null);
   }
   function saveComposeDraft(pubkey, draft) {
     const hasContent = !!((draft.text && draft.text.trim()) || (draft.media && draft.media.length));
-    chrome.storage.local.get('sidecar_compose_drafts', (r) => {
-      const all = (r && r.sidecar_compose_drafts) || {};
+    (async () => {
+      const all = (await call({ type: 'SIDECAR_SECRET_GET', store: 'drafts' })) || {};
       if (hasContent) all[pubkey] = { text: draft.text, media: draft.media, savedAt: Date.now() };
       else delete all[pubkey];
-      chrome.storage.local.set({ sidecar_compose_drafts: all });
+      await call({ type: 'SIDECAR_SECRET_SET', store: 'drafts', value: all });
+    })().catch(() => {
+      // Swallowed on purpose: the one realistic failure is Sidecar locking
+      // between keystrokes — every pre-lock keystroke was already saved, and the
+      // editor in memory still holds the text. A rejected save must not spam the
+      // console for a draft nobody is typing into anymore.
     });
   }
-  function clearComposeDraft(pubkey) {
-    chrome.storage.local.get('sidecar_compose_drafts', (r) => {
-      const all = (r && r.sidecar_compose_drafts) || {};
-      if (!all[pubkey]) return;
+  async function clearComposeDraft(pubkey) {
+    try {
+      const all = (await call({ type: 'SIDECAR_SECRET_GET', store: 'drafts' })) || {};
+      if (!(pubkey in all)) return;
       delete all[pubkey];
-      chrome.storage.local.set({ sidecar_compose_drafts: all });
-    });
+      await call({ type: 'SIDECAR_SECRET_SET', store: 'drafts', value: all });
+    } catch (_) {}
   }
 
   // The review window before something irreversible goes out, shared by the note
@@ -10279,19 +10285,19 @@
   // Locally-recorded payment metadata (counterparty/comment/fee), keyed by the
   // BOLT11 invoice. NWC's list_transactions doesn't carry who we paid, so for
   // lightning-address sends we stash the address here and match it back by
-  // invoice when rendering history. Capped to the most recent entries.
-  const PAY_META_KEY = 'sidecar_pay_meta';
+  // invoice when rendering history. Capped to the most recent entries. Encrypted
+  // at rest via the background's secret store (audit M5/S1) — counterparties and
+  // user-typed comments are no one else's business, including anyone holding the
+  // profile on disk.
   function getPayMeta() {
-    return new Promise((res) => {
-      try {
-        chrome.storage.local.get(PAY_META_KEY, (o) => res((o && o[PAY_META_KEY]) || {}));
-      } catch (_) { res({}); }
-    });
+    return call({ type: 'SIDECAR_SECRET_GET', store: 'paymeta' })
+      .then((m) => m || {})
+      .catch(() => ({}));
   }
   async function savePayMeta(invoice, meta) {
     if (!invoice) return;
     try {
-      const all = await getPayMeta();
+      const all = (await getPayMeta()) || {};
       all[invoice] = Object.assign({}, all[invoice], meta, { ts: Date.now() });
       const keys = Object.keys(all);
       if (keys.length > 300) {
@@ -10300,7 +10306,7 @@
           .slice(0, keys.length - 300)
           .forEach((k) => delete all[k]);
       }
-      chrome.storage.local.set({ [PAY_META_KEY]: all });
+      await call({ type: 'SIDECAR_SECRET_SET', store: 'paymeta', value: all });
     } catch (_) {}
   }
 

--- a/test/secret-store.test.js
+++ b/test/secret-store.test.js
@@ -1,0 +1,271 @@
+'use strict';
+
+// Unit coverage for the encrypted local stores (drafts / payment metadata) —
+// audit M5/S1, the second half of issue #196.
+//
+// Two layers, both pinned here:
+//
+//   keystore.js — the "notes key" envelope: one random key, wrapped under the
+//     derived key and re-wrapped by changePin. The hazard is the PIN change: if
+//     the re-wrap is missed (or interleaves with a first-use wrap write), every
+//     draft and payment note becomes ciphertext nobody can open. changePin
+//     re-wraps in the SAME storage write as the re-keyed vault, and both writes
+//     ride the store chain. These tests reload keystore.js against persisted
+//     storage — a simulated service-worker restart — because the in-memory key
+//     would otherwise paper over a stale wrap on disk.
+//
+//   background.js — secretGet/secretPut: envelope reads and writes, the one-time
+//     migration off the legacy plaintext keys (the encrypted copy must land
+//     before the plaintext is removed), and fail-closed behavior while locked.
+
+const { test, before, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const ROOT = path.join(__dirname, '..');
+
+// Callback-style area like MV3, with the two load-bearing properties from
+// keystore-concurrency.test.js: yields to the microtask queue (so races are
+// deterministic, not timing-dependent) and structured-clones values in and out
+// (a shared live reference would make lost-update races impossible to produce).
+function makeSlowStorageArea() {
+  const data = {};
+  const yieldABit = async () => { for (let i = 0; i < 5; i++) await Promise.resolve(); };
+  const clone = (v) => (v === undefined ? v : structuredClone(v));
+  return {
+    get(keys, cb) {
+      yieldABit().then(() => {
+        let out = {};
+        if (keys == null) out = clone(data);
+        else if (typeof keys === 'string') { if (keys in data) out[keys] = clone(data[keys]); }
+        else if (Array.isArray(keys)) { for (const k of keys) if (k in data) out[k] = clone(data[k]); }
+        else { for (const k of Object.keys(keys)) out[k] = (k in data) ? clone(data[k]) : keys[k]; }
+        cb(out);
+      });
+    },
+    set(obj, cb) {
+      yieldABit().then(() => {
+        for (const [k, v] of Object.entries(obj)) data[k] = clone(v);
+        cb && cb();
+      });
+    },
+    remove(keys, cb) {
+      yieldABit().then(() => {
+        for (const k of (Array.isArray(keys) ? keys : [keys])) delete data[k];
+        cb && cb();
+      });
+    },
+    clear(cb) { yieldABit().then(() => { for (const k of Object.keys(data)) delete data[k]; cb && cb(); }); },
+  };
+}
+
+const PIN = 'sidecar-test-pin';
+
+// ---- part 1: the keystore envelope, with real WebCrypto ----
+let KS, NostrTools, CRYPTO, keystoreSrc;
+
+before(() => {
+  globalThis.self = globalThis;
+  globalThis.chrome = {
+    storage: { local: makeSlowStorageArea(), session: makeSlowStorageArea() },
+  };
+  for (const f of ['nostr-tools.js', 'crypto.js']) {
+    vm.runInThisContext(fs.readFileSync(path.join(ROOT, f), 'utf8'), { filename: f });
+  }
+  NostrTools = globalThis.NostrTools;
+  CRYPTO = globalThis.SidecarCrypto;
+  keystoreSrc = fs.readFileSync(path.join(ROOT, 'keystore.js'), 'utf8');
+  assert.ok(NostrTools && CRYPTO);
+});
+
+// A "service worker restart": a fresh closure over the SAME storage areas. The
+// session area survives SW eviction in real life (that's its whole job), so the
+// new instance re-derives its unlocked state from it.
+function freshKeystore() {
+  vm.runInThisContext(keystoreSrc, { filename: 'keystore.js' });
+  return globalThis.SidecarKeystore;
+}
+
+beforeEach(async () => {
+  globalThis.chrome.storage.local.clear(() => {});
+  globalThis.chrome.storage.session.clear(() => {});
+  KS = freshKeystore();
+  await KS.initialize(PIN);
+  await KS.unlock(PIN);
+});
+
+test('a first getNotesKey creates a wrapped key and stays usable', async () => {
+  const k = await KS.getNotesKey();
+  assert.ok(k, 'expected a CryptoKey while unlocked');
+  const sealed = await CRYPTO.encryptString(k, 'draft text');
+  assert.equal(await CRYPTO.decryptString(k, sealed), 'draft text');
+});
+
+test('locked means no notes key, and lock forgets it', async () => {
+  await KS.getNotesKey(); // load it once…
+  await KS.lock();
+  assert.equal(await KS.getNotesKey(), null, 'locked: envelope operations must be off');
+});
+
+test('a PIN change keeps the SAME raw notes key (verified after a restart)', async () => {
+  const k1 = await KS.getNotesKey();
+  const sealed = await CRYPTO.encryptString(k1, 'the draft that must survive');
+  await KS.changePin(PIN, 'a-longer-second-pin');
+  // In-memory state would hide a stale wrap — prove the DISK copy is good by
+  // unwrapping it from a fresh instance (simulated SW restart).
+  const KS2 = freshKeystore();
+  await KS2.ensureLoaded();
+  const k2 = await KS2.getNotesKey();
+  assert.ok(k2, 'the wrapped notes key did not survive the PIN change');
+  assert.equal(
+    await CRYPTO.decryptString(k2, sealed),
+    'the draft that must survive',
+    'the notes key changed material in the PIN change — every draft and payment note would be unreadable'
+  );
+});
+
+// The exact interleaving that the serialization exists for: the FIRST use of
+// getNotesKey (its own wrap write) racing changePin's re-wrap. If either escapes
+// the store chain, one write can land a wrap keyed to the old PIN after the
+// vault has already moved to the new one.
+test('a first-use getNotesKey racing changePin still leaves a usable wrap', async () => {
+  const [k1] = await Promise.all([KS.getNotesKey(), KS.changePin(PIN, 'third-long-pin')]);
+  const sealed = await CRYPTO.encryptString(k1, 'raced draft');
+  const KS2 = freshKeystore();
+  await KS2.ensureLoaded();
+  const k2 = await KS2.getNotesKey();
+  assert.ok(k2);
+  assert.equal(await CRYPTO.decryptString(k2, sealed), 'raced draft');
+});
+
+test('a wrong PIN is rejected before anything is re-wrapped', async () => {
+  await KS.getNotesKey();
+  await assert.rejects(() => KS.changePin('wrong-pin', 'new-long-pin'), /Incorrect current PIN/);
+  const k = await KS.getNotesKey(); // still the pre-change key, still working
+  assert.equal(await CRYPTO.decryptString(k, await CRYPTO.encryptString(k, 'x')), 'x');
+});
+
+// ---- part 2: background.js secretGet / secretPut, lifted into a vm ----
+//
+// The crypto here is a mock (key correctness is part 1's job, with real
+// WebCrypto); what these pin is the storage choreography around the envelope.
+
+const bgSource = fs.readFileSync(path.join(ROOT, 'background.js'), 'utf8');
+function lift(pattern, label) {
+  const m = bgSource.match(pattern);
+  if (!m) throw new Error('Could not find ' + label + ' in background.js');
+  return m[0];
+}
+
+// `locked` and `failDecrypt` are flipped by individual tests.
+function makeCtx({ locked, failDecrypt }) {
+  const KEY = { sentinel: 'notes key' };
+  const area = makeSlowStorageArea();
+  const ops = []; // ['set', key] / ['remove', key] — order is asserted below
+  const origSet = area.set.bind(area);
+  const origRemove = area.remove.bind(area);
+  area.set = (obj, cb) => { ops.push(['set', ...Object.keys(obj)]); origSet(obj, cb); };
+  area.remove = (keys, cb) => { ops.push(['remove', ...(Array.isArray(keys) ? keys : [keys])]); origRemove(keys, cb); };
+  const sget = (keys) => new Promise((res) => area.get(keys, res));
+  const sset = (obj) => new Promise((res) => area.set(obj, res));
+  const ctx = {
+    KS: { isLocked: () => locked, getNotesKey: async () => (locked ? null : KEY) },
+    CRYPTO: {
+      encryptString: async (k, s) => ({ iv: 'mock', ct: 'ENC(' + s + ')' }),
+      decryptString: async (k, enc) => {
+        if (failDecrypt) throw new Error('OperationError');
+        const m = /^ENC\((.*)\)$/.exec(enc && enc.ct);
+        if (!m) throw new Error('OperationError');
+        return m[1];
+      },
+    },
+    sget,
+    sset,
+    chrome: { storage: { local: { remove: (k, cb) => area.remove(k, cb) } } },
+  };
+  vm.createContext(ctx);
+  vm.runInContext(
+    lift(/const SECRET_STORES = \{[\s\S]*?\};/, 'SECRET_STORES') + '\n' +
+    lift(/async function secretGet\(name\)\s*\{[\s\S]*?\n\}/, 'secretGet') + '\n' +
+    lift(/async function secretPut\(name, value\)\s*\{[\s\S]*?\n\}/, 'secretPut') + '\n' +
+    'globalThis.secretGet = secretGet; globalThis.secretPut = secretPut; globalThis.SECRET_STORES = SECRET_STORES;',
+    ctx
+  );
+  return { ctx, area, ops };
+}
+
+test('locked reads return null and never touch the legacy plaintext', async () => {
+  const { ctx, area } = makeCtx({ locked: true, failDecrypt: false });
+  area.set({ sidecar_compose_drafts: { pk1: { text: 'secret' } } }, () => {});
+  assert.equal(await ctx.secretGet('drafts'), null);
+});
+
+test('an unknown store name is refused', async () => {
+  const { ctx } = makeCtx({ locked: false, failDecrypt: false });
+  await assert.rejects(() => ctx.secretGet('diary'), /Unknown secret store/);
+  await assert.rejects(() => ctx.secretPut('diary', {}), /Unknown secret store/);
+});
+
+test('an envelope is decrypted and returned; legacy is not consulted', async () => {
+  const { ctx, area, ops } = makeCtx({ locked: false, failDecrypt: false });
+  area.set({ sidecar_drafts_enc: { v: 1, enc: { iv: 'mock', ct: 'ENC({"pk1":{"text":"hi"}})' } } }, () => {});
+  area.set({ sidecar_compose_drafts: { pk1: { text: 'legacy' } } }, () => {});
+  ops.length = 0; // the seeding writes above are not the read's business
+  const out = await ctx.secretGet('drafts');
+  assert.equal(out.pk1.text, 'hi');
+  assert.equal(ops.length, 0, 'no writes or removes should happen on a clean read');
+});
+
+test('a corrupt envelope without legacy is null — and is NOT deleted', async () => {
+  const { ctx, area } = makeCtx({ locked: false, failDecrypt: true });
+  area.set({ sidecar_drafts_enc: { v: 1, enc: { iv: 'x', ct: 'garbage' } } }, () => {});
+  assert.equal(await ctx.secretGet('drafts'), null);
+  const left = await new Promise((res) => area.get('sidecar_drafts_enc', res));
+  assert.ok(left.sidecar_drafts_enc, 'the corrupt envelope must stay on disk for possible recovery');
+});
+
+test('a corrupt envelope falls back to a still-present legacy copy', async () => {
+  const { ctx, area } = makeCtx({ locked: false, failDecrypt: true });
+  area.set({ sidecar_drafts_enc: { v: 1, enc: { iv: 'x', ct: 'garbage' } } }, () => {});
+  area.set({ sidecar_pay_meta: { lnbc123: { ts: 1 } } }, () => {});
+  const out = await ctx.secretGet('paymeta');
+  assert.equal(out.lnbc123.ts, 1, 'data still on disk should not be shown as empty');
+});
+
+test('legacy plaintext migrates: envelope first, plaintext removed after', async () => {
+  const { ctx, area, ops } = makeCtx({ locked: false, failDecrypt: false });
+  area.set({ sidecar_pay_meta: { lnbc1: { ts: 1 }, lnbc2: { ts: 2 } } }, () => {});
+  const out = await ctx.secretGet('paymeta');
+  assert.deepEqual(Object.keys(out).sort(), ['lnbc1', 'lnbc2']);
+  const stored = await new Promise((res) => area.get('sidecar_pay_meta_enc', res));
+  assert.ok(stored.sidecar_pay_meta_enc && stored.sidecar_pay_meta_enc.enc,
+    'the encrypted copy must be on disk');
+  assert.match(stored.sidecar_pay_meta_enc.enc.ct, /lnbc1/, 'and contain the migrated data');
+  const legacy = await new Promise((res) => area.get('sidecar_pay_meta', res));
+  assert.equal(legacy.sidecar_pay_meta, undefined, 'the plaintext must be gone');
+  const setIdx = ops.findIndex((o) => o[0] === 'set' && o.includes('sidecar_pay_meta_enc'));
+  const rmIdx = ops.findIndex((o) => o[0] === 'remove' && o.includes('sidecar_pay_meta'));
+  assert.ok(setIdx >= 0 && rmIdx > setIdx, 'encrypted copy lands BEFORE the plaintext is removed');
+});
+
+test('no envelope and no legacy is an empty store, not an error', async () => {
+  const { ctx } = makeCtx({ locked: false, failDecrypt: false });
+  // Object.keys, not deepEqual on the object itself: it comes from the vm
+  // context, whose realm has its own Object.prototype.
+  assert.deepEqual(Object.keys(await ctx.secretGet('drafts')), []);
+});
+
+test('secretPut refuses while locked, writes an envelope while unlocked', async () => {
+  const locked = makeCtx({ locked: true, failDecrypt: false });
+  await assert.rejects(() => locked.ctx.secretPut('drafts', { a: 1 }), /locked/);
+
+  const open = makeCtx({ locked: false, failDecrypt: false });
+  await open.ctx.secretPut('drafts', { pk1: { text: 'typed draft' } });
+  const stored = await new Promise((res) => open.area.get('sidecar_drafts_enc', res));
+  assert.ok(stored.sidecar_drafts_enc && stored.sidecar_drafts_enc.v === 1);
+  // And what put writes, get reads back:
+  const round = await open.ctx.secretGet('drafts');
+  assert.equal(round.pk1.text, 'typed draft');
+});


### PR DESCRIPTION
Closes the other half of #196 (audit M5/S1) — the half #212 deliberately deferred. With this, everything Sidecar persists about what you were writing and who you paid is ciphertext at rest.

## The finding

`sidecar_compose_drafts` and `sidecar_pay_meta` sat in chrome.storage.local as plaintext: half-written notes and payment counterparties/notes, readable by anyone holding the browser profile. Everything else with that sensitivity (nsecs, NWC strings) was already sealed under the PIN-derived key.

## What changed

**The envelope key (keystore.js).** One random 32-byte "notes key", stored only wrapped under the derived key. Drafts and pay-meta are sealed with it, so a PIN change re-wraps one small blob instead of re-encrypting every draft. The trap: there is exactly one place the old derived key dies (`changePin`), and if the re-wrap is missed — or interleaves with a first-use wrap write — every draft becomes ciphertext nobody can open. So the re-wrap lands in the SAME storage write as the re-keyed vault (no crash window between them), and `getNotesKey` and `changePin` both ride the serialized store chain (no interleaving). A corrupt wrap propagates rather than regenerating — generating a fresh key would orphan the wrapped one and silently destroy the drafts it still protects.

**The stores (background.js).** `secretGet`/`secretPut` behind `SIDECAR_SECRET_GET/SET` (extension-page gated like the rest of the control surface). While locked the answer is simply null — the composer and wallet history are unreachable while locked anyway, and a locked fallback to legacy plaintext would keep the exposure this exists to close. Legacy plaintext migrates once: the encrypted copy is written and confirmed before the plaintext is removed. A corrupt envelope is never deleted, and falls back to a still-present legacy copy rather than showing an empty draft over data that still exists.

**The panel (sidepanel.js).** The draft trio and pay-meta get/save now route through the messages — same shapes, same caps. One behavioral note: a save that fails because Sidecar locked between keystrokes is swallowed — every pre-lock keystroke was already saved, and the in-memory editor still holds the text.

PRIVACY.md flips the "not encrypted at rest" bullet from #212 to describe the encrypted store and the one-time migration.

## Tests

13 new in test/secret-store.test.js, split by layer. The keystore tests run real WebCrypto and reload keystore.js against persisted storage — a simulated service-worker restart, because the in-memory key would otherwise paper over a stale wrap on disk — covering PIN-change survival, the first-use-racing-`changePin` interleave, and wrong-PIN rejection. The background tests pin the envelope read/write choreography, migration ordering (encrypted copy lands before plaintext removal), corrupt-envelope fallback, and fail-closed locked behavior. Suite: 441 total, the same two pre-existing vendoring reds. Manual QA: type a draft and let the worker die — draft restores; change the PIN — draft still opens; lock — composer shows nothing.

🍹 Muddled with GLM 5.3 (z.ai)