### PR TITLE
1.9.1: fix the wallet outage that blocked 1.9.0, and reship the batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ Release practice: the latest release's highlights are also summarized in-app, in
 guide's **What's new** section (`help.html#whats-new`, linked from Settings → Updates).
 Update that section alongside this file as part of every release.
 
-## [1.9.0] — 2026-08-17
+## [1.9.1] — 2026-08-19
+
+*1.9.0 was packaged and tagged but never released; everything below ships here instead.*
 
 ### Added
 - **A printable backup sheet for a new key.** After you've set a name, picture and bio, Sidecar offers a one-page PDF holding the key it just generated — styled as an old-fashioned telegram, set in Courier, generated entirely in the browser with no library and no network call. The nsec is on it twice: as selectable text you can copy, and as a QR you can scan back in. A serial derived from the npub (`NP-AEH2ZW-CQ4NWX`) lets you tell one sheet from another, and match a sheet to an identity, without revealing anything secret. The tinted paper stock is an optional content group set to off for printing, so it looks like a telegram on screen without flooding a printer with ink; the border carries the color instead. Dismissible — it interrupts once, at the only moment the key is new and unsaved. (#175)

--- a/background.js
+++ b/background.js
@@ -2288,7 +2288,11 @@ async function stepUpPin(pin) {
   });
 }
 
