### PR TITLE
Send: resolve a lightning address before asking for an amount

### DIFF
--- a/sidepanel.js
+++ b/sidepanel.js
@@ -10873,12 +10873,121 @@
       const cancel = h('button', { className: 'ghost', textContent: 'Cancel' });
       cancel.addEventListener('click', closeModal);
 
+      // The recipient card: who the address resolved to, and on what terms.
+      const card = h('div', { className: 'ln-recipient hidden' });
+      const commentDefault = comment.placeholder;
+      let resolved = null;      // params for the address currently in the card
+      let resolveSeq = 0;       // guards against a slow lookup landing after a newer one
+      let debounce = null;
+
+      function resetCard() {
+        resolved = null;
+        card.textContent = '';
+        card.classList.add('hidden');
+        card.classList.remove('checking', 'failed');
+        comment.disabled = false;
+        comment.maxLength = 280;
+        comment.placeholder = commentDefault;
+      }
+
+      function renderCard(p) {
+        card.textContent = '';
+        card.classList.remove('hidden', 'checking', 'failed');
+        const head = h('div', { className: 'ln-recipient-head' });
+        if (p.image) {
+          head.append(h('img', { className: 'ln-recipient-avatar', src: p.image, alt: '' }));
+        }
+        const who = h('div', { className: 'ln-recipient-who' });
+        // textContent throughout — every string here came from the recipient's server.
+        who.append(h('span', { className: 'ln-recipient-name', textContent: p.identifier || p.addr }));
+        const limits = p.minSats === p.maxSats
+          ? fmtSats(p.minSats) + ' sats only'
+          : fmtSats(p.minSats) + ' to ' + fmtSats(p.maxSats) + ' sats';
+        who.append(h('span', { className: 'ln-recipient-limits', textContent: limits }));
+        head.append(who);
+        card.append(head);
+        if (p.description) {
+          card.append(h('p', { className: 'ln-recipient-desc', textContent: p.description }));
+        }
+        const tags = h('div', { className: 'ln-recipient-tags' });
+        tags.append(h('span', {
+          className: 'ln-recipient-tag',
+          textContent: p.commentAllowed ? 'Comments up to ' + p.commentAllowed : 'No comments',
+        }));
+        if (p.zappable) tags.append(h('span', { className: 'ln-recipient-tag', textContent: 'Zappable' }));
+        card.append(tags);
+
+        // Match the comment field to what this recipient will actually accept,
+        // rather than letting someone write 280 characters that get truncated or
+        // dropped without explanation.
+        if (p.commentAllowed) {
+          comment.disabled = false;
+          comment.maxLength = p.commentAllowed;
+          comment.placeholder = commentDefault;
+        } else {
+          comment.disabled = true;
+          comment.value = '';
+          comment.placeholder = 'This wallet does not accept comments';
+        }
+      }
+
+      async function lookup(addr) {
+        const seq = ++resolveSeq;
+        card.textContent = '';
+        card.classList.remove('hidden', 'failed');
+        card.classList.add('checking');
+        card.append(h('span', { className: 'ln-recipient-status', textContent: 'Checking ' + addr + '…' }));
+        try {
+          const p = await lnAddressParams(addr);
+          if (seq !== resolveSeq) return; // a newer address is being checked
+          resolved = { ...p, addr };
+          renderCard(resolved);
+        } catch (e) {
+          if (seq !== resolveSeq) return;
+          resolved = null;
+          card.textContent = '';
+          card.classList.remove('checking');
+          card.classList.add('failed');
+          // Last line of defence. Every throw above is written to be read aloud,
+          // but anything unforeseen (a parser, a platform error) would arrive
+          // here as jargon, and jargon in a payment dialog reads as a fault in
+          // Sidecar rather than a fact about the address.
+          const raw = (e && e.message) || '';
+          const speakable = raw && raw.length <= 90 && !/[{}<>]|JSON|token|undefined|TypeError/i.test(raw);
+          card.append(h('span', {
+            className: 'ln-recipient-fail-title',
+            textContent: speakable ? raw : "Couldn't check that address",
+          }));
+          card.append(h('span', {
+            className: 'ln-recipient-status',
+            textContent: 'Check the spelling, or paste an invoice instead.',
+          }));
+        }
+      }
+
       // Auto-detect: only a lightning address needs an amount (invoices carry it).
       function detect() {
         const v = input.value.replace(/^lightning:/i, '').trim();
-        const needsAmount = isLnAddress(v) && !isLnInvoice(v);
-        amount.classList.toggle('hidden', !needsAmount);
-        amountLabel.classList.toggle('hidden', !needsAmount);
+        const isAddr = isLnAddress(v) && !isLnInvoice(v);
+        amount.classList.toggle('hidden', !isAddr);
+        amountLabel.classList.toggle('hidden', !isAddr);
+
+        if (debounce) { clearTimeout(debounce); debounce = null; }
+        if (!isAddr) { resolveSeq++; resetCard(); return; }
+        if (resolved && resolved.addr === v) return; // already showing this one
+
+        resetCard();
+        // Debounced, and only once the address is complete enough to be real.
+        // Every lookup is a request to a stranger's server announcing an intent
+        // to pay them, so this must not fire on each keystroke of a half-typed
+        // domain — that would hand a trail to every typo along the way.
+        //
+        // isLnAddress is deliberately not reused for the gate: it accepts a
+        // one-character TLD, which is right for deciding whether to show the
+        // amount field and wrong for deciding whether to make a request. Pausing
+        // mid-word should not send anything to `breez.t`.
+        if (!/^[^@\s]+@[^@\s]+\.[^@\s]{2,}$/.test(v)) return;
+        debounce = setTimeout(() => lookup(v), 600);
       }
       input.addEventListener('input', detect);
 
