### PR TITLE
Toasts: above the bottom chrome, tappable to dismiss

### DIFF
--- a/sidepanel.js
+++ b/sidepanel.js
@@ -292,13 +292,23 @@
     t.appendChild(span);
     host.appendChild(t);
     requestAnimationFrame(() => t.classList.add('show'));
-    const hide = setTimeout(() => {
+    const dismiss = () => {
       t.classList.remove('show');
       const rm = setTimeout(() => t.remove(), 250);
       const cur = _toastTimers.get(t);
       if (cur) cur.remove = rm;
-    }, 3200);
+    };
+    const hide = setTimeout(dismiss, 3200);
     _toastTimers.set(t, { hide, remove: null });
+    // A tap dismisses immediately: 3.2s is a long time to wait out a toast that
+    // is sitting on something you want, and there was no way out at all. Runs
+    // the timer's own exit (fade, then remove) rather than yanking the node, so
+    // the transition plays and the replacement logic's timers stay coherent.
+    t.addEventListener('click', () => {
+      const timers = _toastTimers.get(t);
+      if (timers) { clearTimeout(timers.hide); clearTimeout(timers.remove); }
+      dismiss();
+    });
     return t;
   }
 

--- a/styles.css
+++ b/styles.css
@@ -2540,7 +2540,13 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
 
 .toasts {
   position: fixed;
-  bottom: 14px;
+  /* Above the bottom chrome, not just above the floor. The compose FAB stands
+     18px off the bottom and is 54px tall, and the brand-foot logo button sits in
+     the middle of that same band; flush to the floor a toast parked on both for
+     its whole life (top placement had the same fight with the actions row).
+     92px = FAB top (18 + 54) + 20px of air; if the FAB's geometry changes, this
+     number follows it. */
+  bottom: 92px;
   left: 50%;
   transform: translateX(-50%);
   display: flex;
@@ -2561,6 +2567,9 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
   font-weight: 600;
   border: 1px solid var(--border);
   box-shadow: 0 12px 32px rgba(0, 0, 0, 0.55);
+  /* tappable: see the click handler in toast() — the timer is otherwise a
+     mandatory 3.2s wait */
+  cursor: pointer;
   transform: translateY(12px);
   opacity: 0;
   transition: transform 0.22s ease, opacity 0.22s ease;


### PR DESCRIPTION
## What

Toasts sat flush to the panel floor, parked on the compose FAB and the brand-foot logo (the About/version button) for their full 3.2s. The top placement before that blocked the actions row. They now float 92px up, clearing the FAB by 20px, and a tap dismisses them.

## Why 92

The FAB stands 18px off the floor and is 54px tall, so its top edge is 72px up; 92 = FAB top + 20px of air. The derivation lives in a comment at the rule, so a future FAB resize knows the number follows it.

## Tap to dismiss

`toast()` had no dismissal but the timer: a mandatory 3.2s wait, which is why any overlap stung. A click now clears both timers and runs the timer's own exit (fade, then remove), so the replacement bookkeeping in `_toastTimers` stays coherent. Double tap is harmless: `remove()` on a detached node is a no-op.

## Passed on

- Right-aligned above the FAB: implies the toast belongs to the FAB, and of ~40 call sites most have nothing to do with it.
- In-flow below the tabs: occludes nothing, but every toast becomes a 50px layout jump for 3.2s.
- Top-center: the empty middle of the topbar is about 50px wide at 400px. Too narrow for text.

## Verified

At 400px (side panel width): toast bottom edge at 92px, FAB top at 648px, exactly 20px clear, logo visible below the toast. The prompt popup has no toasts, so the panel is the only surface. Suite 558/560, the two pre-existing.

🥃 stirred with [GLM 5.3](https://z.ai)