### PR TITLE
Backups: last-backed-up dates, restore confirmations that count what's real

### DIFF
--- a/sidepanel.js
+++ b/sidepanel.js
@@ -7970,9 +7970,20 @@
     { key: 'mute', label: 'Mute list', kind: 10000, dtag: 'sidecar:mute-backup' },
   ];
 
+  // The newest copy of a replaceable identity event (kind 0/3/10002/10000) —
+  // what backups snapshot, exports write to file, and the restore confirm
+  // compares against. Read from the account's declared NIP-65 relays plus
+  // purplepag.es plus Settings, never Settings alone: replaceable events go
+  // stale independently per relay, and one configured relay holding an old copy
+  // (here: an empty kind 3 from two months back) can be the only answer within
+  // the window while the relays actually carrying the current 1000+ list sit
+  // outside the configured set — a backup exported from that read captures the
+  // wipe it exists to undo. readRelayUrls is resolved before the race so its
+  // own (cached) NIP-65 fetch doesn't eat the 6s query budget.
   async function fetchLatestEvent(kind) {
+    const relays = await readRelayUrls(state.activePubkey);
     return Promise.race([
-      poolGet(await relayUrls(false), { kinds: [kind], authors: [state.activePubkey] }),
+      poolGet(relays, { kinds: [kind], authors: [state.activePubkey] }),
       new Promise((res) => setTimeout(() => res(null), 6000)),
     ]).catch(() => null);
   }
@@ -8014,20 +8025,60 @@
     await publishSigned(signed);
   }
 
+  // What a list restore would change, as plain numbers. Counts are p-tags;
+  // DROPPED and ADDED are set differences, because counts alone can hide the
+  // danger both ways: 289 vs 312 can be a reshuffle rather than a loss, and a
+  // same-count swap can be a total loss. "23 you follow today are not in the
+  // backup" is the number that stops a bad restore.
+  function listDiff(currentTags, backupTags) {
+    // x[1] required: a valueless ['p'] tag is malformed, and counting it as an
+    // undefined member inflates both sides and can fake a difference between
+    // identical lists.
+    const cur = new Set((currentTags || []).filter((x) => x && x[0] === 'p' && x[1]).map((x) => x[1]));
+    const bak = new Set((backupTags || []).filter((x) => x && x[0] === 'p' && x[1]).map((x) => x[1]));
+    const dropped = [...cur].filter((p) => !bak.has(p)).length;
+    const added = [...bak].filter((p) => !cur.has(p)).length;
+    return { current: cur.size, backup: bak.size, dropped, added };
+  }
+
+  // A mute list's p-tags from both places they can live: public event tags, and
+  // the private list encrypted to self in content (NIP-44, or legacy NIP-04
+  // whose ciphertext carries "?iv="). loadMuteList merges the same two sources
+  // when it applies mutes; any count of a mute list has to merge them too, or
+  // every private list reads as empty — and against the hundreds the user
+  // actually mutes, "0 muted" is not a smaller number, it's the wrong number.
+  // ok=false means content exists but wouldn't decrypt (keystore locked, bad
+  // ciphertext), so callers say that instead of printing the public-only count
+  // as if it were the whole list.
+  async function muteTags(ev) {
+    const tags = (ev && ev.tags) || [];
+    if (!ev || !ev.content) return { tags, private: false, ok: true };
+    const order = ev.content.includes('?iv=') ? [4, 44] : [44, 4];
+    for (const nip of order) {
+      try {
+        const privateTags = JSON.parse(await call({ type: 'SIDECAR_OWNER_DECRYPT', ciphertext: ev.content, nip }));
+        if (Array.isArray(privateTags)) return { tags: tags.concat(privateTags), private: true, ok: true };
+      } catch (_) {}
+    }
+    return { tags, private: true, ok: false };
+  }
+
+  // Decrypt a backup event's source payload. Restore only PIN-gates the SIGN;
+  // the panel may read its own backups freely (the panel is unlocked to be here).
+  async function decryptBackupSource(ev) {
+    const scheme = (ev.tags.find((x) => x[0] === 'encrypted') || [])[1];
+    const nip = scheme === 'nip44' ? 44 : 4; // older backups are NIP-04
+    const plaintext = await call({ type: 'SIDECAR_OWNER_DECRYPT', ciphertext: ev.content, nip });
+    const blob = JSON.parse(plaintext);
+    if (!blob || !blob.source) throw new Error('Backup could not be read');
+    return blob.source;
+  }
+
   // Decrypt the latest backup and re-publish it as the current event (PIN-gated).
   async function restoreBackup(t, pin) {
     const ev = await fetchBackupEvent(t.dtag);
     if (!ev) throw new Error('No backup found for ' + t.label.toLowerCase());
-    const scheme = (ev.tags.find((x) => x[0] === 'encrypted') || [])[1];
-    const nip = scheme === 'nip44' ? 44 : 4; // older backups were NIP-04
-    const plaintext = await call({ type: 'SIDECAR_OWNER_DECRYPT', ciphertext: ev.content, nip });
-    let blob;
-    try {
-      blob = JSON.parse(plaintext);
-    } catch (_) {
-      throw new Error('Backup could not be read');
-    }
-    const s = blob.source || {};
+    const s = await decryptBackupSource(ev);
     const event = { kind: s.kind, created_at: Math.floor(Date.now() / 1000), tags: s.tags || [], content: s.content || '' };
     const signed = await call({ type: 'SIDECAR_OWNER_SIGN', event, pin });
     await publishSigned(signed);
@@ -8194,7 +8245,20 @@
       }
 
       const summary = h('ul', { className: 'restore-list' });