-async function handleControl(message, sendResponse) {
+// `sender` is load-bearing: SIDECAR_GET_NWC gates on it. It has to be threaded
+// through from the listener — this function is a top-level declaration, so it
+// does NOT close over the listener's `sender`, and reading one here without a
+// parameter is a ReferenceError, not an undefined.
+async function handleControl(message, sender, sendResponse) {
   try {
     await KS.ensureLoaded(); // reflect a session unlock that survived SW restart
     let result;
@@ -2701,7 +2705,13 @@ async function handleControl(message, sendResponse) {
         // to see the string: display code uses SIDECAR_NWC_META, backup code uses
         // the SIDECAR_NWC_BACKUP_* helpers below, and human-visible export goes
         // through SIDECAR_REVEAL_NWC's PIN step-up.
-        if (typeof sender.url !== 'string' || sender.url !== chrome.runtime.getURL('sidepanel.html')) {
+        // Read `sender` defensively rather than `typeof sender.url`: typeof only
+        // makes a BARE undeclared name safe, so the property access was itself a
+        // ReferenceError whenever sender was missing — which is how this gate
+        // spent 1.9.0 rejecting the side panel too.
+        const senderUrl = sender ? sender.url : null;
+        const from = typeof senderUrl === 'string' ? senderUrl : '';
+        if (from !== chrome.runtime.getURL('sidepanel.html')) {
           throw new Error('Not allowed from this context');
         }
         result = { connection: await KS.getNwc(message.pubkey) };
@@ -3021,6 +3031,6 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   }
 
   // Everything else is a keystore/config control message.
-  handleControl(message, sendResponse);
+  handleControl(message, sender, sendResponse);
   return true;
 });

--- a/help.html
+++ b/help.html
@@ -382,7 +382,7 @@
          linked below. -->
     <section class="guide-section" id="whats-new">
       <h2>What's new</h2>
-      <p class="whatsnew-version">Version 1.9.0</p>
+      <p class="whatsnew-version">Version 1.9.1</p>
       <ul class="whatsnew-list">
         <li><strong>A printable backup sheet for a new key.</strong> Create a key and Sidecar offers you a one-page PDF of it, styled as an old-fashioned telegram. Your nsec is on it as text you can copy and as a QR you can scan back in, alongside a serial number that lets you tell one sheet from another without revealing anything secret. Print it and store it where you keep passports. It's built on your own machine — nothing is sent anywhere.</li>
         <li><strong>Import a key by scanning that sheet.</strong> Four ways in: upload a photo of the sheet, upload the PDF itself, paste an image from your clipboard, or scan it live with your camera. Everything is decoded on your machine.</li>

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Sidecar | A Classy Nostr Signer",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "minimum_chrome_version": "114",
   "description": "A multi-account NIP-07 Nostr signer with a built-in Lightning wallet, in your browser sidebar.",
   "permissions": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sidecar-nostr-signer",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "A multi-account NIP-07 nostr signer with a built-in Lightning wallet, in your browser sidebar",
   "scripts": {
     "dev": "echo 'Load this folder as an unpacked extension at chrome://extensions'",

--- a/test/control-sender-scope.test.js
+++ b/test/control-sender-scope.test.js
@@ -1,0 +1,118 @@
+'use strict';
+
+// Regression cover for the 1.9.0 wallet outage.
+//
+// SIDECAR_GET_NWC is gated on the sender being the side panel. The gate lived in
+// handleControl(), which is a TOP-LEVEL declaration — it does not close over the
+// onMessage listener's `sender`, and the listener never passed one. So `sender`
+// was an undeclared identifier at that point.
+//
+// The guard was written as `typeof sender.url !== 'string'`, which reads like a
+// null-check and isn't: `typeof` only makes a BARE undeclared name safe, so the
+// property access threw ReferenceError every single time. handleControl's own
+// try/catch turned that into a tidy { ok: false } response, so nothing crashed
+// and nothing logged — SIDECAR_GET_NWC simply failed for everyone, in every
+// browser. ensureNwc() is its only caller and the only path that builds the
+// wallet client, so every install reported "no wallet" while the connection
+// string sat intact and decryptable on disk.
+//
+// Two layers here. Structural checks that `sender` is threaded from the listener
+// into handleControl, and a behavioral check that runs the real gate expression
+// lifted out of background.js against several senders — including a missing one,
+// which must deny rather than throw.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const ROOT = path.join(__dirname, '..');
+const source = fs.readFileSync(path.join(ROOT, 'background.js'), 'utf8');
+
+const PANEL_URL = 'chrome-extension://ngmdaeibdldkcblgnklodlenhgnfdimj/sidepanel.html';
+const PROMPT_URL = 'chrome-extension://ngmdaeibdldkcblgnklodlenhgnfdimj/prompt.html';
+
+// ---- structural: the wiring that was missing ----
+
+test('handleControl declares a sender parameter', () => {
+  const m = source.match(/async function handleControl\(([^)]*)\)/);
+  assert.ok(m, 'handleControl not found in background.js');
+  const params = m[1].split(',').map((s) => s.trim());
+  assert.ok(
+    params.includes('sender'),
+    'handleControl must take `sender` — it is a top-level function and cannot ' +
+      'close over the listener\'s. Got: (' + m[1] + ')'
+  );
+});
+
+test('the onMessage listener passes sender into handleControl', () => {
+  const m = source.match(/handleControl\(([^)]*)\)\s*;/);
+  assert.ok(m, 'no handleControl(...) call site found');
+  const args = m[1].split(',').map((s) => s.trim());
+  assert.ok(args.includes('sender'), 'call site must forward `sender`. Got: (' + m[1] + ')');
+});
+
+// Note: `typeof sender.url` is NOT banned outright. Inside the onMessage
+// listener `sender` is a real parameter, so the pattern is safe there and is
+// used legitimately (see the fromExtPage check). What made it a bug was the
+// scope, not the syntax — which is what the two tests above and the
+// missing-sender case below actually pin down.
+
+// ---- behavioral: run the real gate against real senders ----
+
+// Lift the guard out of the SIDECAR_GET_NWC case so the test exercises shipped
+// code rather than a copy that can drift away from it.
+function liftGate() {
+  const block = source.match(/case 'SIDECAR_GET_NWC': \{[\s\S]*?\n\s*break;/);
+  assert.ok(block, 'SIDECAR_GET_NWC case not found');
+  const guard = block[0].match(/const senderUrl = [\s\S]*?\n\s*\}/);
+  assert.ok(guard, 'sender guard not found inside the SIDECAR_GET_NWC case');
+  return guard[0];
+}
+
+// Returns 'allowed' | 'denied', or rethrows anything that is not the deny error
+// — a ReferenceError here is the original bug and must fail the test loudly.
+function runGate(sender) {
+  const ctx = {
+    sender,
+    chrome: { runtime: { getURL: (p) => 'chrome-extension://ngmdaeibdldkcblgnklodlenhgnfdimj/' + p } },
+    result: null,
+  };
+  vm.createContext(ctx);
+  try {
+    vm.runInContext('(function () {\n' + liftGate() + '\nreturn "allowed";\n})()', ctx);
+    return 'allowed';
+  } catch (e) {
+    if (e instanceof ReferenceError) throw e;
+    assert.match(e.message, /Not allowed from this context/);
+    return 'denied';
+  }
+}
+
+test('the side panel is allowed through', () => {
+  assert.equal(runGate({ url: PANEL_URL }), 'allowed');
+});
+
+test('another extension page is denied', () => {
+  assert.equal(runGate({ url: PROMPT_URL }), 'denied');
+});
+
+test('a missing sender denies instead of throwing ReferenceError', () => {
+  assert.equal(runGate(undefined), 'denied');
+});
+
+test('a sender with no url denies', () => {
+  assert.equal(runGate({}), 'denied');
+});
+
+test('a non-string url denies', () => {
+  assert.equal(runGate({ url: 42 }), 'denied');
+});
+
+test('a page merely prefixed with the panel path is denied', () => {
+  assert.equal(
+    runGate({ url: 'chrome-extension://ngmdaeibdldkcblgnklodlenhgnfdimj/sidepanel.html.evil' }),
+    'denied'
+  );
+});


### PR DESCRIPTION
1.9.0 was tagged, packaged, and submitted to both stores. It broke the wallet on every install, so the submissions were withdrawn and the GitHub release is now a draft. This is that batch, reshipped as 1.9.1 with the bug fixed.

## What broke

`85fea19` gated `SIDECAR_GET_NWC` on the sender being the side panel. But `handleControl` never took a `sender` parameter, and it is a top-level declaration, so it does not close over the listener's either. The guard read `typeof sender.url !== 'string'`, which looks like a null-check and is not one — `typeof` only makes a *bare* undeclared name safe, so the property access itself threw `ReferenceError` on every call. `handleControl`'s own try/catch turned that into a tidy `{ok: false}`, so nothing crashed and nothing logged.

`ensureNwc()` is the only remaining caller of that message and the only path that builds the wallet client, so every install reported "no wallet" while the connection string sat intact and decryptable on disk. Restore appeared to do nothing: it saved correctly, then died re-rendering through the same call.

Found by bisect: `v1.8.0` good, `85fea19^` good, `85fea19` bad.

## The fix

`handleControl` takes `sender`, the listener passes it, and the gate reads it defensively so a missing sender denies rather than throws.

`test/control-sender-scope.test.js` pins the wiring and runs the real gate expression, lifted from source, against a panel sender, another extension page, a missing sender, a sender with no url, a non-string url, and a lookalike path. All 8 fail against `c36150f`. Suite: 450 tests, 448 pass, two pre-existing `nostr-tools` module failures.

## Why 1.9.1

AMO permanently burns a version number once uploaded, even after a withdrawal. Both stores move to 1.9.1 together.

The changelog does not mention the sender fix. Between 1.8.0 and 1.9.1 that bug never existed for any user, so listing it would be inaccurate and would only raise a question nobody has. One italic line notes that 1.9.0 never shipped, so the version gap is not a mystery.

## Verified

Wallet found and restored on a real profile with existing data, on the fixed build.

🍹 Garnished with [Claude Code](https://claude.com/claude-code)
