### PR TITLE
Re-wrap NWC connections on a PIN change, and stop claiming a dead wallet

### DIFF
--- a/background.js
+++ b/background.js
@@ -2727,7 +2727,19 @@ async function handleControl(message, sender, sendResponse) {
       case 'SIDECAR_NWC_META': {
         // Metadata-only view of the stored connection: presence + lightning
         // address. Never returns the string itself (see SIDECAR_GET_NWC above).
-        const connection = await KS.getNwc(message.pubkey);
+        // An undecryptable record reports as no wallet rather than throwing: this
+        // is the display path, and the useful answer for someone whose connection
+        // was lost to the pre-fix PIN change is the "connect a wallet" affordance,
+        // which re-pairing overwrites cleanly. `unreadable` distinguishes it from
+        // a genuinely empty slot for anything that wants to say so.
+        let connection = null;
+        let unreadable = false;
+        try {
+          connection = await KS.getNwc(message.pubkey);
+        } catch (e) {
+          if (e && e.code === 'NWC_UNREADABLE') unreadable = true;
+          else throw e;
+        }
         let lud16 = null;
         if (connection) {
           try {
@@ -2736,7 +2748,7 @@ async function handleControl(message, sender, sendResponse) {
             lud16 = v && v.includes('@') ? v.trim() : null;
           } catch (_) {}
         }
-        result = { has: !!connection, lud16 };
+        result = { has: !!connection, unreadable, lud16 };
         break;
       }
       case 'SIDECAR_NWC_BACKUP_CIPHERTEXT': {

--- a/keystore.js
+++ b/keystore.js
@@ -388,17 +388,43 @@
     all[pk] = await C.encryptString(derivedKey, connectionString);
     await set({ [NWC_KEY]: all });
   }
+  // A record that won't decrypt is gone for good — the key that sealed it no
+  // longer exists. That is recoverable (re-pair from the wallet app) but only if
+  // we say so: a raw OperationError from deep inside the wallet client tells the
+  // user nothing they can act on.
+  function unreadableNwc() {
+    const err = new Error('Wallet connection could not be decrypted. Reconnect your wallet.');
+    err.code = 'NWC_UNREADABLE';
+    return err;
+  }
+
   async function getNwc(pubkey) {
     requireUnlocked();
     const pk = pubkey || (await getActivePubkey());
     const all = await loadNwcStore();
     if (!all[pk]) return null;
-    return C.decryptString(derivedKey, all[pk]);
+    try {
+      return await C.decryptString(derivedKey, all[pk]);
+    } catch (_) {
+      throw unreadableNwc();
+    }
   }
+  // Presence AND readability. Every caller of this is a gate in front of an
+  // operation that needs the string, so a record we can't open is not a wallet
+  // as far as they're concerned — answering "yes" sends them into a failure they
+  // can't interpret. While locked, presence is the only question we can answer,
+  // which is fine: those paths unlock before they get any further.
   async function hasNwc(pubkey) {
     const pk = pubkey || (await getActivePubkey());
     const all = await loadNwcStore();
-    return !!all[pk];
+    if (!all[pk]) return false;
+    if (isLocked()) return true;
+    try {
+      await C.decryptString(derivedKey, all[pk]);
+      return true;
+    } catch (_) {
+      return false;
+    }
   }
   async function clearNwc(pubkey) {
     const pk = pubkey || (await getActivePubkey());
@@ -463,6 +489,28 @@
       write[NOTES_KEY] = { v: 1, enc: await C.encryptBytes(newKey, raw) };
       C.wipe(raw);
     }
+    // Same story for the NWC connection strings, which live in their own storage
+    // key but are sealed under this same derived key. Missing them is not
+    // hypothetical — it shipped, and a PIN change silently left every stored
+    // wallet connection as ciphertext under a key nobody had any more, while
+    // presence checks kept reporting a connected wallet.
+    const nwcAll = await loadNwcStore();
+    let nwcRewrapped = false;
+    for (const [pk, rec] of Object.entries(nwcAll)) {
+      let conn;
+      try {
+        conn = await C.decryptString(oldKey, rec);
+      } catch (_) {
+        // Already unreadable — sealed under a PIN from before this fix. Leave the
+        // record exactly as found. It can't be recovered, but deleting a user's
+        // data on their behalf during an unrelated operation is the wrong
+        // instinct even when that data is provably unopenable.
+        continue;
+      }
+      nwcAll[pk] = await C.encryptString(newKey, conn);
+      nwcRewrapped = true;
+    }
+    if (nwcRewrapped) write[NWC_KEY] = nwcAll;
     await set(write);
     derivedKey = newKey; // stay unlocked
     await persistSession(newKey);

--- a/test/nwc-rewrap.test.js
+++ b/test/nwc-rewrap.test.js
@@ -1,0 +1,220 @@
+'use strict';
+
+// Unit coverage for NWC connection strings across a PIN change.
+//
+// The NWC store is a separate storage key from the vault, but its contents are
+// sealed under the SAME derived key as the account private keys. changePin
+// re-wrapped the vault and the notes key and missed this one, so changing a PIN
+// left every stored wallet connection as ciphertext under a key that no longer
+// existed. Nothing said so: the presence check only looked for the record, so
+// the panel kept reporting a connected wallet and the failure surfaced later as
+// a raw AES-GCM error from inside the wallet client.
+//
+// Two properties are pinned here. The re-wrap itself, verified after a simulated
+// service-worker restart so an in-memory key can't paper over stale ciphertext
+// on disk. And the honesty of the gates for anyone already broken by the old
+// behavior: a record that won't open reports as no wallet, with a typed error
+// rather than an OperationError.
+
+const { test, before, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const ROOT = path.join(__dirname, '..');
+
+// Callback-style area like MV3. Structured-clones in and out so a shared live
+// reference can't hide a lost write (see keystore-concurrency.test.js).
+function makeSlowStorageArea() {
+  const data = {};
+  const yieldABit = async () => { for (let i = 0; i < 5; i++) await Promise.resolve(); };
+  const clone = (v) => (v === undefined ? v : structuredClone(v));
+  return {
+    get(keys, cb) {
+      yieldABit().then(() => {
+        let out = {};
+        if (keys == null) out = clone(data);
+        else if (typeof keys === 'string') { if (keys in data) out[keys] = clone(data[keys]); }
+        else if (Array.isArray(keys)) { for (const k of keys) if (k in data) out[k] = clone(data[k]); }
+        else { for (const k of Object.keys(keys)) out[k] = (k in data) ? clone(data[k]) : keys[k]; }
+        cb(out);
+      });
+    },
+    set(obj, cb) {
+      yieldABit().then(() => { for (const [k, v] of Object.entries(obj)) data[k] = clone(v); cb && cb(); });
+    },
+    remove(keys, cb) {
+      yieldABit().then(() => { for (const k of (Array.isArray(keys) ? keys : [keys])) delete data[k]; cb && cb(); });
+    },
+    clear(cb) { yieldABit().then(() => { for (const k of Object.keys(data)) delete data[k]; cb && cb(); }); },
+  };
+}
+
+const PIN = 'sidecar-test-pin';
+const PIN2 = 'a-longer-second-pin';
+const NWC_KEY = 'sidecar_nwc_connections';
+const CONN = 'nostr+walletconnect://abc?relay=wss%3A%2F%2Frelay.example&secret=deadbeef&lud16=zap%40example.com';
+const CONN2 = 'nostr+walletconnect://def?relay=wss%3A%2F%2Frelay2.example&secret=cafebabe';
+
+let KS, keystoreSrc;
+
+before(() => {
+  globalThis.self = globalThis;
+  globalThis.chrome = {
+    storage: { local: makeSlowStorageArea(), session: makeSlowStorageArea() },
+  };
+  for (const f of ['nostr-tools.js', 'crypto.js']) {
+    vm.runInThisContext(fs.readFileSync(path.join(ROOT, f), 'utf8'), { filename: f });
+  }
+  keystoreSrc = fs.readFileSync(path.join(ROOT, 'keystore.js'), 'utf8');
+});
+
+// A "service worker restart": a fresh closure over the same storage areas.
+function freshKeystore() {
+  vm.runInThisContext(keystoreSrc, { filename: 'keystore.js' });
+  return globalThis.SidecarKeystore;
+}
+
+beforeEach(async () => {
+  globalThis.chrome.storage.local.clear(() => {});
+  globalThis.chrome.storage.session.clear(() => {});
+  KS = freshKeystore();
+  await KS.initialize(PIN);
+  await KS.unlock(PIN);
+});
+
+function storageGet(key) {
+  return new Promise((resolve) => globalThis.chrome.storage.local.get(key, (r) => resolve(r[key])));
+}
+
+test('a connection string round-trips with no PIN change', async () => {
+  const { pubkey } = await KS.generateAccount('one');
+  await KS.setNwc(pubkey, CONN);
+  assert.equal(await KS.getNwc(pubkey), CONN);
+  assert.equal(await KS.hasNwc(pubkey), true);
+});
+
+test('a PIN change keeps the connection readable', async () => {
+  const { pubkey } = await KS.generateAccount('one');
+  await KS.setNwc(pubkey, CONN);
+  await KS.changePin(PIN, PIN2);
+  assert.equal(await KS.getNwc(pubkey), CONN, 'still decrypts under the new derived key');
+  assert.equal(await KS.hasNwc(pubkey), true);
+});
+
+test('the re-wrap is on disk, not just in memory (verified after a restart)', async () => {
+  const { pubkey } = await KS.generateAccount('one');
+  await KS.setNwc(pubkey, CONN);
+  await KS.changePin(PIN, PIN2);
+  KS = freshKeystore();          // simulated SW eviction
+  await KS.unlock(PIN2);
+  assert.equal(await KS.getNwc(pubkey), CONN);
+});
+
+test('every account is re-wrapped, not just the active one', async () => {
+  const a = await KS.generateAccount('one');
+  const b = await KS.generateAccount('two');
+  await KS.setNwc(a.pubkey, CONN);
+  await KS.setNwc(b.pubkey, CONN2);
+  await KS.changePin(PIN, PIN2);
+  KS = freshKeystore();
+  await KS.unlock(PIN2);
+  assert.equal(await KS.getNwc(a.pubkey), CONN);
+  assert.equal(await KS.getNwc(b.pubkey), CONN2);
+});
+
+test('the ciphertext actually changed (a no-op write would pass the above by luck)', async () => {
+  const { pubkey } = await KS.generateAccount('one');
+  await KS.setNwc(pubkey, CONN);
+  const before = (await storageGet(NWC_KEY))[pubkey];
+  await KS.changePin(PIN, PIN2);
+  const after = (await storageGet(NWC_KEY))[pubkey];
+  assert.notEqual(before.ct, after.ct, 're-wrapped under a different key');
+});
+
+test('two PIN changes in a row stay readable', async () => {
+  const { pubkey } = await KS.generateAccount('one');
+  await KS.setNwc(pubkey, CONN);
+  await KS.changePin(PIN, PIN2);
+  await KS.changePin(PIN2, 'a-third-long-pin');
+  KS = freshKeystore();
+  await KS.unlock('a-third-long-pin');
+  assert.equal(await KS.getNwc(pubkey), CONN);
+});
+
+test('a PIN change with no wallet connected writes no NWC record', async () => {
+  await KS.generateAccount('one');
+  await KS.changePin(PIN, PIN2);
+  assert.equal(await storageGet(NWC_KEY), undefined, 'nothing to re-wrap, nothing written');
+});
+
+test('a rejected PIN change leaves the connection alone', async () => {
+  const { pubkey } = await KS.generateAccount('one');
+  await KS.setNwc(pubkey, CONN);
+  await assert.rejects(() => KS.changePin('wrong-pin-entirely', PIN2), /Incorrect current PIN/);
+  assert.equal(await KS.getNwc(pubkey), CONN);
+});
+
+// ---- already-broken records: anyone who changed their PIN before the fix ----
+
+// Seal a record under a key nobody holds, reproducing the pre-fix on-disk state.
+async function plantUnreadable(pubkey) {
+  const C = globalThis.SidecarCrypto;
+  const orphanKey = await C.deriveKey('some-key-that-is-gone', C.newKdf());
+  const all = (await storageGet(NWC_KEY)) || {};
+  all[pubkey] = await C.encryptString(orphanKey, CONN);
+  await new Promise((r) => globalThis.chrome.storage.local.set({ [NWC_KEY]: all }, r));
+}
+
+test('an unreadable record throws a typed error, not an OperationError', async () => {
+  const { pubkey } = await KS.generateAccount('one');
+  await plantUnreadable(pubkey);
+  await assert.rejects(() => KS.getNwc(pubkey), (e) => {
+    assert.equal(e.code, 'NWC_UNREADABLE');
+    assert.match(e.message, /Reconnect your wallet/);
+    return true;
+  });
+});
+
+test('an unreadable record reports as no wallet, so gates fail closed', async () => {
+  const { pubkey } = await KS.generateAccount('one');
+  await plantUnreadable(pubkey);
+  assert.equal(await KS.hasNwc(pubkey), false, 'a wallet that cannot be opened is not a wallet');
+});
+
+test('reconnecting overwrites a broken record', async () => {
+  const { pubkey } = await KS.generateAccount('one');
+  await plantUnreadable(pubkey);
+  await KS.setNwc(pubkey, CONN2);
+  assert.equal(await KS.getNwc(pubkey), CONN2);
+  assert.equal(await KS.hasNwc(pubkey), true);
+});
+
+test('a PIN change preserves a broken record rather than dropping it', async () => {
+  const { pubkey } = await KS.generateAccount('one');
+  await plantUnreadable(pubkey);
+  const before = (await storageGet(NWC_KEY))[pubkey];
+  await KS.changePin(PIN, PIN2);
+  const after = (await storageGet(NWC_KEY))[pubkey];
+  assert.deepEqual(after, before, 'left exactly as found; we do not delete user data here');
+});
+
+test('one broken record does not stop a good one from re-wrapping', async () => {
+  const a = await KS.generateAccount('one');
+  const b = await KS.generateAccount('two');
+  await KS.setNwc(b.pubkey, CONN2);
+  await plantUnreadable(a.pubkey);
+  await KS.changePin(PIN, PIN2);
+  KS = freshKeystore();
+  await KS.unlock(PIN2);
+  assert.equal(await KS.getNwc(b.pubkey), CONN2, 'the healthy account survived');
+  assert.equal(await KS.hasNwc(a.pubkey), false);
+});
+
+test('while locked, presence is still the answer (nothing can be decrypted)', async () => {
+  const { pubkey } = await KS.generateAccount('one');
+  await KS.setNwc(pubkey, CONN);
+  await KS.lock();
+  assert.equal(await KS.hasNwc(pubkey), true, 'locked: presence is all we can honestly report');
+});


### PR DESCRIPTION
`changePin` re-wrapped the vault, the verifier, and the notes key, but never `sidecar_nwc_connections` — which `setNwc` seals under that same derived key. Changing a PIN left every stored wallet connection as ciphertext under a key that no longer existed anywhere.

Nothing said so. `hasNwc` only checked that the record was *present*, so the panel kept showing a connected wallet and the gate in front of payments kept letting attempts through, until it surfaced as a raw AES-GCM `OperationError` from deep inside the wallet client.

- `changePin` re-wraps each connection in the **same** storage write as the re-keyed vault and notes key, so a crash cannot re-key one and not the other
- an undecryptable record is left byte-for-byte as found rather than dropped — unrecoverable either way, but deleting a user's data during an unrelated operation is the wrong instinct
- `getNwc` throws a typed `NWC_UNREADABLE` instead of leaking an `OperationError`
- `hasNwc` answers presence **and** readability while unlocked, so those gates fail closed; locked, it still answers presence, which is all it honestly can
- `SIDECAR_NWC_META` reports an undecryptable record as no wallet plus an `unreadable` flag, so the panel offers "connect a wallet" instead of breaking, and re-pairing overwrites the dead record cleanly

`test/nwc-rewrap.test.js` covers the re-wrap across a simulated service-worker restart, multiple accounts, repeated PIN changes, a rejected PIN change, and the already-broken records anyone who changed a PIN before this fix is still carrying. 8 of its 14 fail against the previous code. Suite: 464 tests, 462 pass, two pre-existing `nostr-tools` module failures.

**This cannot recover a connection already lost to the old behavior.** The derived key is gone and `changePin` rolls a fresh KDF salt, so even the old PIN cannot re-derive it. Re-pairing from the wallet app is the only path back.

🥃 Strained with [Claude Code](https://claude.com/claude-code)