-      valid.forEach((ev) => summary.append(h('li', { textContent: kindLabel(ev.kind) })));
+      // Each row's second line — what the file holds vs what's live — fills in
+      // async below; Restore stays disabled until it has, because the counts ARE
+      // the confirmation (a backup file older than a live list is how lists get
+      // shrunk, and the row is where that has to be visible).
+      const subs = new Map();
+      valid.forEach((ev) => {
+        const sub = h('div', { className: 'restore-list-sub' }, [
+          h('span', { className: 'recv-spinner' }),
+          document.createTextNode(' checking relays…'),
+        ]);
+        subs.set(ev, sub);
+        summary.append(h('li', {}, [h('div', { className: 'item-label', textContent: kindLabel(ev.kind) }), sub]));
+      });
+      go.disabled = true;
       children.push(
         h('p', {
           className: 'hint',
@@ -8202,6 +8266,62 @@
         }),
         summary
       );
+      (async () => {
+        const kinds = [...new Set(valid.map((ev) => ev.kind))];
+        const live = new Map(await Promise.all(kinds.map(async (k) => [k, await fetchLatestEvent(k)])));
+        for (const ev of valid) {
+          const sub = subs.get(ev);
+          if (!sub || !sub.isConnected) continue;
+          sub.innerHTML = '';
+          const cur = live.get(ev.kind);
+          if (ev.kind === 0) {
+            let incoming = {};
+            try { incoming = JSON.parse(ev.content || '{}'); } catch (_) {}
+            sub.append(profilePreviewPane(incoming));
+          } else if (ev.kind === 3 || ev.kind === 10000) {
+            const noun = ev.kind === 10000 ? 'muted' : 'followed';
+            // Mute lists carry their members encrypted in content as often as in
+            // tags — count both sources on both sides, or a private list reads
+            // as empty on every line.
+            const bak = ev.kind === 10000
+              ? await muteTags(ev)
+              : { tags: ev.tags, private: false, ok: true };
+            const now = ev.kind === 10000 && cur ? await muteTags(cur) : null;
+            const liveTags = ev.kind === 10000 ? (now && now.ok ? now.tags : null) : (cur && cur.tags);
+            if (!bak.ok) {
+              sub.classList.add('warn');
+              sub.textContent = 'Private mute list in this file — Sidecar could not decrypt it to count';
+            } else {
+              const d = listDiff(liveTags, bak.tags);
+              if (!d.backup) {
+                // An empty list in the file is a state to name, not a count to
+                // print: "0 followed" reads like a measured zero, and restoring
+                // publishes that emptiness over whatever is live.
+                sub.classList.add('warn');
+                sub.textContent = 'Empty ' + (ev.kind === 10000 ? 'mute' : 'follow') + ' list in this file';
+                if (cur && liveTags && d.current) {
+                  sub.textContent += ' · ' + d.current.toLocaleString('en-US') + ' live now would be ' + (ev.kind === 10000 ? 'unmuted' : 'lost');
+                }
+              } else {
+                sub.textContent = d.backup.toLocaleString('en-US') + ' ' + noun +
+                  (bak.private ? ' (private list)' : '') +
+                  (cur ? (liveTags ? ' · ' + d.current.toLocaleString('en-US') + ' now' : ' · live list unreadable') : ' · nothing live now');
+                if (liveTags && (d.dropped || d.added)) {
+                  sub.classList.add('warn');
+                  sub.textContent += ' · ' + (d.dropped ? d.dropped.toLocaleString('en-US') + ' will be ' + (ev.kind === 10000 ? 'unmuted' : 'removed') : '') +
+                    (d.dropped && d.added ? ', ' : '') + (d.added ? d.added.toLocaleString('en-US') + ' added' : '');
+                }
+              }
+            }
+          } else if (ev.kind === 10002) {
+            const n = (ev.tags || []).filter((x) => x && x[0] === 'r').length;
+            sub.textContent = n.toLocaleString('en-US') + ' relay' + (n === 1 ? '' : 's');
+          } else {
+            sub.textContent = '';
+          }
+        }
+        if (summary.isConnected) go.disabled = false;
+      })();
       if (foreign) {
         children.push(h('p', { className: 'hint warn', textContent: foreign + ' event(s) from another account were skipped.' }));
       }
