### PR TITLE
Settle the signEvent request shape before it reaches a prompt, and derive q tags

### DIFF
--- a/background.js
+++ b/background.js
@@ -888,6 +888,108 @@ function isNip42AuthEvent(ev) {
   return true;
 }
 
+// ---- signEvent request shape ----
+// NIP-07 says signEvent takes an event template, and pages get that wrong in ways
+// that used to surface at the worst possible moment. A page that sent the event as a
+// JSON string, positionally in an array, or not at all produced an approval card
+// reading "Kind —" with no tag count and no content preview — nothing for the user to
+// judge — and then, AFTER they approved, nostr-tools threw "can't serialize event with
+// wrong or missing properties" from inside the signer. The site reported an opaque
+// failure and the user went and posted from another client.
+//
+// So the shape is settled here, before anything is queued. A prompt that cannot say
+// what it is signing is worse than a refusal.
+//
+// Liberal about three unambiguous mistakes, because the alternative is a dead end for
+// something we can read perfectly well:
+//   - the event may arrive as params.event, as params itself, or as a JSON string
+//     (pages ported from NIP-46, where params is [json], do this);
+//   - a numeric-string kind ("1") is coerced to a number. This one is the quiet
+//     hazard: it LABELS correctly by accident (object keys stringify, so
+//     APPROVAL_KIND_LABELS["1"] hits) while silently taking the wrong branch in every
+//     kind check we make — COALESCE_KINDS.has, RELAX.neverRelaxes, the 9734 zap test,
+//     isNip42AuthEvent's 22242, and BASELINE's TRACKED.has. That last one is the
+//     destructive-overwrite guard, so a kind:"3" follow-list wipe would skip its
+//     warning entirely;
+//   - absent created_at / tags / content are filled in, never overwritten. A client
+//     that deliberately backdates an event keeps its timestamp.
+//
+// Anything still unreadable throws, with a message the page can show its user.
+//
+// Returns a fresh { event } — the object that gets queued, previewed, AND signed, so
+// the approval card and the signature can never describe different events. Junk keys
+// the page sent alongside are dropped (nothing downstream reads them for signEvent).
+function normalizeTagValue(v) {
+  if (v == null) return ''; // ['p', pk, undefined] → an empty relay hint, which is what it meant
+  if (typeof v === 'string') return v;
+  if (typeof v === 'boolean') return String(v);
+  if (typeof v === 'number' && Number.isFinite(v)) return String(v);
+  return null; // objects/arrays have no sane string form — better to refuse than sign "[object Object]"
+}
+function normalizeSignEventParams(params) {
+  let ev = params && (params.event || params);
+  if (typeof ev === 'string') {
+    try { ev = JSON.parse(ev); } catch (_) {
+      throw new Error("signEvent: the event isn't valid JSON");
+    }
+  }
+  if (!ev || typeof ev !== 'object' || Array.isArray(ev)) {
+    throw new Error('signEvent: expected an event object (NIP-07 signEvent takes one event)');
+  }
+  const rawKind = typeof ev.kind === 'string' && /^\d+$/.test(ev.kind.trim()) ? Number(ev.kind.trim()) : ev.kind;
+  if (!Number.isInteger(rawKind) || rawKind < 0) {
+    throw new Error('signEvent: event.kind must be a non-negative integer');
+  }
+  const rawTags = ev.tags == null ? [] : ev.tags;
+  if (!Array.isArray(rawTags)) throw new Error('signEvent: event.tags must be an array');
+  const tags = [];
+  for (const t of rawTags) {
+    if (!Array.isArray(t)) throw new Error('signEvent: every entry in event.tags must be an array');
+    const out = [];
+    for (const v of t) {
+      const s = normalizeTagValue(v);
+      if (s === null) throw new Error('signEvent: tag values must be strings');
+      out.push(s);
+    }
+    tags.push(out);
+  }
+  if (ev.content != null && typeof ev.content !== 'string') {
+    throw new Error('signEvent: event.content must be a string');
+  }
+  const created_at = ev.created_at == null ? Math.floor(Date.now() / 1000) : ev.created_at;
+  if (!Number.isInteger(created_at)) {
+    throw new Error('signEvent: event.created_at must be a Unix timestamp in seconds');
+  }
+  // Spread first so a client-stamped pubkey (the applesauce author hint read below)
+  // survives, then overwrite with the normalized fields.
+  return { event: Object.assign({}, ev, { kind: rawKind, tags, content: ev.content == null ? '' : ev.content, created_at }) };
+}
+
+// A shape fingerprint for a REFUSED request, recorded to Activity so a recurrence
+// documents itself. The original report of this failure arrived with no payload to
+// look at, because a refusal left no trace anywhere: the page got the error and
+// Sidecar remembered nothing (dlog is dev-builds only).
+//
+// Types and structure ONLY. No content, no tag values, no pubkeys — we refused to sign
+// this thing, so keeping a copy of it would be the wrong trade. The kind value is the
+// one exception: a bare event kind identifies nobody and is the single most useful
+// field for working out which client sent it.
+function describeSignEventShape(params) {
+  const shapeOf = (v) =>
+    v === undefined ? 'missing' : v === null ? 'null' : Array.isArray(v) ? 'array' : typeof v;
+  const out = { params: shapeOf(params), event: shapeOf(params && params.event) };
+  const ev = params && (params.event || params);
+  if (ev && typeof ev === 'object' && !Array.isArray(ev)) {
+    out.kind = shapeOf(ev.kind);
+    out.tags = shapeOf(ev.tags);
+    out.content = shapeOf(ev.content);
+    out.created_at = shapeOf(ev.created_at);
+    if (typeof ev.kind === 'number') out.kindValue = ev.kind;
+    else if (typeof ev.kind === 'string' && ev.kind.length <= 12) out.kindValue = ev.kind;
+  }
+  return out;
+}
+
 async function handleNostrRpc(method, params, host, sendResponse, originWindowId) {
   try {
     if (!host) throw new Error('Missing host');
@@ -897,8 +999,22 @@ async function handleNostrRpc(method, params, host, sendResponse, originWindowId
     let signKind = null;
     let signEvent = null;
     if (method === 'signEvent') {
-      signEvent = params && (params.event || params);
-      signKind = signEvent && signEvent.kind;
+      // Throws on an unreadable event — before the queue, the prompt, and the key.
+      try {
+        params = normalizeSignEventParams(params);
+      } catch (e) {
+        // Leave a trace before rethrowing. `rejected` marks a request Sidecar itself
+        // refused on shape; it is NOT a user rejection (those aren't logged — nothing
+        // reached the key, and the user already knows they said no).
+        const shape = describeSignEventShape(params);
+        dlog('warn', 'bg', 'Refused an unreadable signEvent', { host, reason: e.message, shape });
+        try {
+          await logActivity({ ts: Date.now(), host, method, kind: null, rejected: e.message, shape });
+        } catch (_) { /* bookkeeping must not change the answer the page gets */ }
+        throw e;
+      }
+      signEvent = params.event;
+      signKind = signEvent.kind; // guaranteed an integer from here down
     }
 
     // The identity this request signs as. getPublicKey is a login: it

--- a/docs/issue-kind-1-nevent-signing.md
+++ b/docs/issue-kind-1-nevent-signing.md
@@ -1,0 +1,151 @@
+# Signing A Kind-1 Note Showed An Unreadable Event Kind
+
+## Report
+
+When posting a normal kind `1` note whose body included a NIP-19 `nevent`
+reference, Sidecar showed the signing request as an unrecognized event kind
+instead of a normal note. The post had to be sent with another client.
+
+The reference supplied with the report:
+
+```text
+nevent1qvzqqqqqqypzpmnw5yatnljuff5w47d35d87q99xddqpzlzsac4xzn6vm22ekmn5qyt8wumn8ghj7mn0wd68yetvd96x2uewdaexwtcpzamhxue69uhhyetvv9ujuct60fsk6mewdejhgtcqyqqqpewddujmzj23fcfpaeygep2xl763u6r6n86ktwmcksalm0n4wxy2yhr
+```
+
+## The `nevent` Was Not The Cause
+
+Ruled out by reading the paths rather than by failing to reproduce it:
+
+- Nothing in either approval surface derives the kind from the body. Both read
+  `ev.kind` off the request params and nothing else (`sidepanel.js`
+  `renderApprovalPreview`, `prompt.js` `renderPreview`). The only decoded NIP-19
+  kind anywhere is in `embedRef`, where an `naddr`'s kind goes into a relay
+  filter for the embed card.
+- The two surfaces keep separate kind tables, and the tables are identical — same
+  97 keys, same strings, both with `1: 'Note'`. A well-formed kind `1` cannot
+  render as unrecognized on either one. `test/approval-kind-isolation.test.js`
+  now pins the tables to each other.
+- The reference itself decodes to `kind: 1`, so the first cut of that test
+  ("a kind:1 event labels as a note") could not have failed either way. Its
+  fixtures now carry a referenced kind that differs from the outer kind.
+
+## What Actually Produced It
+
+Sidecar accepted `params.event || params` with no shape validation at any layer.
+Every plausible malformed shape ended exactly the way the report ends — an
+approval card that describes nothing, then a post that fails:
+
+| The page sends | The prompt showed | Then |
+| --- | --- | --- |
+| `signEvent(JSON.stringify(event))` | `Kind —`, no tag count, no content preview | `signer.js` threw `signEvent: missing event`, *after* approval |
+| `signEvent([event])`, or no argument | the same blank card | nostr-tools threw `can't serialize event with wrong or missing properties` |
+| `kind` as the string `"1"` | labeled correctly, but the Formatted view silently disappeared (`noteLike` tests `=== 1`) | the same serializer throw |
+
+A user who saw a blank kind, approved anyway, and got an opaque failure would
+describe it as Sidecar not recognizing the event, and would then go and post from
+another client.
+
+A string kind also mis-tiered the background's own checks, all of which are
+identity or `Set` comparisons: `COALESCE_KINDS.has`, `RELAX.neverRelaxes`, the
+`9734` zap test, `isNip42AuthEvent`'s `22242`, and `BASELINE`'s `TRACKED.has`.
+That last one is the destructive-overwrite guard, so a `kind: "3"` follow-list
+wipe skipped its warning entirely — defense in depth rather than an exploitable
+hole, since nostr-tools then refused to sign it, but it was the wrong branch on
+the one check that exists to prevent data loss.
+
+## The Fix
+
+1. `normalizeSignEventParams` in `background.js` settles the shape before
+   anything is queued, prompted, or signed. Liberal where the intent is
+   unambiguous (a JSON-string event, a numeric-string kind, absent
+   `tags`/`content`/`created_at`, non-string tag values); throws a
+   `signEvent: …` error the page can show its user where it isn't. The
+   normalized event is what gets queued, previewed, and signed, so the approval
+   card and the signature can never describe different events.
+2. Both approval surfaces now label an unreadable event `Unreadable`, carry an
+   explicit warning, and open the JSON view, instead of showing a bare `—` with
+   Allow looking as ordinary as ever. Unreachable after (1), kept because the
+   thing it replaces was a blind approval.
+3. The composer's missing `q` tag — see below.
+
+## Also Found: The Composer Could Not Quote
+
+`doPublish` tagged only the client tag and `p` tags from `npub` mentions, so a
+`nostr:nevent…` pasted into Sidecar's composer went out as plain text. Clients
+key quote rendering off NIP-18's `q` tag, the quoted author was never notified,
+and Sidecar's own notification list does the same (`notificationKind`'s `hasQ`) —
+so a quote composed in Sidecar did not read as a quote in Sidecar.
+
+`quoteTags` now derives `q` tags from body references (`note`/`nevent` by event
+id, `naddr` by `kind:pubkey:d` coordinate) and offers the quoted authors for `p`
+tags. Still out of scope: replies (the panel composer has no reply path at all,
+by design — Sidecar hands threads off to a web client) and page comments
+(`buildWebComment`, which quotes nothing today).
+
+## Regression Coverage
+
+- `test/sign-event-shape.test.js` — the accepted and rejected shapes, that every
+  accepted one produces an event the vendored nostr-tools actually signs, and
+  that a coerced kind reaches `COALESCE_KINDS`, the baseline guard, and
+  `isNip42AuthEvent` as a number.
+- `test/approval-kind-isolation.test.js` — a body reference cannot change the
+  signed event's kind (with fixtures whose referenced kind differs from the outer
+  kind), unreadable events are called out on both surfaces, and the two surfaces
+  know exactly the same kinds.
+- `test/quote-tags.test.js` — `q` tags per reference type, relay hints, dedupe,
+  malformed refs skipped, and no overlap with `mentionPTags`.
+
+## Not Reproducible On Request
+
+Confirmed with the reporter: the failure will not reproduce now. That is what the
+analysis above predicts — the `nevent` is not the trigger, so repeating the same
+action in the same client proves nothing, and a client update (or a different code
+path that day: a retry, a restored draft, a quote built by another component) would
+make the payload shape that caused it disappear for good.
+
+So the shape gate closes a class of real defects, but which one your reporter hit
+is not established. Recorded as a hypothesis, not a confirmed root cause. The `q`
+tag gap below is independent of the report and was confirmed by reading the code.
+
+## If It Recurs
+
+A refusal now documents itself. `handleNostrRpc` writes a `rejected` entry to
+Activity before rethrowing, so Activity → Log shows "Refused an unreadable signing
+request", the host, the reason, and (on hover) a shape fingerprint —
+`params`/`event`/`kind`/`tags`/`content`/`created_at` as types, plus the kind value.
+Types and structure only: no content, no tag values, no pubkeys from a request
+Sidecar declined to sign. Before this, a refusal left no trace on a store build at
+all (`dlog` is dev-builds only), which is exactly why the first report arrived with
+nothing to look at.
+
+Still worth asking for: whether the approval appeared in the side panel or the
+popup window, and which client and version.
+
+## Open, Reviewed But Not Changed
+
+Found while reading these paths. None of it is implicated in the report; all of it
+is adjacent enough to want a second look if a similar one arrives.
+
+- **Batched approvals preview only the head.** `pendingView` groups the showing
+  request with every queued entry sharing host + account + kind, and "Allow all (N)"
+  signs the group. The comment reasons that same-kind means a site can't slip a
+  different event type into a batch — true, but two *different notes* are the same
+  kind, so a site can have a second kind-1 signed off a card that describes the
+  first.
+- **`batchKeyOf` groups on a null kind.** Encrypt methods are batchable and carry
+  `kind: null`, so a `nip04.encrypt` and a `nip44.encrypt` from one host and account
+  share a batch key despite being different methods.
+- **The panel's approval preview touches the network.** `renderNotePreview` resolves
+  embeds from relays and fetches OG metadata for every https link in the content,
+  from the signing screen, before the user has approved anything. Deliberate — the
+  popup (`prompt.js`) documents the opposite choice for exactly this reason — but it
+  means a request being *reviewed* has already reached out.
+- **`noteLike` and the unreadable check assume a normalized kind.** Both surfaces
+  test `ev.kind === 1` / `Number.isInteger(ev.kind)`, which is now safe only because
+  `handleNostrRpc` guarantees it. Any future path that builds prompt data elsewhere
+  reopens the string-kind hole.
+- **Page comments can't quote.** `buildWebComment` emits no `q` tags, so the
+  composer fix does not cover kind-1111 comments.
+- **User rejections aren't logged.** `rejected` entries cover shape refusals only.
+  A user who rejects a prompt leaves no record either, so "I said no and it still
+  happened" would arrive with as little evidence as this report did.

--- a/prompt.js
+++ b/prompt.js
@@ -119,6 +119,18 @@
     if (kind == null) return null;
     return KIND_WARNINGS[kind] || (!KIND_LABELS[kind] ? 'Unrecognized event kind — review carefully before approving.' : null);
   }