@@ -10896,6 +11005,14 @@
           } else if (isLnAddress(val)) {
             const sats = parseInt(amount.value, 10);
             if (!sats || sats < 1) return (err.textContent = 'Enter an amount in sats.');
+            // Check against the limits we already fetched, so an out-of-range
+            // amount is caught here rather than after a round trip. The server
+            // still enforces its own at invoice time — this only saves the trip.
+            if (resolved && resolved.addr === val && (sats < resolved.minSats || sats > resolved.maxSats)) {
+              return (err.textContent = resolved.minSats === resolved.maxSats
+                ? 'This address only accepts ' + fmtSats(resolved.minSats) + ' sats.'
+                : 'Amount must be between ' + fmtSats(resolved.minSats) + ' and ' + fmtSats(resolved.maxSats) + ' sats.');
+            }
             address = val;
             pay.disabled = true;
             pay.textContent = 'Paying…';
@@ -10935,6 +11052,7 @@
       modal.append(
         h('h3', { textContent: 'Send' }),
         input,
+        card,
         amountLabel,
         amount,
         comment,
@@ -11139,12 +11257,97 @@
     });
   }
 
+  // ---- LNURL-pay resolution -------------------------------------------------
+  //
+  // Everything below the fetch is attacker-controlled: the domain owner writes
+  // the description, the identifier, the image, and the limits. It is rendered
+  // with textContent only, never markup, and every field is clamped to a size
+  // that cannot push the rest of the form off screen. A recipient does not get
+  // to redesign the send dialog.
+
+  const LN_DESC_MAX = 200;      // characters of description we will show
+  const LN_IMAGE_MAX = 200000;  // characters of base64 — roughly 150KB decoded
+
+  // Pull the human-readable parts out of LNURL-pay's `metadata`, which is a
+  // JSON-encoded array of [mimeType, value] pairs.
+  function parseLnMetadata(raw) {
+    const out = { description: '', identifier: '', image: '' };
+    let entries;
+    try { entries = JSON.parse(raw); } catch (_) { return out; }
+    if (!Array.isArray(entries)) return out;
+    for (const entry of entries) {
+      if (!Array.isArray(entry) || entry.length < 2) continue;
+      const [type, value] = entry;
+      if (typeof type !== 'string' || typeof value !== 'string') continue;
+      // Collapse whitespace: a description full of newlines would otherwise
+      // stretch the dialog to whatever height the recipient felt like.
+      if (type === 'text/plain' && !out.description) {
+        out.description = value.replace(/\s+/g, ' ').trim().slice(0, LN_DESC_MAX);
+      } else if ((type === 'text/identifier' || type === 'text/email') && !out.identifier) {
+        out.identifier = value.replace(/\s+/g, '').slice(0, 128);
+      } else if (!out.image && /^image\/(png|jpeg);base64$/.test(type) && value.length <= LN_IMAGE_MAX) {
+        // Only the two types LUD-06 defines, and only as a data: URI, so it can
+        // never become a request back to the recipient's server.
+        if (/^[A-Za-z0-9+/=]+$/.test(value)) out.image = 'data:' + type.split(';')[0] + ';base64,' + value;
+      }
+    }
+    return out;
+  }
+
+  // Fetch a lightning address's pay parameters. Separate from the invoice call
+  // so the Send form can show the recipient's terms before anyone commits to an
+  // amount — previously min/max were only discovered by having a payment
+  // rejected, after the amount was already typed.
+  async function lnAddressParams(addr) {
+    const [name, domain] = String(addr || '').split('@');
+    if (!name || !domain) throw new Error('That does not look like a lightning address');
+
+    // Each failure gets its own sentence, because they mean different things to
+    // whoever is standing there with an address they expected to work: the
+    // domain is unreachable, or it is reachable and simply has no such address,
+    // or it answered with something that is not a lightning address at all.
+    // What must never surface is the underlying parser complaining about a
+    // DOCTYPE, which is what a 404 HTML page produces and tells the user nothing.
+    let res;
+    try {
+      res = await fetch('https://' + domain + '/.well-known/lnurlp/' + name);
+    } catch (_) {
+      throw new Error("Couldn't reach " + domain);
+    }
+    if (!res.ok) throw new Error(domain + ' has no lightning address for ' + name);
+    let meta;
+    try {
+      meta = await res.json();
+    } catch (_) {
+      // A web page where a lightning address should be. Same thing, from the
+      // user's side, as the address not existing.
+      throw new Error(domain + ' has no lightning address for ' + name);
+    }
+    if (!meta || meta.tag !== 'payRequest' || !meta.callback) {
+      throw new Error(domain + ' answered, but not with a lightning address');
+    }
+    const minMsat = Number(meta.minSendable);
+    const maxMsat = Number(meta.maxSendable);
+    if (!Number.isFinite(minMsat) || !Number.isFinite(maxMsat) || minMsat < 0 || maxMsat < minMsat) {
+      throw new Error(domain + ' returned payment limits that make no sense');
+    }
+    const comment = Number(meta.commentAllowed);
+    return {
+      meta,
+      minSats: Math.ceil(minMsat / 1000),
+      maxSats: Math.floor(maxMsat / 1000),
+      commentAllowed: Number.isFinite(comment) && comment > 0 ? Math.min(comment, 1000) : 0,
+      zappable: !!(meta.allowsNostr && meta.nostrPubkey),
+      ...parseLnMetadata(meta.metadata),
+    };
+  }
+
   // Resolve a lightning address (user@domain) to a BOLT11 invoice via LNURL-pay.
   async function lnAddressToInvoice(addr, msats, comment) {
-    const [name, domain] = addr.split('@');
-    if (!name || !domain) throw new Error('Invalid lightning address');
-    const meta = await (await fetch('https://' + domain + '/.well-known/lnurlp/' + name)).json();
-    if (meta.tag !== 'payRequest' || !meta.callback) throw new Error('Not a valid lightning address');
+    // Re-fetched rather than reusing whatever the form previewed: the preview
+    // may be minutes old, and the limits it showed are not the ones that will be
+    // enforced. The server's answer at payment time is the only one that counts.
+    const { meta } = await lnAddressParams(addr);
     if (msats < meta.minSendable || msats > meta.maxSendable) {
       throw new Error('Amount must be ' + Math.ceil(meta.minSendable / 1000) + '–' + Math.floor(meta.maxSendable / 1000) + ' sats');
     }

--- a/styles.css
+++ b/styles.css
@@ -2078,6 +2078,51 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
 .tx-d-val.copyable:hover { color: var(--lav); }
 .tx-d-val.copied { color: var(--success); }
 .send-comment { width: 100%; margin-top: 8px; }
+.send-comment:disabled { opacity: 0.5; cursor: not-allowed; }
+
+/* Recipient card in the Send form — what a lightning address resolved to, and
+   on what terms. Every string in here is written by the recipient's server, so
+   the box is fixed-width with wrapping and clamped text: it reports, it does not
+   get to lay out the dialog. */
+.ln-recipient {
+  margin-top: 8px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: rgba(var(--border-rgb), 0.08);
+}
+.ln-recipient.checking { border-style: dashed; }
+.ln-recipient-status { color: var(--muted); font-size: 12px; overflow-wrap: anywhere; }
+/* A failed lookup states the fact on the first line and what to do on the
+   second, quieter one. The failure is usually the address being wrong, not
+   anything alarming, so it stays legible rather than shouting in red. */
+.ln-recipient.failed { border-color: var(--border-strong); }
+.ln-recipient-fail-title {
+  display: block; color: var(--text); font-size: 13px; margin-bottom: 3px;
+  overflow-wrap: anywhere;
+}
+.ln-recipient.failed .ln-recipient-status { color: var(--muted); }
+.ln-recipient-head { display: flex; align-items: center; gap: 10px; }
+.ln-recipient-avatar {
+  width: 32px; height: 32px; flex: 0 0 32px;
+  border-radius: 50%; object-fit: cover; background: var(--velvet-2);
+}
+.ln-recipient-who { display: flex; flex-direction: column; min-width: 0; }
+.ln-recipient-name {
+  color: var(--text); font-size: 13px; font-weight: 600;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.ln-recipient-limits { color: var(--gold); font-size: 12px; font-family: var(--font-mono); }
+.ln-recipient-desc {
+  color: var(--muted); font-size: 12px; line-height: 1.5; margin: 8px 0 0;
+  overflow-wrap: anywhere;
+  display: -webkit-box; -webkit-box-orient: vertical; -webkit-line-clamp: 3; overflow: hidden;
+}
+.ln-recipient-tags { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; }
+.ln-recipient-tag {
+  color: var(--muted); font-size: 11px;
+  border: 1px solid var(--border); border-radius: 999px; padding: 2px 8px;
+}
 .recv-out { display: flex; flex-direction: column; align-items: center; gap: 12px; margin-top: 16px; }
 .recv-qr { background: #fff; border-radius: 12px; padding: 10px; width: 220px; height: 220px; }
 .modal-qr { display: block; margin: 4px auto 2px; }

--- a/test/ln-recipient.test.js
+++ b/test/ln-recipient.test.js
@@ -1,0 +1,312 @@
+'use strict';
+
+// LNURL-pay recipient resolution for the Send form.
+//
+// Typing a lightning address now resolves it before you commit to an amount, so
+// the form can show who it reached, what they say, and what they will accept.
+// Previously the limits were only discovered by having a payment rejected.
+//
+// Everything these functions parse is written by whoever runs the recipient's
+// domain: the description, the identifier, the image, the limits. So the tests
+// that matter most are the hostile ones — a description that tries to be a
+// kilometre long, an image that is not an image, limits that are backwards or
+// missing, metadata that is not even JSON. The rule being pinned is that a
+// recipient reports, and never gets to reshape the dialog or smuggle markup
+// into it.
+
+const { test, before } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const ROOT = path.join(__dirname, '..');
+const source = fs.readFileSync(path.join(ROOT, 'sidepanel.js'), 'utf8');
+
+function lift(pattern, label) {
+  const m = source.match(pattern);
+  if (!m) throw new Error('Could not find ' + label + ' in sidepanel.js');
+  return m[0];
+}
+
+let ctx;
+
+before(() => {
+  ctx = {
+    console,
+    LN_DESC_MAX: 200,
+    LN_IMAGE_MAX: 200000,
+    fetchResult: null,
+    // The one network call, stubbed. Returns whatever the test planted.
+    // Mirrors the real Response shape closely enough to exercise the failure
+    // branches: a status, and a json() that can itself reject the way a
+    // 404 HTML page does.
+    fetchOk: true,
+    fetchThrows: false,
+    jsonThrows: false,
+    fetch: async () => {
+      if (ctx.fetchThrows) throw new TypeError('Failed to fetch');
+      return {
+        ok: ctx.fetchOk,
+        json: async () => {
+          if (ctx.jsonThrows) throw new SyntaxError('Unexpected token \'<\'');
+          return ctx.fetchResult;
+        },
+      };
+    },
+  };
+  vm.createContext(ctx);
+  vm.runInContext(
+    lift(/const LN_DESC_MAX = [\s\S]*?const LN_IMAGE_MAX = \d+;/, 'the clamp constants') + '\n' +
+      lift(/function parseLnMetadata\(raw\) \{[\s\S]*?\n  \}/, 'parseLnMetadata') + '\n' +
+      lift(/async function lnAddressParams\(addr\) \{[\s\S]*?\n  \}/, 'lnAddressParams') + '\n' +
+      'globalThis.parseLnMetadata = parseLnMetadata;' +
+      'globalThis.lnAddressParams = lnAddressParams;',
+    ctx
+  );
+});
+
+const meta = (entries) => JSON.stringify(entries);
+
+// ---- metadata parsing ----
+
+test('pulls the description, identifier, and image out of metadata', () => {
+  const r = ctx.parseLnMetadata(meta([
+    ['text/plain', 'Send me sats'],
+    ['text/identifier', 'thedaniel@breez.tips'],
+    ['image/png;base64', 'aGVsbG8='],
+  ]));
+  assert.equal(r.description, 'Send me sats');
+  assert.equal(r.identifier, 'thedaniel@breez.tips');
+  assert.equal(r.image, 'data:image/png;base64,aGVsbG8=');
+});
+
+// Fields are asserted individually rather than with deepEqual: these objects are
+// built inside the vm context, so they carry that realm's Object.prototype and
+// deepEqual's prototype check fails on structurally identical values.
+const assertEmpty = (r, why) => {
+  assert.equal(r.description, '', why + ': description');
+  assert.equal(r.identifier, '', why + ': identifier');
+  assert.equal(r.image, '', why + ': image');
+};
+
+test('metadata that is not JSON yields empty fields rather than throwing', () => {
+  assertEmpty(ctx.parseLnMetadata('this is not json'), 'not json');
+});
+
+test('metadata that is JSON but not an array is handled', () => {
+  assertEmpty(ctx.parseLnMetadata('{"description":"nope"}'), 'json object');
+  assertEmpty(ctx.parseLnMetadata('null'), 'json null');
+  assertEmpty(ctx.parseLnMetadata(''), 'empty string');
+});
+
+test('malformed entries are skipped, good ones still read', () => {
+  const r = ctx.parseLnMetadata(meta([
+    'not-a-pair',
+    ['text/plain'],
+    [42, 'wrong types'],
+    ['text/plain', 'the real one'],
+  ]));
+  assert.equal(r.description, 'the real one');
+});
+
+test('a description cannot run away with the dialog', () => {
+  const r = ctx.parseLnMetadata(meta([['text/plain', 'x'.repeat(5000)]]));
+  assert.equal(r.description.length, 200);
+});
+
+test('newlines in a description are collapsed, not rendered as height', () => {
+  const r = ctx.parseLnMetadata(meta([['text/plain', 'line one\n\n\n\n\nline two\t\tend']]));
+  assert.equal(r.description, 'line one line two end');
+});
+
+test('the first description wins, so a second cannot override it', () => {
+  const r = ctx.parseLnMetadata(meta([
+    ['text/plain', 'first'],
+    ['text/plain', 'second'],
+  ]));
+  assert.equal(r.description, 'first');
+});
+
+// ---- the image, which is the sharpest edge ----
+
+test('only png and jpeg are accepted as images', () => {
+  for (const type of ['image/svg+xml;base64', 'image/gif;base64', 'text/html;base64', 'image/png']) {
+    const r = ctx.parseLnMetadata(meta([[type, 'aGVsbG8=']]));
+    assert.equal(r.image, '', type + ' must not become an image');
+  }
+});
+
+test('an image payload that is not base64 is refused', () => {
+  // The shape that matters: anything that could break out of the data: URI.
+  for (const payload of ['"><script>alert(1)</script>', 'aGVsbG8=" onerror="x', 'not base64!']) {
+    const r = ctx.parseLnMetadata(meta([['image/png;base64', payload]]));
+    assert.equal(r.image, '', 'refused: ' + payload);
+  }
+});
+
+test('an oversized image is dropped rather than embedded', () => {
+  const r = ctx.parseLnMetadata(meta([['image/png;base64', 'A'.repeat(200001)]]));
+  assert.equal(r.image, '');
+});
+
+test('an image exactly at the cap is still accepted', () => {
+  const r = ctx.parseLnMetadata(meta([['image/png;base64', 'A'.repeat(200000)]]));
+  assert.ok(r.image.startsWith('data:image/png;base64,AAAA'));
+});
+
+// ---- resolving an address ----
+
+function plant({ min, max, comment, nostr, entries }) {
+  ctx.fetchResult = {
+    tag: 'payRequest',
+    callback: 'https://breez.tips/lnurlp/callback',
+    minSendable: min,
+    maxSendable: max,
+    commentAllowed: comment,
+    allowsNostr: !!nostr,
+    nostrPubkey: nostr ? 'abc123' : undefined,
+    metadata: meta(entries || [['text/plain', 'Zap me']]),
+  };
+}
+
+test('resolves limits into sats, rounding so both ends are payable', async () => {
+  // 1500 msat cannot be paid as 1 sat, and 2500 msat cannot be paid as 3.
+  plant({ min: 1500, max: 2500 });
+  const p = await ctx.lnAddressParams('thedaniel@breez.tips');
+  assert.equal(p.minSats, 2, 'min rounds up');
+  assert.equal(p.maxSats, 2, 'max rounds down');
+});
+
+test('reads comment allowance and zappability', async () => {
+  plant({ min: 1000, max: 100000000, comment: 120, nostr: true });
+  const p = await ctx.lnAddressParams('thedaniel@breez.tips');
+  assert.equal(p.commentAllowed, 120);
+  assert.equal(p.zappable, true);
+});
+
+test('a wallet that allows no comments reports zero', async () => {
+  plant({ min: 1000, max: 1000, comment: 0 });
+  const p = await ctx.lnAddressParams('a@b.com');
+  assert.equal(p.commentAllowed, 0);
+});
+
+test('a missing or absurd comment allowance is normalized', async () => {
+  plant({ min: 1000, max: 1000 });
+  assert.equal((await ctx.lnAddressParams('a@b.com')).commentAllowed, 0, 'absent');
+  plant({ min: 1000, max: 1000, comment: -5 });
+  assert.equal((await ctx.lnAddressParams('a@b.com')).commentAllowed, 0, 'negative');
+  plant({ min: 1000, max: 1000, comment: 99999 });
+  assert.equal((await ctx.lnAddressParams('a@b.com')).commentAllowed, 1000, 'capped');
+});
+
+test('allowsNostr without a pubkey is not zappable', async () => {
+  ctx.fetchResult = {
+    tag: 'payRequest', callback: 'https://x/y', minSendable: 1, maxSendable: 2,
+    allowsNostr: true, metadata: meta([['text/plain', 'x']]),
+  };
+  assert.equal((await ctx.lnAddressParams('a@b.com')).zappable, false);
+});
+
+test('an address without an @ is rejected before any request', async () => {
+  ctx.fetchResult = null;
+  await assert.rejects(() => ctx.lnAddressParams('not-an-address'), /does not look like a lightning address/);
+  await assert.rejects(() => ctx.lnAddressParams(''), /does not look like a lightning address/);
+});
+
+test('a response that is not a payRequest is rejected', async () => {
+  ctx.fetchResult = { tag: 'withdrawRequest', callback: 'https://x/y' };
+  await assert.rejects(() => ctx.lnAddressParams('a@b.com'), /not with a lightning address/);
+});
+
+test('a payRequest with no callback is rejected', async () => {
+  ctx.fetchResult = { tag: 'payRequest', minSendable: 1, maxSendable: 2 };
+  await assert.rejects(() => ctx.lnAddressParams('a@b.com'), /not with a lightning address/);
+});
+
+test('backwards or missing limits are rejected, not shown', async () => {
+  plant({ min: 100000, max: 1000 });
+  await assert.rejects(() => ctx.lnAddressParams('a@b.com'), /limits that make no sense/);
+  plant({ min: undefined, max: 1000 });
+  await assert.rejects(() => ctx.lnAddressParams('a@b.com'), /limits that make no sense/);
+  plant({ min: -1, max: 1000 });
+  await assert.rejects(() => ctx.lnAddressParams('a@b.com'), /limits that make no sense/);
+});
+
+// ---- failures a person has to read ----
+//
+// The first version of this surfaced the raw parser error when a domain served
+// an HTML 404: "Unexpected token '<', "<!DOCTYPE "... is not valid JSON". That
+// is a true statement about a JSON parser and a useless one about an address, so
+// each failure now says which thing went wrong in a sentence.
+
+test('a domain serving an HTML 404 says the address does not exist', async () => {
+  ctx.fetchOk = false;
+  ctx.jsonThrows = true;
+  await assert.rejects(
+    () => ctx.lnAddressParams('bfgreen@sidecar.top'),
+    (e) => {
+      assert.match(e.message, /sidecar\.top has no lightning address for bfgreen/);
+      assert.doesNotMatch(e.message, /JSON|token|DOCTYPE/i, 'no parser jargon');
+      return true;
+    }
+  );
+  ctx.fetchOk = true;
+  ctx.jsonThrows = false;
+});
+
+test('a 200 that is actually a web page is treated the same way', async () => {
+  ctx.fetchOk = true;
+  ctx.jsonThrows = true;
+  await assert.rejects(
+    () => ctx.lnAddressParams('bfgreen@sidecar.top'),
+    (e) => {
+      assert.match(e.message, /has no lightning address for bfgreen/);
+      assert.doesNotMatch(e.message, /JSON|token|DOCTYPE/i);
+      return true;
+    }
+  );
+  ctx.jsonThrows = false;
+});
+
+test('an unreachable domain names the domain, not the network stack', async () => {
+  ctx.fetchThrows = true;
+  await assert.rejects(
+    () => ctx.lnAddressParams('someone@nowhere.example'),
+    (e) => {
+      assert.match(e.message, /Couldn't reach nowhere\.example/);
+      assert.doesNotMatch(e.message, /TypeError|Failed to fetch/);
+      return true;
+    }
+  );
+  ctx.fetchThrows = false;
+});
+
+test('every failure message is short enough and plain enough to show as-is', async () => {
+  // Mirrors the panel's own last-resort filter: anything longer than 90 chars or
+  // carrying jargon gets replaced with a generic line, so a message that trips
+  // that filter is one the user will never actually see.
+  const speakable = (m) => m.length <= 90 && !/[{}<>]|JSON|token|undefined|TypeError/i.test(m);
+  const cases = [
+    () => { ctx.fetchThrows = true; },
+    () => { ctx.fetchOk = false; },
+    () => { ctx.jsonThrows = true; },
+    () => { ctx.fetchResult = { tag: 'withdrawRequest', callback: 'https://x/y' }; },
+    () => { plant({ min: 999999, max: 1 }); },
+  ];
+  for (const setup of cases) {
+    ctx.fetchThrows = false; ctx.fetchOk = true; ctx.jsonThrows = false;
+    setup();
+    await assert.rejects(() => ctx.lnAddressParams('someone@example.com'), (e) => {
+      assert.ok(speakable(e.message), 'not showable as-is: ' + e.message);
+      return true;
+    });
+  }
+  ctx.fetchThrows = false; ctx.fetchOk = true; ctx.jsonThrows = false;
+});
+
+test('a description survives resolution intact and clamped', async () => {
+  plant({ min: 1000, max: 2000, entries: [['text/plain', 'y'.repeat(500)]] });
+  const p = await ctx.lnAddressParams('a@b.com');
+  assert.equal(p.description.length, 200);
+});


### PR DESCRIPTION
The Send form took an address and an amount and only contacted the recipient when you pressed Pay. The accepted range was discovered by having a payment rejected, after the amount was already typed, and the Comment box invited 280 characters whether or not the recipient accepted any.

## What it does now

Typing a lightning address resolves it after a short pause and shows what came back: who it reached, whatever the wallet says about itself, the range it accepts, and whether it takes comments or zaps.

- The Comment field takes its `maxLength` from that answer, and disables itself with a reason when the recipient accepts none
- An out-of-range amount is caught locally instead of after a round trip
- `lnAddressToInvoice` re-fetches rather than trusting the preview: the card may be minutes old, and the limits it showed are not the ones that will be enforced

## The card is hostile input, not content

Every string in it is written by whoever runs the recipient's domain.

- rendered with `textContent` throughout, never markup
- description clamped to 200 characters with whitespace collapsed, so nobody stretches the dialog to whatever height they like
- images only `image/png` or `image/jpeg`, only if the payload is strictly base64, capped at ~150KB, and always a `data:` URI so the card cannot become a request back to the recipient's server
- backwards, missing, or non-numeric limits are refused rather than displayed

## Failures say which thing went wrong

A domain serving an HTML 404 previously produced the raw parser error: `Unexpected token '<', "<!DOCTYPE "... is not valid JSON`. True about a JSON parser, useless about an address, and it reads as a fault in Sidecar rather than a fact about where the money was going.

Unreachable domain, no such address, and answered-but-not-a-lightning-address are now three different sentences. The renderer also filters anything over 90 characters or carrying `{}`, `<>`, `JSON`, `token`, `undefined`, or `TypeError` down to a generic line, as a last resort against something unforeseen from the platform. A test asserts every failure path produces something that survives that filter, so a future message that trips it fails the suite rather than reaching a user.

## Lookups

Debounced, and gated on a complete domain with a two-character TLD. `isLnAddress` is deliberately not reused for that gate: it accepts a one-character TLD, which is right for deciding whether to show the amount field and wrong for deciding whether to announce an intent to pay someone. Pausing mid-word should not send anything to `breez.t`.

## Tests

`test/ln-recipient.test.js`, 25 tests, mostly the hostile cases: SVG and HTML posing as images, payloads carrying `onerror=`, a 5000-character description, reversed limits, metadata that is not JSON, and the exact HTML-404 case that produced the parser error.

Suite: 532 tests, 530 pass, two pre-existing `nostr-tools` module failures.

No new permission — `host_permissions` already covers `https://*/*`.

🍷 Poured with [Claude Code](https://claude.com/claude-code)