@@ -8402,11 +8522,24 @@
     });
   }
 
+  // The restore confirm. This used to be a PIN box and a promise: it re-published
+  // whatever the latest backup held, sight unseen, and a backup older than a live
+  // list that had moved on would silently shrink it. Restoring over newer data is
+  // the destructive-event case the panel warns about everywhere else, so both
+  // sides are fetched first — the backup (readable without the PIN; only the
+  // signing step is gated) and the current live event — and the modal shows what
+  // will change before it ever asks for the PIN.
+  //
+  // For the lists the headline is the SET difference, not the counts: "289 vs
+  // 312" can be a reshuffle, "23 you follow today are not in the backup" cannot
+  // be anything but a loss. For the profile the same job is done by a preview
+  // pane — the bio rendered as the bio, not as a JSON diff.
   function restoreModal(t) {
     openModal((modal) => {
       const pin = h('input', { type: 'password', maxLength: 32 });
       const err = h('div', { className: 'error' });
       const go = h('button', { className: 'primary', textContent: 'Restore' });
+      go.disabled = true; // until the comparison has rendered
       go.addEventListener('click', async () => {
         err.textContent = '';
         if (!pin.value) return (err.textContent = 'Enter your PIN.');
@@ -8425,6 +8558,14 @@
       });
       const cancel = h('button', { className: 'ghost', textContent: 'Cancel' });
       cancel.addEventListener('click', closeModal);
+
+      const compare = h('div', { className: 'restore-compare' }, [
+        h('div', { className: 'recv-waiting' }, [
+          h('span', { className: 'recv-spinner' }),
+          h('span', { textContent: 'Checking your relays…' }),
+        ]),
+      ]);
+
       modal.append(
         h('h3', { textContent: 'Restore ' + t.label }),
         h('p', {
@@ -8432,12 +8573,151 @@
           textContent:
             'Re-publishes your latest ' + t.label.toLowerCase() + ' backup as your current ' + t.label.toLowerCase() + '. Requires your PIN.',
         }),
+        compare,
         h('label', { textContent: 'PIN' }),
         pin,
         err,
         h('div', { className: 'actions' }, [go, cancel])
       );
+
+      (async () => {
+        const [ev, cur] = await Promise.all([fetchBackupEvent(t.dtag), fetchLatestEvent(t.kind)]);
+        if (!compare.isConnected) return; // the modal was closed mid-fetch
+        compare.innerHTML = '';
+        if (!ev) {
+          compare.append(h('p', { className: 'hint warn', textContent: 'No backup found for ' + t.label.toLowerCase() + '. Try backing up first.' }));
+          pin.disabled = true;
+          return;
+        }
+        let s;
+        try {
+          s = await decryptBackupSource(ev);
+        } catch (e) {
+          compare.append(h('p', { className: 'hint warn', textContent: (e && e.message) || 'Backup could not be read.' }));
+          pin.disabled = true;
+          return;
+        }
+        compare.append(await buildRestoreCompare(t, s, ev.created_at, cur));
+        if (compare.isConnected) go.disabled = false;
+      })();
     });
+  }
+
+  // The comparison block itself, shared shape for every backup type. `cur` is the
+  // live event (or null when the relays hold none — then the restore is a first
+  // publish, not an overwrite, and saying so is the honest framing). Async
+  // because mute lists count through muteTags, which decrypts the private half
+  // of the list out of content.
+  async function buildRestoreCompare(t, source, backupAt, cur) {
+    const wrap = h('div');
+    const when = relativeTime(backupAt);
+
+    if (t.kind === 0) {
+      let incoming = {};
+      try { incoming = JSON.parse(source.content || '{}'); } catch (_) {}
+      let live = null;
+      if (cur) { try { live = JSON.parse(cur.content || '{}'); } catch (_) {} }
+      const changed = live === null || JSON.stringify(live) !== JSON.stringify(incoming);
+      wrap.append(profilePreviewPane(incoming));
+      wrap.append(
+        h('p', {
+          className: 'hint' + (changed ? ' warn' : ''),
+          textContent: live === null
+            ? 'No profile on your relays yet — this will publish the backup above.'
+            : changed
+              ? 'This replaces the profile you have live now.'
+              : 'Same profile as what you have live now.',
+        })
+      );
+      return wrap;
+    }
+
+    const noun = t.key === 'mute' ? 'muted' : 'followed';
+    const bak = t.key === 'mute' ? await muteTags(source) : { tags: source.tags, private: false, ok: true };
+    const now = t.key === 'mute' && cur ? await muteTags(cur) : null;
+    // null liveTags = no live event at all, or a private live list that wouldn't
+    // decrypt — both mean the diff numbers can't be trusted, so none are shown.
+    const liveTags = t.key === 'mute' ? (now && now.ok ? now.tags : null) : (cur && cur.tags);
+
+    if (!bak.ok) {
+      wrap.append(h('div', { className: 'recovery-confirm' }, [
+        h('div', { className: 'recovery-count-lg' }, [
+          h('strong', { textContent: 'Private mute list' }),
+        ]),
+        h('div', { className: 'recovery-sub', textContent: 'Sidecar could not decrypt it to count · backup from ' + when }),
+      ]));
+      return wrap;
+    }
+
+    const d = listDiff(liveTags, bak.tags);
+    if (!d.backup) {
+      // Name the state, don't print its count: "0 accounts followed in the
+      // backup" reads like a measured zero, and the restore publishes that
+      // emptiness over whatever is live.
+      wrap.append(h('div', { className: 'recovery-confirm' }, [
+        h('div', { className: 'recovery-count-lg' }, [
+          h('strong', { textContent: 'Empty ' + (t.key === 'mute' ? 'mute' : 'follow') + ' list' }),
+        ]),
+        h('div', {
+          className: 'recovery-sub',
+          textContent: (liveTags ? d.current.toLocaleString('en-US') + ' ' + noun + ' live now' : cur ? 'Live list unreadable' : 'Nothing live on your relays now') + ' · backup from ' + when,
+        }),
+      ]));
+      if (liveTags && d.current) {
+        wrap.append(h('p', {
+          className: 'hint warn',
+          textContent: 'The backup holds no ' + noun + ' accounts — restoring publishes the empty list over the ' + d.current.toLocaleString('en-US') + ' you have now.',
+        }));
+      }
+      return wrap;
+    }
+
+    const rows = h('div', { className: 'recovery-confirm' }, [
+      h('div', { className: 'recovery-count-lg' }, [
+        h('strong', { textContent: d.backup.toLocaleString('en-US') }),
+        document.createTextNode(' accounts ' + noun + ' in the backup'),
+      ]),
+      h('div', {
+        className: 'recovery-sub',
+        textContent:
+          (liveTags ? d.current.toLocaleString('en-US') + ' ' + noun + ' now' : cur ? 'Live list unreadable' : 'Nothing live on your relays now') +
+          ' · backup from ' + when + (bak.private ? ' · private list' : ''),
+      }),
+    ]);
+    wrap.append(rows);
+    if (!liveTags) return wrap;
+    if (d.dropped || d.added) {
+      const parts = [];
+      if (d.dropped) parts.push(d.dropped.toLocaleString('en-US') + (t.key === 'mute' ? ' currently muted will be unmuted' : ' you follow today are not in the backup and will be removed'));
+      if (d.added) parts.push(d.added.toLocaleString('en-US') + (t.key === 'mute' ? ' currently audible will be muted' : ' in the backup are new'));
+      wrap.append(h('p', { className: 'hint warn', textContent: parts.join('; ') + '.' }));
+    } else {
+      wrap.append(h('p', { className: 'hint', textContent: 'Same accounts as what you have live now.' }));
+    }
+    return wrap;
+  }
+
+  // The bio as the bio: a profile-shaped preview of what the restore will
+  // publish, so "is this MY bio?" is answered by looking rather than by diffing
+  // field names. Plain text only — the profile view linkifies the live copy, but
+  // a preview of an about-to-be-written event has no business pretending to be
+  // interactive.
+  function profilePreviewPane(p) {
+    const pane = h('div', { className: 'restore-preview' });
+    const head = h('div', { className: 'restore-preview-head' }, [
+      avatarEl({ picture: p.picture || '', npub: state.activePubkey }, 'restore-preview-av'),
+      h('div', { className: 'restore-preview-id' }, [
+        h('div', { className: 'profile-name restore-preview-name', textContent: p.display_name || p.name || '(no name)' }),
+        p.nip05 ? h('div', { className: 'hint restore-preview-nip05', textContent: p.nip05 }) : null,
+      ]),
+    ]);
+    pane.append(head);
+    pane.append(
+      p.about
+        ? h('div', { className: 'profile-about restore-preview-about', textContent: p.about })
+        : h('p', { className: 'hint', textContent: '(no bio in this backup)' })
+    );
+    return pane;
   }
 
   // ---- NIP-65 relay list editor (Profile tab) ----