+  // A request we can't read as an event at all — no integer kind, so there is nothing
+  // to label, no tag count, and no content to preview. normalizeSignEventParams in
+  // background.js now rejects these at the RPC boundary, so this should be
+  // unreachable; it stays because the failure it replaces was a signing card showing a
+  // bare "—" where the event should be, with Allow looking as ordinary as ever. If one
+  // ever gets through again, say so on the card instead of showing a blank.
+  // Duplicated verbatim in sidepanel.js — same words on both approval surfaces.
+  const UNREADABLE_WARNING =
+    "Sidecar can't read this request as a nostr event. Don't allow it unless you know what this site is doing.";
+  function kindUnreadable(ev) {
+    return !Number.isInteger(ev && ev.kind);
+  }
 
   // The renderable note text for an event: kind:1 → its content; kind 6/16 reposts →
   // the embedded original event's content (a repost's content field is that event's
@@ -259,11 +271,12 @@
     }
     if (data.method === 'signEvent') {
       const ev = (data.params && (data.params.event || data.params)) || {};
+      const unreadable = kindUnreadable(ev);
       const rows = [];
-      rows.push(row('Kind', kindLabel(ev.kind)));
+      rows.push(row('Kind', unreadable ? 'Unreadable' : kindLabel(ev.kind)));
       if (Array.isArray(ev.tags)) rows.push(row('Tags', String(ev.tags.length)));
       els.preview.innerHTML = rows.join('');
-      const warning = kindWarning(ev.kind);
+      const warning = unreadable ? UNREADABLE_WARNING : kindWarning(ev.kind);
       if (warning) {
         const warn = document.createElement('div');
         warn.className = 'kind-warn';
@@ -325,7 +338,9 @@
         els.preview.appendChild(box);
         setLocked(true);
       }
-      if (ev.content) appendEventContent(els.preview, ev);
+      // Unreadable: show the payload even with no content field, because the JSON view
+      // is then the only description of what's being signed.
+      if (ev.content || unreadable) appendEventContent(els.preview, ev);
       els.preview.classList.remove('hidden');
     } else if (data.method === 'nip04.decrypt' || data.method === 'nip44.decrypt') {
       els.preview.innerHTML = row('From', peerLabel());

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -4474,7 +4474,7 @@
   //
   // Plain sheet only, on purpose. This is a minute into the user's first
   // session, and almost nobody has heard of an ncryptsec — the encrypted sheet
-  // is offered later, from Profile → Backup & restore, by people who know what
+  // is offered later, from Profile → Data backup, by people who know what
   // they're opting into.
   function backupSheetPromptModal(nsec, account) {
     openModal((modal) => {
@@ -4507,7 +4507,7 @@
         // No sheet button here on purpose. At account creation there is no profile
         // yet, and the sheet prints the display name — one taken now is addressed to
         // "THE BEARER OF THIS SHEET" permanently. It's offered after the setup
-        // wizard instead (see generateAccount), and from Profile → Backup & restore.
+        // wizard instead (see generateAccount), and from Profile → Data backup.
         modal.append(
           h('h3', { textContent: opts.title }),
           opts.intro ? h('p', { className: 'hint', textContent: opts.intro }) : document.createTextNode(''),
@@ -8889,8 +8889,8 @@
   function renderBackupSection(view, active) {
     const setting = h('div', { className: 'setting backup-setting' });
     setting.append(
-      h('h3', { textContent: 'Backup & restore' }),
-      h('p', { className: 'hint', textContent: 'Stored on your relays as a NIP-78 record, encrypted to your own key (NIP-44, or NIP-04 for very large lists).' })
+      h('h3', { textContent: 'Data backup' }),
+      h('p', { className: 'hint', textContent: 'Your profile, follows, and mute list — data only, never your secret key — stored on your relays as an encrypted record you can restore here (NIP-78, NIP-44; NIP-04 for very large lists), or saved to a file below.' })
     );
     const list = h('div', { className: 'list flat' });
     BACKUP_TYPES.forEach((t) => {
@@ -8926,7 +8926,7 @@
       h('p', {
         className: 'hint',
         textContent:
-          'Or save a signed copy of your profile, follows, and lists as a file — an offline safety copy you can restore here later. This file holds your data only, never your secret key — for the key itself, back it up below.',
+          'Or save a signed copy of your profile, follows, and lists as a file — an offline safety copy you can restore here later. This file holds no secret key.',
       })
     );
     const exportBtn = h('button', { className: 'secondary', textContent: 'Download data backup' });
@@ -8954,8 +8954,8 @@
           'Export your secret key as copyable text or an encrypted ncryptsec, or print it as a one-page sheet. This IS your key — never send it by email or chat.',
       })
     );
-    // The Accounts screen's "Back up private key" entry, mirrored here — Backup &
-    // restore is where someone backing everything up should find the key export,
+    // The Accounts screen's "Back up private key" entry, mirrored here — the backup
+    // screen is where someone backing everything up should find the key export,
     // not only via the account row's menu. Same modal, same PIN step-up, so there
     // is exactly one key-backup flow to reason about. The printable sheet is an
     // action INSIDE the modal (plain from the nsec tab, encrypted masquerade from

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -2133,6 +2133,52 @@
     return out;
   }
 
+  // NIP-18 `q` tags for the event references in a note's body, plus the pubkeys of the
+  // quoted authors (the caller p-tags them — see doPublish).
+  //
+  // A bech32 reference in the content is not, on its own, a quote: without the `q` tag
+  // the note goes out as plain text with a 210-character string in the middle of it.
+  // Clients key quote rendering off `q`, the quoted author is never notified, and
+  // Sidecar's OWN notification list does exactly that (notificationKind's hasQ, which
+  // is how "quoted your note" is told apart from a reply) — so a quote composed here
+  // didn't read as a quote even in Sidecar.
+  //
+  // note/nevent quote by event id; naddr quotes by "kind:pubkey:d" coordinate, since an
+  // addressable event's id changes with every edit.
+  const BODY_REF_RE = /nostr:(note1[0-9a-z]+|nevent1[0-9a-z]+|naddr1[0-9a-z]+)/g;
+  function quoteTags(content) {
+    const tags = [];
+    const authors = [];
+    const seen = new Set();
+    let m;
+    BODY_REF_RE.lastIndex = 0;
+    while ((m = BODY_REF_RE.exec(String(content || ''))) !== null) {
+      let d = null;
+      try { d = NT.nip19.decode(m[1]); } catch (_) { continue; } // malformed ref — skip it, don't fail the post
+      let value = null;
+      let relay = '';
+      let author = '';
+      if (d.type === 'note') {
+        value = d.data;
+      } else if (d.type === 'nevent') {
+        value = d.data.id;
+        relay = (d.data.relays || [])[0] || '';
+        author = d.data.author || '';
+      } else if (d.type === 'naddr') {
+        value = d.data.kind + ':' + d.data.pubkey + ':' + d.data.identifier;
+        relay = (d.data.relays || [])[0] || '';
+        author = d.data.pubkey || '';
+      }
+      if (!value || seen.has(value)) continue;
+      seen.add(value);
+      // Positional tag, so an author can only be given if the relay slot is filled —
+      // with an empty string when there's no hint, which is what other clients emit.
+      tags.push(author ? ['q', value, relay, author] : relay ? ['q', value, relay] : ['q', value]);
+      if (author) authors.push(author);
+    }
+    return { tags, authors };
+  }
+
   // `includeClientTag` comes from the same Settings toggle that governs notes, so
   // the switch means what it says rather than covering only kind 1. Verified that
   // Jumble renders it: ReplyNote and NotePage both mount <ClientTag> with no kind
@@ -5242,6 +5288,27 @@
   }
 
   function activityRow(e) {
+    // A request Sidecar refused on shape (see normalizeSignEventParams in
+    // background.js) never reached the key, so it must not borrow METHOD_META's
+    // "Signed …" wording — that would describe a signature that doesn't exist. The
+    // reason is on the row and the shape fingerprint is on hover: this is the record
+    // that was missing when the original "unrecognized kind" report came in with no
+    // payload to look at.
+    if (e.rejected) {
+      const row = h('div', { className: 'item activity-item' });
+      const iconBox = h('div', { className: 'act-icon' });
+      iconBox.appendChild(icon('alert'));
+      const main = h('div', { className: 'item-main' }, [
+        h('div', { className: 'item-label', textContent: 'Refused an unreadable signing request' }),
+        h('div', { className: 'item-sub', textContent: (e.host || '') + ' · ' + relTime(e.ts) }),
+        h('div', { className: 'item-sub', textContent: String(e.rejected).replace(/^signEvent: /, '') }),
+      ]);
+      if (e.shape) {
+        row.title = Object.keys(e.shape).map((k) => k + ': ' + e.shape[k]).join('\n');
+      }
+      row.append(iconBox, main);
+      return row;
+    }
     const meta = METHOD_META[e.method] || { icon: 'feather', label: () => e.method };
     const row = h('div', { className: 'item activity-item' });
     const iconBox = h('div', { className: 'act-icon' });
@@ -7226,9 +7293,21 @@
       // Shared with the page-comment path — see mentionPTags. Was inline here, which
       // is how comments ended up shipping without it.
       const pTags = mentionPTags(content);
+      // A body reference makes this a NIP-18 quote — see quoteTags. The quoted author
+      // gets a `p` tag as well (that's what turns the quote into a notification for
+      // them), without duplicating an @mention of the same person.
+      const quotes = quoteTags(content);
+      const seenP = new Set(pTags.map((t) => t[1]));
+      for (const pk of quotes.authors) {
+        if (seenP.has(pk)) continue;
+        seenP.add(pk);
+        pTags.push(['p', pk]);
+      }
       // The "client" tag (attributes the note to Sidecar) is opt-out via Settings.
       const settings = await call({ type: 'SIDECAR_GET_SETTINGS' });
-      const tags = settings && settings.showClientTag === false ? [...pTags] : [CLIENT_TAG.slice(), ...pTags];
+      const tags = settings && settings.showClientTag === false
+        ? [...pTags, ...quotes.tags]
+        : [CLIENT_TAG.slice(), ...pTags, ...quotes.tags];
       const event = {
         kind: 1,
         created_at: Math.floor(Date.now() / 1000),
@@ -11545,6 +11624,18 @@
     if (kind == null) return null;
     return APPROVAL_KIND_WARNINGS[kind] || (!APPROVAL_KIND_LABELS[kind] ? 'Unrecognized event kind — review carefully before approving.' : null);
   }
+  // A request we can't read as an event at all — no integer kind, so there is nothing
+  // to label, no tag count, and no content to preview. normalizeSignEventParams in
+  // background.js now rejects these at the RPC boundary, so this should be
+  // unreachable; it stays because the failure it replaces was a signing card showing a
+  // bare "—" where the event should be, with Allow looking as ordinary as ever. If one
+  // ever gets through again, say so on the card instead of showing a blank.
+  // Duplicated verbatim in prompt.js — same words on both approval surfaces.
+  const APPROVAL_UNREADABLE_WARNING =
+    "Sidecar can't read this request as a nostr event. Don't allow it unless you know what this site is doing.";
+  function approvalKindUnreadable(ev) {
+    return !Number.isInteger(ev && ev.kind);
+  }
 
   // The renderable note text for an event: kind:1 → its content; kind 6/16 reposts →
   // the embedded original event's content (a repost's content field is that event's
@@ -11674,9 +11765,10 @@
       if (data.memo) box.append(row('Memo', String(data.memo)));
     } else if (data.method === 'signEvent') {
       const ev = (data.params && (data.params.event || data.params)) || {};
-      box.append(row('Kind', approvalKindLabel(ev.kind)));
+      const unreadable = approvalKindUnreadable(ev);
+      box.append(row('Kind', unreadable ? 'Unreadable' : approvalKindLabel(ev.kind)));
       if (Array.isArray(ev.tags)) box.append(row('Tags', String(ev.tags.length)));
-      const warning = approvalKindWarning(ev.kind);
+      const warning = unreadable ? APPROVAL_UNREADABLE_WARNING : approvalKindWarning(ev.kind);
       if (warning) box.append(h('div', { className: 'kind-warn', textContent: warning }));
       // Destructive replaceable overwrite (see replaceable-baseline.js) — louder than
       // the kind warning above, because this one is about losing data you already have.
@@ -11719,7 +11811,9 @@
           ])
         );
       }