@@ -8897,16 +9177,28 @@
       h('p', { className: 'hint', textContent: 'Your profile, follows, and mute list — data only, never your secret key — stored on your relays as an encrypted record you can restore here (NIP-78, NIP-44; NIP-04 for very large lists), or saved to a file below.' })
     );
     const list = h('div', { className: 'list flat' });
+    const statuses = new Map();
+    // "Backed up" and when, on two lines: the status column is narrow, and a
+    // gold "Backed up · 2 days ago" ran into the buttons on exactly the rows
+    // that had both. The when is furniture, not the signal — grey, below. The
+    // check mirrors the wallet badge, so "Backed up" reads the same everywhere.
+    const setBackedUp = (status, when) => {
+      status.textContent = '';
+      status.classList.add('done');
+      const tick = icon('check');
+      tick.classList.add('backup-check');
+      status.append(tick, 'Backed up', h('div', { className: 'backup-status-time', textContent: when }));
+    };
     BACKUP_TYPES.forEach((t) => {
       const status = h('div', { className: 'backup-status', textContent: 'Not backed up' });
+      statuses.set(t.key, status);
       const backup = h('button', { className: 'mini', textContent: 'Back up' });
       backup.addEventListener('click', async () => {
         backup.disabled = true;
         backup.textContent = 'Backing up…';
         try {
           await createBackup(t);
-          status.textContent = 'Backed up ✓';
-          status.classList.add('done');
+          setBackedUp(status, 'just now');
           toast(t.label + ' backed up', 'success');
         } catch (e) {
           // Keep the row tidy — surface the detail in a toast, not inline.
@@ -8922,6 +9214,17 @@
         h('div', { className: 'item-actions' }, [backup, restore]),
       ]);
       list.append(row);
+    });
+    // The last-backup time comes from the relays, not from memory: the row used
+    // to say "Not backed up" on every open until you backed up again in that
+    // session, which read as the backup having been lost. The kind:30078 event's
+    // created_at IS when the backup was taken. isConnected guards a rerender
+    // that replaced the section while the fetch was out.
+    BACKUP_TYPES.forEach(async (t) => {
+      const status = statuses.get(t.key);
+      const ev = await fetchBackupEvent(t.dtag);
+      if (!ev || !status.isConnected) return;
+      setBackedUp(status, relativeTime(ev.created_at));
     });
     setting.append(list);
 

--- a/styles.css
+++ b/styles.css
@@ -321,7 +321,14 @@ input:focus, select:focus, textarea:focus {
   white-space: nowrap;
 }
 .mini:hover { border-color: var(--gold-soft); }
-.mini.ghost { background: transparent; border-color: transparent; color: var(--muted); }
+/* The big-button .ghost rule below (14px, 12px 16px padding) ties .mini on
+   specificity and beats it by file order, which quietly rendered every mini
+   ghost a full size class bigger than its filled sibling. Restate .mini's
+   metrics here: a mini ghost is a mini first, ghost second. */
+.mini.ghost {
+  background: transparent; border-color: transparent; color: var(--muted);
+  font-size: 12px; padding: 7px 12px; border-width: 1px; border-style: solid;
+}
 .mini.ghost:hover { color: var(--text); border-color: transparent; }
 
 /* edit-profile form */
@@ -1364,6 +1371,8 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 100%;
 }
 .backup-status.done { color: var(--gold); }
+.backup-status .backup-check { width: 11px; height: 11px; margin-right: 4px; vertical-align: -1px; }
+.backup-status-time { color: var(--faint); margin-top: 1px; }
 /* A backup that exists but holds a different wallet — the reassuring gold ✓ would
    be exactly wrong here, so it reads as a warning instead. */
 .backup-status.warn { color: var(--warn); }
@@ -1398,7 +1407,25 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
 .recovery-badge.rec { background: rgba(var(--accent-rgb), 0.16); color: var(--gold); }
 .recovery-confirm { background: var(--velvet-1); border: 1px solid var(--border); border-radius: 12px; padding: 14px; margin-top: 4px; }
 .restore-list { margin: 4px 0 10px; padding-left: 20px; color: var(--text); }
-.restore-list li { margin: 3px 0; }
+.restore-list li { margin: 3px 0 12px; }
+/* second line of a file-restore row: counts in the file vs counts live now.
+   Warn color only when the restore would actually change the list. */
+.restore-list-sub { font-size: 12px; color: var(--muted); margin-top: 1px; padding-left: 2px; }
+.restore-list-sub.warn { color: var(--warn); }
+.restore-list-sub .recv-spinner { width: 10px; height: 10px; border-width: 2px; margin-right: 4px; }
+
+/* what a restore will publish, shown before the PIN is asked for. The counts
+   block reuses .recovery-confirm (the follow-recovery modal's card); the profile
+   preview is its own pane because a bio answers "is this mine?" by looking. */
+.restore-compare { margin: 10px 0 4px; }
+.restore-preview { background: var(--velvet-1); border: 1px solid var(--border); border-radius: 12px; padding: 14px; }
+.restore-preview-head { display: flex; align-items: center; gap: 10px; }
+.restore-preview-av { width: 40px; height: 40px; border-radius: 50%; overflow: hidden; flex-shrink: 0; background: linear-gradient(180deg, var(--av-from), var(--av-to)); }
+.restore-preview-av img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.restore-preview-id { min-width: 0; }
+.restore-preview-name { font-size: 16px; margin: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.restore-preview-nip05 { font-size: 12px; margin-top: 1px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.restore-preview-about { font-size: 13px; margin: 10px 0 0; max-height: 140px; overflow: hidden; }
 .show-more-btn { display: block; width: 100%; margin: 4px 0 10px; color: var(--lav); font-weight: 600; }
 #activity-clear { display: block; margin: 8px auto 0; }
 

--- a/test/backup-list-diff.test.js
+++ b/test/backup-list-diff.test.js
@@ -1,0 +1,136 @@
+'use strict';
+
+// Unit coverage for listDiff() and muteTags() — the counting behind the restore
+// confirmations.
+//
+// The modal work is DOM and isn't unit-testable here, but the NUMBERS are the
+// confirmation: "23 you follow today are not in the backup" is what stops a
+// restore that would shrink a live list, and a wrong number there is the
+// destructive-event bug this whole flow exists to prevent. The one case that
+// matters most is the reshuffle: same count on both sides, different members —
+// counts alone read as "no change" while the restore loses real follows.
+// muteTags is here for the private-list half: mutes encrypted in content count
+// as zero unless they're decrypted and merged, and a private list of hundreds
+// reading as "0 muted" is the wrong number, not a smaller one.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const ROOT = path.join(__dirname, '..');
+const source = fs.readFileSync(path.join(ROOT, 'sidepanel.js'), 'utf8');
+
+const m = source.match(/function listDiff\(currentTags, backupTags\) \{[\s\S]*?\n  \}/);
+if (!m) throw new Error('Could not find listDiff in sidepanel.js');
+const listDiff = new vm.Script('(function(){' + m[0] + '\nreturn listDiff;\n})()').runInNewContext({});
+
+const mm = source.match(/async function muteTags\(ev\) \{[\s\S]*?\n  \}/);
+if (!mm) throw new Error('Could not find muteTags in sidepanel.js');
+// The realm gets a fake `call` standing in for SIDECAR_OWNER_DECRYPT, so each
+// test scripts exactly what the keystore returns (and records which NIP it was
+// asked for, to pin the 44-first / 4-first heuristic).
+const makeMuteTags = (call) =>
+  new vm.Script('(function(){' + mm[0] + '\nreturn muteTags;\n})()').runInNewContext({ call });
+
+// Per-field asserts, not deepEqual: the lifted function runs in a vm realm, and
+// deepStrictEqual cross-realm rejects its return object even when every value
+// matches.
+function same(d, current, backup, dropped, added) {
+  assert.equal(d.current, current);
+  assert.equal(d.backup, backup);
+  assert.equal(d.dropped, dropped);
+  assert.equal(d.added, added);
+}
+
+const p = (n) => ['p', 'pk' + n];
+const N = (n) => Array.from({ length: n }, (_, i) => p(i));
+
+test('identical lists: nothing dropped, nothing added', () => {
+  same(listDiff(N(5), N(5)), 5, 5, 0, 0);
+});
+
+test('older backup: dropped counts only the current-only follows', () => {
+  same(listDiff(N(10), N(7)), 10, 7, 3, 0);
+});
+
+test('backup holds extras: added counts them', () => {
+  same(listDiff(N(3), N(5)), 3, 5, 0, 2);
+});
+
+test('reshuffle: equal counts, different members — the case counts alone miss', () => {
+  const cur = [p('a'), p('b'), p('c')];
+  const bak = [p('x'), p('y'), p('z')];
+  const d = listDiff(cur, bak);
+  assert.equal(d.current, 3);
+  assert.equal(d.backup, 3);
+  assert.equal(d.dropped, 3);
+  assert.equal(d.added, 3);
+});
+
+test('no live event: everything in the backup is new, nothing is lost', () => {
+  same(listDiff(null, N(4)), 0, 4, 0, 4);
+});
+
+test('non-p tags and duplicate entries are not counted', () => {
+  const tags = [p(1), p(1), ['e', 'evt1'], ['p'], p(2)];
+  same(listDiff(tags, [p(1), p(2)]), 2, 2, 0, 0);
+});
+
+test('muteTags: no content — public tags only, never marked private', async () => {
+  const fail = async () => { throw new Error('must not be called'); };
+  const out = await makeMuteTags(fail)({ tags: [p(1), p(2)], content: '' });
+  assert.equal(out.ok, true);
+  assert.equal(out.private, false);
+  assert.equal(out.tags.length, 2);
+});
+
+test('muteTags: NIP-44 private list merges with public tags, nip 44 tried first', async () => {
+  const tried = [];
+  const call = async (msg) => {
+    tried.push(msg.nip);
+    return JSON.stringify([['p', 'priv1'], ['p', 'priv2'], ['word', 'spam']]);
+  };
+  const out = await makeMuteTags(call)({ tags: [p(1)], content: 'ciphertext-without-iv' });
+  assert.deepEqual(tried, [44]);
+  assert.equal(out.ok, true);
+  assert.equal(out.private, true);
+  // 1 public + 3 decrypted (word tags ride along; listDiff filters by kind)
+  assert.equal(out.tags.length, 4);
+});
+
+test('muteTags: legacy NIP-04 ciphertext ("?iv=") tries nip 4 first', async () => {
+  const tried = [];
+  const call = async (msg) => {
+    tried.push(msg.nip);
+    if (msg.nip === 4) return JSON.stringify([p('priv')]);
+    throw new Error('wrong scheme');
+  };
+  const out = await makeMuteTags(call)({ tags: [], content: 'ct?iv=iv' });
+  assert.deepEqual(tried, [4]);
+  assert.equal(out.ok, true);
+  assert.equal(out.private, true);
+});
+
+test('muteTags: undecryptable content — ok=false, public tags kept', async () => {
+  const call = async () => { throw new Error('Keystore is locked'); };
+  const out = await makeMuteTags(call)({ tags: [p(1)], content: 'ct' });
+  assert.equal(out.ok, false);
+  assert.equal(out.private, true);
+  assert.equal(out.tags.length, 1);
+});
+
+test('muteTags: decrypted non-array is not a list — falls through to ok=false', async () => {
+  const tried = [];
+  const call = async (msg) => { tried.push(msg.nip); return '"a client note, not tags"'; };
+  const out = await makeMuteTags(call)({ tags: [], content: 'ct' });
+  assert.deepEqual(tried, [44, 4]); // both schemes tried, neither produced tags
+  assert.equal(out.ok, false);
+});
+
+test('muteTags + listDiff: a pubkey muted publicly and privately counts once', async () => {
+  const call = async () => JSON.stringify([['p', 'pk1'], ['p', 'pk9']]);
+  const out = await makeMuteTags(call)({ tags: [p(1), p(2)], content: 'ct' });
+  same(listDiff(out.tags, out.tags), 3, 3, 0, 0);
+});


### PR DESCRIPTION
Three asks from the backup screen, plus two integrity fixes that fell out of
testing them against real data, plus row polish.

The features:
- Backup rows show when each list was last backed up — read from the 30078's
  created_at, not session memory, so the row is right on a fresh open instead
  of saying "Not backed up" until you back up again.
- Restore confirms what it would overwrite, in both restore paths (the NIP-78
  modal and the file import): set differences, not just counts — "23 you
  follow today are not in the backup and will be removed" is the number that
  stops a bad restore. Counts alone hide the reshuffle: same N on both sides,
  different members.
- The profile backup renders as a bio preview pane, so "is this MY bio?" is
  answered by looking rather than by diffing field names.

The integrity fixes, both found on my own account's data:
- fetchLatestEvent read Settings relays only. nos.lol (a default) holds a
  two-month-old empty kind 3 for this account; it won the race one day and the
  export captured the empty list while every relay actually carrying the live
  1,100+ list sat outside the configured set. Restoring that file would have
  made the wipe real. It now reads readRelayUrls — NIP-65 plus purplepag.es
  plus Settings, the same set the follow-recovery screen already uses.
- Mutes are private: NIP-44-encrypted in the kind 10000 content (546 muted,
  per mutable). The confirm counted p-tags only, so every private list read
  as "0 muted". Both sides now decrypt and merge, the same dual read
  loadMuteList has always done; a list that won't decrypt says so rather than
  printing the public-only count as the whole thing, and an empty list is
  named ("Empty follow list in this file · 1,101 live now would be lost")
  rather than counted — "0 followed" reads like a measured zero.

Tests: listDiff and the new muteTags lifted into node:test via a vm realm —
12 cases, including the reshuffle and the scheme heuristic (NIP-44 first,
NIP-04 first when the ciphertext carries ?iv=). Suite 570/572; the two
failures are the pre-existing search-entity/web-comment ones that need
node_modules.

Polish: mini ghosts were rendering a size class above their filled siblings
(the big-button .ghost rule ties .mini on specificity and wins by file
order) — that also fixed the two Forget-site Cancel buttons. The timestamp
moved to its own grey line under a checked "Backed up".

Note: the JSON file exported before this branch is the bad capture — re-export
after this merges if you want a file worth keeping.

🍹 shaken with [GLM 5.3](https://z.ai)