-      if (ev.content) appendEventContent(box, ev);
+      // Unreadable: show the payload even with no content field, because the JSON view
+      // is then the only description of what's being signed.
+      if (ev.content || unreadable) appendEventContent(box, ev);
     } else if (data.method === 'nip04.decrypt' || data.method === 'nip44.decrypt') {
       box.append(peerRow('From', data.params && data.params.pubkey));
     } else if (data.method === 'nip04.encrypt' || data.method === 'nip44.encrypt') {

--- a/test/approval-kind-isolation.test.js
+++ b/test/approval-kind-isolation.test.js
@@ -1,0 +1,156 @@
+'use strict';
+
+// A NIP-19 event reference in a note body describes the REFERENCED event. It must never
+// replace the kind of the outer event being approved for signing.
+//
+// Reported as: posting a kind:1 note whose body carried an `nevent` showed an
+// unrecognized event kind on the approval screen. The first version of this test used
+// the reference from the report — which decodes to kind 1 itself — and asserted that a
+// kind:1 event labels as "1 — Note". That can't fail: if Sidecar DID substitute the
+// referenced kind, the label would read "1 — Note" either way. The fixtures below carry
+// a referenced kind that is deliberately NOT the outer kind, so a leak would show up as
+// a wrong label instead of hiding behind a matching one.
+//
+// Both approval surfaces are covered, because there are two: the side panel's own card
+// (sidepanel.js) and the standalone popup window (prompt.js). They keep separate copies
+// of the kind tables, so the last test here pins them to each other — a kind that
+// labels on one surface and not the other is the same bug wearing a different hat.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const ROOT = path.join(__dirname, '..');
+
+// The reference from the report, kept as the original fixture. It decodes to kind 1.
+const REPORTED_NEVENT =
+  'nevent1qvzqqqqqqypzpmnw5yatnljuff5w47d35d87q99xddqpzlzsac4xzn6vm22ekmn5qyt8wumn8ghj7mn0wd68yetvd96x2uewdaexwtcpzamhxue69uhhyetvv9ujuct60fsk6mewdejhgtcqyqqqpewddujmzj23fcfpaeygep2xl763u6r6n86ktwmcksalm0n4wxy2yhr';
+
+// The two approval surfaces, and the names each gives the same four things.
+const SURFACES = [
+  {
+    file: 'sidepanel.js',
+    labels: 'APPROVAL_KIND_LABELS',
+    warnings: 'APPROVAL_KIND_WARNINGS',
+    labelFn: 'approvalKindLabel',
+    warningFn: 'approvalKindWarning',
+    unreadableFn: 'approvalKindUnreadable',
+    unreadableWarning: 'APPROVAL_UNREADABLE_WARNING',
+  },
+  {
+    file: 'prompt.js',
+    labels: 'KIND_LABELS',
+    warnings: 'KIND_WARNINGS',
+    labelFn: 'kindLabel',
+    warningFn: 'kindWarning',
+    unreadableFn: 'kindUnreadable',
+    unreadableWarning: 'UNREADABLE_WARNING',
+  },
+];
+
+function approvalKindFns(s) {
+  const source = fs.readFileSync(path.join(ROOT, s.file), 'utf8');
+  const grab = (re, what) => {
+    const m = source.match(re);
+    if (!m) throw new Error('Could not lift ' + what + ' from ' + s.file);
+    return m[0];
+  };
+  const context = {};
+  vm.createContext(context);
+  vm.runInContext(
+    [
+      grab(new RegExp('const ' + s.labels + ' = \\{[\\s\\S]*?\\n  \\};'), s.labels),
+      grab(new RegExp('const ' + s.warnings + ' = \\{[\\s\\S]*?\\n  \\};'), s.warnings),
+      grab(new RegExp('function ' + s.labelFn + '\\(kind\\) \\{[\\s\\S]*?\\n  \\}'), s.labelFn),
+      grab(new RegExp('function ' + s.warningFn + '\\(kind\\) \\{[\\s\\S]*?\\n  \\}'), s.warningFn),
+      grab(new RegExp('function ' + s.unreadableFn + '\\(ev\\) \\{[\\s\\S]*?\\n  \\}'), s.unreadableFn),
+      grab(new RegExp('const ' + s.unreadableWarning + ' =\\n?[\\s\\S]*?;'), s.unreadableWarning),
+      'globalThis.label = ' + s.labelFn + ';',
+      'globalThis.warning = ' + s.warningFn + ';',
+      'globalThis.unreadable = ' + s.unreadableFn + ';',
+      'globalThis.unreadableWarning = ' + s.unreadableWarning + ';',
+      'globalThis.labels = ' + s.labels + ';',
+      'globalThis.warnings = ' + s.warnings + ';',
+    ].join('\n'),
+    context
+  );
+  return context;
+}
+
+function nostrTools() {
+  const c = { TextEncoder, TextDecoder, Uint8Array, ArrayBuffer };
+  vm.createContext(c);
+  vm.runInContext(fs.readFileSync(path.join(ROOT, 'nostr-tools.js'), 'utf8'), c);
+  return c.NostrTools;
+}
+const NT = nostrTools();
+
+// A kind:1 note quoting a LONG-FORM ARTICLE (kind 30023). Outer kind and referenced
+// kind now differ, which is the whole point.
+const ARTICLE_NEVENT = NT.nip19.neventEncode({
+  id: 'b'.repeat(64),
+  author: 'c'.repeat(64),
+  kind: 30023,
+  relays: ['wss://relay.example.com/'],
+});
+
+test('the fixtures really do carry the kinds these tests assume', () => {
+  assert.equal(NT.nip19.decode(REPORTED_NEVENT).data.kind, 1);
+  assert.equal(NT.nip19.decode(ARTICLE_NEVENT).data.kind, 30023);
+});
+
+test('a body reference cannot change the kind of the event being signed', () => {
+  const events = [
+    // The reported case, kept verbatim.
+    { kind: 1, tags: [], content: 'Replying to nostr:' + REPORTED_NEVENT },
+    // The case that can actually catch a leak: if the referenced kind ever reached the
+    // label, this would read "30023 — Long-form article".
+    { kind: 1, tags: [], content: 'Worth reading: nostr:' + ARTICLE_NEVENT },
+    // And the inverse — an article whose body quotes a note must stay an article.
+    { kind: 30023, tags: [['d', 'my-post']], content: 'As I said in nostr:' + REPORTED_NEVENT },
+  ];
+  const expected = { 1: '1 — Note', 30023: '30023 — Long-form article' };
+  for (const s of SURFACES) {
+    const { label, warning } = approvalKindFns(s);
+    for (const ev of events) {
+      assert.equal(label(ev.kind), expected[ev.kind], s.file + ' must label the OUTER event');
+      assert.equal(warning(ev.kind), null, s.file + ' must not warn about an unknown kind');
+    }
+  }
+});
+
+test('an event with no readable kind is called out, not shown as a blank row', () => {
+  // The shapes normalizeSignEventParams now rejects at the RPC boundary. If one ever
+  // reaches a prompt again, the card has to say so — the old behavior was a "Kind —"
+  // row with Allow looking as ordinary as ever.
+  for (const s of SURFACES) {
+    const { unreadable, unreadableWarning, label } = approvalKindFns(s);
+    for (const ev of [{}, { kind: null }, { kind: '1' }, { kind: 1.5 }, 'a json string', undefined]) {
+      assert.equal(unreadable(ev), true, s.file + ': ' + JSON.stringify(ev) + ' is not a readable event');
+    }
+    assert.equal(unreadable({ kind: 1 }), false);
+    assert.equal(unreadable({ kind: 30023 }), false);
+    assert.match(unreadableWarning, /can't read this request/);
+    // The label helper still has its own null answer; the surfaces just don't rely on
+    // it to carry the warning any more.
+    assert.equal(label(null), '—');
+  }
+});
+
+test('both approval surfaces know exactly the same kinds', () => {
+  // Two copies of the tables, one per surface. A kind added to one and not the other
+  // means the same event reads as "unrecognized" in the panel and named in the popup
+  // (or the reverse), which is how a "wrong kind" report gets filed in the first place.
+  const [panel, popup] = SURFACES.map(approvalKindFns);
+  assert.deepEqual(Object.keys(panel.labels).sort(), Object.keys(popup.labels).sort());
+  for (const k of Object.keys(panel.labels)) {
+    assert.equal(panel.labels[k], popup.labels[k], 'kind ' + k + ' must read the same on both surfaces');
+  }
+  assert.deepEqual(Object.keys(panel.warnings).sort(), Object.keys(popup.warnings).sort());
+  for (const k of Object.keys(panel.warnings)) {
+    assert.equal(panel.warnings[k], popup.warnings[k], 'kind ' + k + "'s warning must read the same on both surfaces");
+  }
+  assert.equal(panel.unreadableWarning, popup.unreadableWarning);
+});

--- a/test/quote-tags.test.js
+++ b/test/quote-tags.test.js
@@ -1,0 +1,111 @@
+'use strict';
+
+// Unit coverage for quoteTags in sidepanel.js — the NIP-18 `q` tags the composer
+// derives from a note's body.
+//
+// Why it exists: a bech32 reference pasted into the composer used to go out as nothing
+// but text. The note was a quote in the writer's head and a 210-character string in
+// everyone else's client: nothing rendered the quoted event, and the quoted author was
+// never notified. Sidecar's own notification list keys "quoted your note" off exactly
+// this tag (notificationKind's hasQ), so a quote composed in Sidecar didn't read as a
+// quote in Sidecar either.
+//
+// note/nevent quote by event id. naddr quotes by "kind:pubkey:d" coordinate, because an
+// addressable event's id changes every time its author edits it.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const ROOT = path.join(__dirname, '..');
+const source = fs.readFileSync(path.join(ROOT, 'sidepanel.js'), 'utf8');
+function lift(pattern, label) {
+  const m = source.match(pattern);
+  if (!m) throw new Error('Could not find ' + label + ' in sidepanel.js');
+  return m[0];
+}
+
+// The real vendored nip19, not a stub — these tags are only as correct as the decode.
+const ntCtx = { TextEncoder, TextDecoder, Uint8Array, ArrayBuffer };
+vm.createContext(ntCtx);
+vm.runInContext(fs.readFileSync(path.join(ROOT, 'nostr-tools.js'), 'utf8'), ntCtx);
+const NT = ntCtx.NostrTools;
+
+const ctx = { NT };
+vm.createContext(ctx);
+vm.runInContext(
+  lift(/const BODY_REF_RE = [^;]+;/, 'BODY_REF_RE') + '\n' +
+    lift(/function quoteTags\(content\) \{[\s\S]*?\n  \}/, 'quoteTags') + '\n' +
+    lift(/function mentionPTags\(content\) \{[\s\S]*?\n  \}/, 'mentionPTags') + '\n' +
+    'globalThis.quoteTags = quoteTags; globalThis.mentionPTags = mentionPTags;',
+  ctx
+);
+const quoteTags = (s) => JSON.parse(JSON.stringify(ctx.quoteTags(s)));
+const mentionPTags = (s) => JSON.parse(JSON.stringify(ctx.mentionPTags(s)));
+
+const ID_A = 'a'.repeat(64);
+const ID_B = 'b'.repeat(64);
+const PK_A = 'c'.repeat(64);
+const PK_B = 'd'.repeat(64);
+const RELAY = 'wss://relay.example.com/';
+
+const NOTE_REF = NT.nip19.noteEncode(ID_A);
+const NEVENT_REF = NT.nip19.neventEncode({ id: ID_B, author: PK_A, kind: 1, relays: [RELAY] });
+const NEVENT_BARE = NT.nip19.neventEncode({ id: ID_B });
+const NADDR_REF = NT.nip19.naddrEncode({ identifier: 'my-post', pubkey: PK_B, kind: 30023, relays: [RELAY] });
+
+test('a plain note gets no quote tags', () => {
+  assert.deepEqual(quoteTags('just words, no refs'), { tags: [], authors: [] });
+});
+
+test('a note1 reference quotes by id', () => {
+  assert.deepEqual(quoteTags('look at nostr:' + NOTE_REF), { tags: [['q', ID_A]], authors: [] });
+});
+
+test('an nevent reference carries its relay hint and author', () => {
+  // Positional tag: the author can only be given if the relay slot is filled.
+  assert.deepEqual(quoteTags('see nostr:' + NEVENT_REF), {
+    tags: [['q', ID_B, RELAY, PK_A]],
+    authors: [PK_A],
+  });
+});
+
+test('an nevent with no hints still quotes by id', () => {
+  assert.deepEqual(quoteTags('see nostr:' + NEVENT_BARE), { tags: [['q', ID_B]], authors: [] });
+});
+
+test('an naddr quotes by coordinate, not by id', () => {
+  assert.deepEqual(quoteTags('read nostr:' + NADDR_REF), {
+    tags: [['q', '30023:' + PK_B + ':my-post', RELAY, PK_B]],
+    authors: [PK_B],
+  });
+});
+
+test('several references all get tagged, once each', () => {
+  const text = 'nostr:' + NOTE_REF + ' and nostr:' + NEVENT_REF + ' and nostr:' + NOTE_REF + ' again';
+  const { tags } = quoteTags(text);
+  assert.deepEqual(tags, [['q', ID_A], ['q', ID_B, RELAY, PK_A]]);
+});
+
+test('a malformed reference is skipped, not thrown', () => {
+  // Same rule as mentionPTags: a bad paste must not cost the user their draft.
+  const { tags } = quoteTags('nostr:nevent1' + 'q'.repeat(60) + ' plus nostr:' + NOTE_REF);
+  assert.deepEqual(tags, [['q', ID_A]]);
+});
+
+test('profile mentions are not quote tags, and quotes are not mentions', () => {
+  // The two helpers read the same body and must not poach each other's refs — a `q`
+  // for an npub would be meaningless, and a `p` is not how a quote is expressed.
+  const npub = NT.nip19.npubEncode(PK_A);
+  assert.deepEqual(quoteTags('hi nostr:' + npub), { tags: [], authors: [] });
+  assert.deepEqual(mentionPTags('see nostr:' + NEVENT_REF), []);
+});
+
+test('the quoted author is offered for a p tag, which is what notifies them', () => {
+  // doPublish p-tags quoteTags().authors on top of mentionPTags — that is the whole
+  // reason authors is returned separately from tags.
+  const { authors } = quoteTags('nostr:' + NEVENT_REF + ' nostr:' + NADDR_REF);
+  assert.deepEqual(authors, [PK_A, PK_B]);
+});

--- a/test/sign-event-shape.test.js
+++ b/test/sign-event-shape.test.js
@@ -1,0 +1,269 @@
+'use strict';
+
+// Unit coverage for normalizeSignEventParams in background.js — the shape gate in
+// front of every page signEvent.
+//
+// Why it exists: NIP-07's signEvent takes an event template, and pages get that wrong.
+// Before the gate, a page that sent the event as a JSON string, positionally in an
+// array, or not at all got an approval card reading "Kind —" with no tag count and no
+// content preview — nothing on screen to judge — and then, AFTER the user approved,
+// nostr-tools threw "can't serialize event with wrong or missing properties" from
+// inside the signer. The site showed an opaque failure and the user posted from
+// another client instead.
+//
+// Two properties are asserted here, and they pull in opposite directions on purpose:
+//
+//   1. Liberal where the intent is unambiguous — a JSON-string event, a numeric-string
+//      kind, absent tags/content/created_at. These now sign instead of dead-ending.
+//   2. Strict where it isn't — throw BEFORE anything is queued, prompted, or signed,
+//      with a message the page can show. A prompt that can't say what it's signing is
+//      worse than a refusal.
+//
+// The string-kind case is the quiet one, and the reason coercion happens at this single
+// point rather than at each use: kind "1" LABELS correctly by accident (object keys
+// stringify) while failing every identity/Set check downstream — COALESCE_KINDS.has,
+// RELAX.neverRelaxes, the 9734 zap test, isNip42AuthEvent's 22242, and BASELINE's
+// TRACKED.has. That last one is the destructive-overwrite guard, so a kind:"3"
+// follow-list wipe would skip its warning. The final test below pins that.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const ROOT = path.join(__dirname, '..');
+const source = fs.readFileSync(path.join(ROOT, 'background.js'), 'utf8');
+function lift(pattern, label) {
+  const m = source.match(pattern);
+  if (!m) throw new Error('Could not find ' + label + ' in background.js');
+  return m[0];
+}
+
+const ctx = {};
+vm.createContext(ctx);
+vm.runInContext(
+  lift(/function normalizeTagValue\(v\) \{[\s\S]*?\n\}/, 'normalizeTagValue') + '\n' +
+    lift(/function normalizeSignEventParams\(params\) \{[\s\S]*?\n\}/, 'normalizeSignEventParams') + '\n' +
+    lift(/function describeSignEventShape\(params\) \{[\s\S]*?\n\}/, 'describeSignEventShape') + '\n' +
+    // The real kind gates, lifted rather than mirrored — a local copy would drift and
+    // these tests would keep passing against the wrong sets.
+    lift(/const COALESCE_KINDS = new Set\([\s\S]*?\);/, 'COALESCE_KINDS') + '\n' +
+    lift(/function isNip42AuthEvent\(ev\) \{[\s\S]*?\n\}/, 'isNip42AuthEvent') + '\n' +
+    lift(/const NIP42_MAX_CLOCK_SKEW = \d+;/, 'NIP42_MAX_CLOCK_SKEW') + '\n' +
+    'globalThis.normalize = normalizeSignEventParams;' +
+    'globalThis.describe = describeSignEventShape;' +
+    'globalThis.COALESCE_KINDS = COALESCE_KINDS;' +
+    'globalThis.isNip42AuthEvent = isNip42AuthEvent;',
+  ctx
+);
+const normalize = ctx.normalize;
+const describe = ctx.describe;
+
+// The real vendored signer, so "this now signs" means nostr-tools actually accepts it
+// rather than that our own validator is self-consistent. It runs in its own context and
+// its validateEvent gates on `instanceof Object`, which is realm-bound — so the event
+// has to be re-parsed INSIDE that context or every shape "fails" for the wrong reason.
+const ntCtx = { TextEncoder, TextDecoder, Uint8Array, ArrayBuffer, crypto: require('node:crypto').webcrypto };
+vm.createContext(ntCtx);
+vm.runInContext(fs.readFileSync(path.join(ROOT, 'nostr-tools.js'), 'utf8'), ntCtx);
+vm.runInContext(
+  'globalThis.__sk = NostrTools.generateSecretKey();' +
+    'globalThis.signsAndVerifies = (json) => {' +
+    '  const signed = NostrTools.finalizeEvent(JSON.parse(json), globalThis.__sk);' +
+    '  return NostrTools.verifyEvent(signed);' +
+    '};',
+  ntCtx
+);
+const signsAndVerifies = (event) => ntCtx.signsAndVerifies(JSON.stringify(event));
+
+// Same realm boundary, for assertions: normalize() returns an object built in the
+// background.js context, and assert/strict compares prototypes.
+const plain = (o) => JSON.parse(JSON.stringify(o));
+
+const NOTE = { kind: 1, created_at: 1700000000, tags: [['t', 'sidecar']], content: 'hello' };
+
+// ---- accepted shapes ---------------------------------------------------------
+
+test('the canonical NIP-07 shape passes through unchanged', () => {
+  const { event } = normalize({ event: NOTE });
+  assert.deepEqual(plain(event), NOTE);
+});
+
+test('an event sent as params itself (no .event wrapper) is accepted', () => {
+  const { event } = normalize(NOTE);
+  assert.equal(event.kind, 1);
+  assert.equal(event.content, 'hello');
+});
+
+test('an event sent as a JSON string is parsed, not rejected', () => {
+  // The NIP-46 shape (params is [json]) leaking into a NIP-07 call. Used to reach the
+  // signer as a string and throw "signEvent: missing event" after approval.
+  const { event } = normalize({ event: JSON.stringify(NOTE) });
+  assert.deepEqual(plain(event), NOTE);
+});
+
+test('a numeric-string kind is coerced to a number', () => {
+  const { event } = normalize({ event: { ...NOTE, kind: '1' } });
+  assert.equal(event.kind, 1);
+  assert.equal(typeof event.kind, 'number');
+});
+
+test('absent tags, content, and created_at are filled', () => {
+  const { event } = normalize({ event: { kind: 1 } });
+  assert.deepEqual(plain(event.tags), []);
+  assert.equal(event.content, '');
+  assert.equal(typeof event.created_at, 'number');
+  assert.ok(Math.abs(Math.floor(Date.now() / 1000) - event.created_at) < 5);
+});
+
+test('a supplied created_at is never overwritten', () => {
+  // A client backdating an event means it; only an ABSENT timestamp gets stamped.
+  const { event } = normalize({ event: { ...NOTE, created_at: 1600000000 } });
+  assert.equal(event.created_at, 1600000000);
+});
+
+test('a client-stamped author pubkey survives normalization', () => {
+  // applesauce clients name the intended author on the template, and handleNostrRpc
+  // reads it to honor the account the client asked for. Dropping it would silently
+  // re-route the signature to the site binding.
+  const pk = 'a'.repeat(64);
+  const { event } = normalize({ event: { ...NOTE, pubkey: pk } });
+  assert.equal(event.pubkey, pk);
+});
+
+test('non-string tag values are coerced rather than dead-ending the post', () => {
+  const { event } = normalize({ event: { ...NOTE, tags: [['amount', 21000], ['p', 'x', null], ['ok', true]] } });
+  assert.deepEqual(plain(event.tags), [['amount', '21000'], ['p', 'x', ''], ['ok', 'true']]);
+});
+
+test('every accepted shape produces an event nostr-tools will actually sign', () => {
+  for (const params of [
+    { event: NOTE },
+    NOTE,
+    { event: JSON.stringify(NOTE) },
+    { event: { ...NOTE, kind: '1' } },
+    { event: { kind: 1 } },
+    { event: { ...NOTE, tags: [['amount', 21000]] } },
+  ]) {
+    const { event } = normalize(params);
+    assert.equal(signsAndVerifies(event), true, JSON.stringify(params).slice(0, 60));
+  }
+});
+
+// ---- rejected shapes ---------------------------------------------------------
+// Each of these used to reach a prompt showing "Kind —" and then crash in the signer.
+
+test('unreadable payloads are rejected before anything is queued', () => {
+  const cases = [
+    [undefined, /expected an event object/],
+    [{}, /kind must be a non-negative integer/],
+    // params.event null falls back to params itself — an object with no kind.
+    [{ event: null }, /kind must be a non-negative integer/],
+    [[NOTE], /expected an event object/], // positional args
+    [{ event: [NOTE] }, /expected an event object/],
+    [{ event: 'not json at all' }, /isn't valid JSON/],
+    [{ event: { ...NOTE, kind: 'note' } }, /kind must be a non-negative integer/],
+    [{ event: { ...NOTE, kind: 1.5 } }, /kind must be a non-negative integer/],
+    [{ event: { ...NOTE, kind: -1 } }, /kind must be a non-negative integer/],
+    [{ event: { ...NOTE, tags: 'nope' } }, /tags must be an array/],
+    [{ event: { ...NOTE, tags: ['e', 'id'] } }, /every entry in event.tags must be an array/],
+    [{ event: { ...NOTE, tags: [['e', { id: 1 }]] } }, /tag values must be strings/],
+    [{ event: { ...NOTE, content: { text: 'hi' } } }, /content must be a string/],
+    [{ event: { ...NOTE, created_at: 'now' } }, /created_at must be a Unix timestamp/],
+  ];
+  for (const [params, re] of cases) {
+    assert.throws(() => normalize(params), re, 'should reject ' + JSON.stringify(params));
+  }
+});
+
+test('a rejection message names signEvent, so the page can show it verbatim', () => {
+  // It surfaces through handleNostrRpc's catch as the page promise's rejection.
+  for (const params of [undefined, {}, { event: 'x' }]) {
+    try {
+      normalize(params);
+      assert.fail('expected a throw');
+    } catch (e) {
+      assert.match(e.message, /^signEvent: /);
+    }
+  }
+});
+
+// ---- the shape fingerprint recorded on a refusal -----------------------------
+// A refusal used to leave no trace at all: the page got the error and Sidecar
+// remembered nothing, which is why the original report arrived with no payload to look
+// at. handleNostrRpc now writes this fingerprint to Activity before rethrowing.
+
+test('the fingerprint says which mistake the client made', () => {
+  assert.deepEqual(plain(describe(undefined)), { params: 'missing', event: 'missing' });
+  assert.deepEqual(plain(describe([NOTE])), { params: 'array', event: 'missing' });
+  assert.deepEqual(plain(describe({ event: 'some string' })), { params: 'object', event: 'string' });
+  assert.deepEqual(plain(describe({ event: [NOTE] })), { params: 'object', event: 'array' });
+  assert.deepEqual(plain(describe({ event: { ...NOTE, kind: 'note' } })), {
+    params: 'object',
+    event: 'object',
+    kind: 'string',
+    tags: 'array',
+    content: 'string',
+    created_at: 'number',
+    kindValue: 'note', // a bare kind identifies nobody, and it's the most useful field
+  });
+  assert.deepEqual(plain(describe({ event: { kind: 1.5 } })), {
+    params: 'object',
+    event: 'object',
+    kind: 'number',
+    tags: 'missing',
+    content: 'missing',
+    created_at: 'missing',
+    kindValue: 1.5,
+  });
+});
+
+test('the fingerprint keeps nothing from the payload it refused', () => {
+  // We declined to sign this. Keeping a copy of the content, the tag values, or the
+  // author's key would be the wrong trade for a diagnostic.
+  const secrets = ['s3cret-content', 'e-tag-value', 'f'.repeat(64), 'wss://private.relay'];
+  const fingerprint = JSON.stringify(
+    plain(
+      describe({
+        event: {
+          kind: 'nope',
+          content: secrets[0],
+          tags: [['e', secrets[1]], ['relay', secrets[3]]],
+          pubkey: secrets[2],
+          created_at: 1700000000,
+        },
+      })
+    )
+  );
+  for (const s of secrets) assert.equal(fingerprint.includes(s), false, 'leaked ' + s);
+  // Long junk in the kind field is dropped too, rather than logged verbatim.
+  assert.equal('kindValue' in plain(describe({ event: { kind: 'x'.repeat(400) } })), false);
+});
+
+// ---- what the coercion protects ---------------------------------------------
+
+test('a string kind reaches the kind gates as a number', () => {
+  // Before normalization these all took the wrong branch on a string kind, silently:
+  // a kind:"3" wipe skipped the destructive-overwrite warning, and a kind:"22242"
+  // relay auth lost its exemption.
+  // The real destructive-overwrite guard, loaded as the module it is.
+  const bctx = { console };
+  vm.createContext(bctx);
+  vm.runInContext(fs.readFileSync(path.join(ROOT, 'replaceable-baseline.js'), 'utf8'), bctx);
+  const isTracked = bctx.SidecarBaseline.isTracked;
+
+  assert.equal(COALESCE_HAS('30078'), false, 'a raw string kind misses COALESCE_KINDS');
+  assert.equal(COALESCE_HAS(normalize({ event: { kind: '30078' } }).event.kind), true);
+
+  assert.equal(isTracked('3'), false, 'a raw string kind misses the baseline guard');
+  assert.equal(isTracked(normalize({ event: { kind: '3' } }).event.kind), true);
+
+  const auth = { kind: '22242', created_at: Math.floor(Date.now() / 1000), tags: [['relay', 'wss://r'], ['challenge', 'c']], content: '' };
+  assert.equal(ctx.isNip42AuthEvent(auth), false, 'a raw string kind is not recognized as relay auth');
+  assert.equal(ctx.isNip42AuthEvent(normalize({ event: auth }).event), true);
+});
+
+function COALESCE_HAS(kind) {
+  return ctx.COALESCE_KINDS.has(kind);
+}


### PR DESCRIPTION
Two fixes from investigating a report that signing a kind-1 note with an nevent in the body showed an unrecognized event kind, plus a wording change.

The nevent wasn't the cause and couldn't have been — nothing derives the approval kind from the body (the only decoded NIP-19 kind anywhere goes into a relay filter for an embed card), and both surfaces' kind tables are identical and both contain kind 1. The regression test filed with the report couldn't fail either: its reference decodes to kind 1, so "a kind:1 event labels as a note" held whether or not the referenced kind leaked.

What can produce the report is a payload shape we never validated. A page that sent the event as a JSON string, positionally in an array, or not at all got an approval card reading "Kind —" with no tag count and no content preview, and then, after the user approved, nostr-tools threw "can't serialize event with wrong or missing properties" from inside the signer — an opaque failure, and a reason to go post from another client.

- `normalizeSignEventParams` settles the shape at the RPC boundary, before the queue, the prompt, and the key. Liberal where the intent is unambiguous (JSON-string event, numeric-string kind, absent tags/content/created_at, non-string tag values); throws a `signEvent: …` error the page can show where it isn't. The normalized event is what gets queued, previewed, and signed, so the card and the signature can't describe different events.
- A string kind was the quiet hazard: it labels correctly by accident while failing every downstream identity check — `COALESCE_KINDS.has`, `RELAX.neverRelaxes`, the 9734 zap test, `isNip42AuthEvent`, and `BASELINE`'s `TRACKED.has`. That last one is the destructive-overwrite guard, so a `kind:"3"` follow-list wipe skipped its warning.
- Both approval surfaces now label an unreadable event Unreadable, warn, and open the JSON view instead of showing a bare "—" with Allow looking as ordinary as ever. Unreachable after the gate, kept because what it replaces was a blind approval.
- A refusal records itself: Activity gets a rejected entry with the host, the reason, and a shape fingerprint (types and structure only — no content, tag values, or pubkeys). A refusal previously left no trace on a store build, which is why the first report arrived with no payload.
- Separately, confirmed by reading the code rather than from the report: the composer couldn't quote. `doPublish` tagged only the client tag and p tags from npub mentions, so a `nostr:nevent` pasted into it went out as plain text — no client rendered the quote, the quoted author was never notified, and Sidecar's own "quoted your note" notification keys off exactly that tag. It now derives `q` tags.
- Also included: Profile's "Backup & restore" renamed to "Data backup". The old heading covered both the relay-stored data records and the key export below them, so it read as the name for both. The key export keeps its own heading.

Suite: 477 tests, 475 pass, two pre-existing `nostr-tools` module failures. Rebased onto main after the 1.9.1 hotfix.

🍸 Shaken with [Claude Code](https://claude.com/claude-code)
