### PR TITLE
Bookmarks: your NIP-51 lists, read from the relays and removable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,35 @@
+# Sidecar — UI rules
+
+## Row controls in a narrow panel (the recurring remove-button mistake)
+
+The panel is a ~360px sidebar; a modal sheet is 344px max, 300px of usable width
+after its padding. Desktop-dialog muscle memory — actions sitting inline *beside*
+content — does not fit in that width, and the recurring result is a row where the
+content ellipsizes to nothing while a label and two buttons jam against it.
+
+The grammar that already exists in this codebase, in order of preference:
+
+1. **The inline action slot (`.item-actions`) holds one or two icon buttons —
+   nothing with words.** It is `flex-shrink: 0` on purpose: buttons keep their
+   metrics and the content beside them does the truncating. A label plus two
+   buttons is roughly 200px of minimum width; beside content in 300px there is
+   no room for either to be usable.
+
+2. **A confirm that has words takes its own full-width row below the content.**
+   The row becomes a column — content on top, controls stretched beneath
+   (`flex-direction: column; align-items: stretch`). This is the connected-site
+   row (`.site-item` + `.site-controls` in styles.css) and the wallet tx row
+   (`.tx-row`). `.confirm-msg` is `flex: 1` because it was built for that
+   full-width row; dropping it into a side-by-side slot is the layout bug, not a
+   styling problem to patch with smaller text.
+
+3. **Or replace the row's content entirely.** The account switcher's two-tap
+   confirm rewrites the row's own two lines ("Switch to X?" → "Tap again to
+   confirm") — zero added chrome.
+
+Never make controls fit by shrinking them: no smaller font-size or padding on
+buttons, no wrapped or abbreviated button labels ("Rmv?"), no compressed confirm
+text. If something has to shrink, the layout is wrong — stack it (rule 2).
+Truncation belongs to prose only: `white-space: nowrap; overflow: hidden;
+text-overflow: ellipsis` on the line, and `min-width: 0` on the flex child so it
+can actually shrink.

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -83,6 +83,12 @@
         <button id="comment-btn" class="icon-btn" title="Comment on this page">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.9 11.45a9.22 9.22 0 0 1-.99 4.18 9.35 9.35 0 0 1-8.36 5.17 9.22 9.22 0 0 1-4.18-.99L2.1 21.9l2.09-6.27a9.22 9.22 0 0 1-.99-4.18 9.35 9.35 0 0 1 5.17-8.36 9.22 9.22 0 0 1 4.18-.99h.55a9.33 9.33 0 0 1 8.8 8.8z"></path></svg>
         </button>
+        <!-- The account's bookmarks (NIP-51 lists, written by other clients):
+             feather's bookmark. Grouped with the content icons for the same
+             reason the comment button is. -->
+        <button id="bookmarks-btn" class="icon-btn" title="Your bookmarks">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"></path></svg>
+        </button>
         <button id="help-btn" class="icon-btn" title="Help &amp; guides">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><circle cx="12" cy="12" r="4"></circle><line x1="4.93" y1="4.93" x2="9.17" y2="9.17"></line><line x1="14.83" y1="14.83" x2="19.07" y2="19.07"></line><line x1="14.83" y1="9.17" x2="19.07" y2="4.93"></line><line x1="9.17" y1="14.83" x2="4.93" y2="19.07"></line></svg>
         </button>

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -931,6 +931,13 @@
     if (a) showNotifModal(a);
   });
 
+  // Bookmarks lives in the topbar's content group (bell, search, comment),
+  // not as a tab: it's a list you dip into, not a surface you keep open.
+  $('bookmarks-btn').addEventListener('click', () => {
+    if (!state?.activePubkey) return;
+    renderBookmarks();
+  });
+
   // In-progress comment text, keyed by account + target URL. Clicking the overlay
   // dismisses the modal, and losing a half-written comment to a stray click is
   // infuriating in a panel this narrow.
@@ -2406,7 +2413,13 @@
     if (diff < 3600) return Math.floor(diff / 60) + 'm ago';
     if (diff < 86400) return Math.floor(diff / 3600) + 'h ago';
     if (diff < 7 * 86400) return Math.floor(diff / 86400) + 'd ago';
-    return new Date(ts * 1000).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+    // Beyond a week it's a date, and a date without a year reads as this year —
+    // "Mar 4" on something from 2024 is a quiet lie. Year only when it differs.
+    const d = new Date(ts * 1000);
+    return d.toLocaleDateString(undefined, {
+      month: 'short', day: 'numeric',
+      year: d.getFullYear() === new Date().getFullYear() ? undefined : 'numeric',
+    });
   }
 
   function notifLabel(ev) {
@@ -8005,7 +8018,283 @@
     state = await call({ type: 'SIDECAR_GET_STATE' });
   }
 
-  // ---- NIP-78 encrypted backup/restore (profile / follows / mute) ----
+  // ---- Bookmarks (topbar icon → modal): the account's bookmark lists, as other clients wrote them ----
+  // NIP-51 keeps bookmarks in two shapes: kind 10003 is the flat list every
+  // client agrees on, and kind 30001 is one replaceable event per named
+  // category (its d-tag). Sidecar writes none of them — this modal reads what
+  // the account's clients published, groups by category where categories
+  // exist, and removes an entry by republishing the owning list without that
+  // e-tag. Rows hand off to the preferred web client: Sidecar is the signer,
+  // not the reader.
+  const HEX_ID = /^[0-9a-f]{64}$/;
+  const BM_KIND_LABEL = { 0: 'profile', 1: 'note', 6: 'repost', 30023: 'article', 1063: 'live event', 1068: 'live chat' };
+
+  // Every bookmark list event, raw, for bookmarkSections to shape.
+  async function fetchBookmarkLists() {
+    return getPool().querySync(
+      await readRelayUrls(state.activePubkey),
+      { kinds: [10003, 30001], authors: [state.activePubkey] },
+      { maxWait: 6000 }
+    );
+  }
+
+  // Pure: raw kind 10003/30001 events → ordered sections. The flat 10003 comes
+  // first (it's what clients without categories write), then one section per
+  // 30001 d-tag, by name. Replaceable events arrive as copies; newest
+  // created_at per key wins, the same rule loadMuteList applies to kind 10000.
+  // Lifted into test/bookmark-sections.test.js.
+  function bookmarkSections(evs) {
+    const latest = new Map();
+    for (const ev of evs || []) {
+      const d = ev.kind === 10003 ? '' : (ev.tags.find((t) => t[0] === 'd') || [])[1] || '';
+      const key = (ev.kind === 10003 ? 'F|' : 'C|') + d;
+      const cur = latest.get(key);
+      if (!cur || ev.created_at >= cur.created_at) latest.set(key, ev);
+    }
+    const sections = [];
+    const flat = latest.get('F|');
+    if (flat) sections.push({ title: '', ev: flat });
+    [...latest.entries()]
+      .filter(([k]) => k[0] === 'C')
+      .sort((a, b) => a[0].slice(2).localeCompare(b[0].slice(2)))
+      .forEach(([k, ev]) => sections.push({ title: k.slice(2), ev }));
+    return sections;
+  }
+
+  // The bookmarked events themselves. Relays cap ids per filter, so ids go out
+  // in chunks; whichever relay answers first for an id is fine — same id,
+  // same event. A row whose event never comes back still renders (and can
+  // still be opened by id or removed); it just shows no preview.
+  async function fetchEventsByIds(ids) {
+    const relays = await readRelayUrls(state.activePubkey);
+    const found = new Map();
+    const chunks = [];
+    for (let i = 0; i < ids.length; i += 64) chunks.push(ids.slice(i, i + 64));
+    await Promise.all(chunks.map(async (chunk) => {
+      try {
+        const evs = await getPool().querySync(relays, { ids: chunk }, { maxWait: 5000 });
+        (evs || []).forEach((ev) => { if (!found.has(ev.id)) found.set(ev.id, ev); });
+      } catch (_) {}
+    }));
+    return found;
+  }
+
+  // Opened from the topbar icon: a full-height modal (modal-sheet) that paints
+  // at full size immediately, spinner or cached rows inside — the sheet is the
+  // modal, not something content has to grow into. A modal closed mid-fetch
+  // leaves its DOM merely hidden, so "gone" is the overlay check, not
+  // isConnected.
+  function renderBookmarks() {
+    if (!state?.activePubkey) return;
+    openModal((modal) => {
+      modal.classList.add('modal-sheet');
+      const x = h('button', { className: 'modal-x', title: 'Close' });
+      x.appendChild(icon('x'));
+      x.addEventListener('click', closeModal);
+      const scroll = h('div', { className: 'bm-scroll' });
+      modal.append(x, h('h3', { textContent: 'Bookmarks' }), scroll);
+      const gone = () => $('modal-overlay').classList.contains('hidden');
+      if (_bmCache.pubkey === state.activePubkey && _bmCache.evs) {
+        fillBookmarks(scroll, gone, _bmCache.evs, _bmCache.events);
+        // Quiet refresh behind the cached rows: the screen only moves when the
+        // relays actually say something different, and never while a removal
+        // confirm is on screen (a swap there would eat the user's tap).
+        refreshBookmarks().then((changed) => {
+          if (changed && !gone() && !scroll.querySelector('.del-confirm')) {
+            fillBookmarks(scroll, gone, _bmCache.evs, _bmCache.events);
+          }
+        });
+      } else {
+        scroll.append(h('div', { className: 'recv-waiting' }, [
+          h('span', { className: 'recv-spinner' }),
+          h('span', { textContent: 'Reading your relays…' }),
+        ]));
+        refreshBookmarks().then(() => {
+          if (!gone()) fillBookmarks(scroll, gone, _bmCache.evs, _bmCache.events);
+        });
+      }
+    });
+  }
+
+  // Session cache per account: the modal opens instantly from the last fetch,
+  // and a background refresh keeps it honest. Signatures compare which list
+  // events exist (id + created_at) and which bookmark ids resolved, so an
+  // unchanged refresh costs nothing on screen.
+  const _bmCache = { pubkey: null, evs: null, events: null };
+  const bmListsSig = (evs) => (evs || []).map((e) => e.id + ':' + e.created_at).sort().join('|');
+  const bmFoundSig = (events) => [...(events || new Map()).keys()].sort().join(',');
+  async function refreshBookmarks() {
+    const pubkey = state.activePubkey;
+    let evs;
+    try {
+      evs = await fetchBookmarkLists();
+    } catch (_) {
+      return false;
+    }
+    const ids = [];
+    const seen = new Set();
+    bookmarkSections(evs).forEach((s) => s.ev.tags.forEach((t) => {
+      const id = t && t[0] === 'e' && t[1];
+      if (HEX_ID.test(id || '') && !seen.has(id)) { seen.add(id); ids.push(id); }
+    }));
+    const events = await fetchEventsByIds(ids);
+    const changed = _bmCache.pubkey !== pubkey ||
+      bmListsSig(_bmCache.evs) !== bmListsSig(evs) ||
+      bmFoundSig(_bmCache.events) !== bmFoundSig(events);
+    _bmCache.pubkey = pubkey;
+    _bmCache.evs = evs;
+    _bmCache.events = events;
+    return changed;
+  }
+
+  async function fillBookmarks(scroll, gone, evs, events) {
+    // The scroll container is cleared rather than appended to: the quiet
+    // refresh re-runs this on a scroll that already holds rows (and the first
+    // run replaces the spinner), and a second .bm-list under the first would
+    // duplicate every bookmark.
+    scroll.textContent = '';
+    // Sections: the flat list first (what clients without categories write),
+    // then categories by name. A list with no e-tags renders nothing — no
+    // entries to show, none to remove.
+    const sections = bookmarkSections(evs);
+
+    const empty = () => {
+      scroll.textContent = '';
+      scroll.append(h('p', {
+        className: 'hint',
+        textContent: 'No bookmarks yet. Bookmark a note from any Nostr client and it shows up here.',
+      }));
+    };
+    if (!sections.length) return empty();
+
+    // Profiles for the authors (getProfile is cached, so repeat authors are
+    // cheap and a cached reopen resolves instantly).
+    const authors = [...new Set([...events.values()].map((e) => e.pubkey))];
+    const profiles = new Map(await Promise.all(authors.map(async (pk) => [pk, await getProfile(pk)])));
+    if (gone()) return;
+
+    const list = h('div', { className: 'bm-list' });
+    scroll.append(list);
+
+    // One bookmark: the referenced event's author and a snippet, opening in
+    // the preferred web client, removable by republishing the owning list.
+    // `missing` rows (the relays no longer return the event) still render —
+    // dimmed, sorted below the found ones — because they remain bookmarks:
+    // openable by id, and removable.
+    const buildRow = (id, parent, missing) => {
+      const ref = missing ? null : events.get(id);
+      const prof = ref ? profiles.get(ref.pubkey) : null;
+      let npub = '';
+      if (ref) { try { npub = NT.nip19.npubEncode(ref.pubkey); } catch (_) {} }
+      const item = h('div', { className: 'bm-item' + (missing ? ' bm-missing' : ''), title: 'Open in your web client' });
+      const main = h('div', { className: 'bm-main' }, [
+        h('div', { className: 'bm-head' }, [
+          avatarEl({ picture: prof && prof.picture, npub }, 'bm-av'),
+          h('div', { className: 'bm-name', textContent: (prof && prof.name) || (npub ? shortNpub(npub) : 'Unknown author') }),
+        ]),
+        h('div', {
+          className: 'bm-snippet',
+          textContent: missing
+            ? id.slice(0, 8) + '…' + id.slice(-6)
+            : quoteSnippet(ref.content) || '“' + (BM_KIND_LABEL[ref.kind] || 'kind ' + ref.kind) + '”',
+        }),
+        h('div', {
+          className: 'bm-meta',
+          textContent: missing ? 'not found on your relays' : (BM_KIND_LABEL[ref.kind] || 'kind ' + ref.kind) + ' · ' + relativeTime(ref.created_at),
+        }),
+      ]);
+      const actions = h('div', { className: 'item-actions' });
+      // The resting row keeps a lone icon button in the inline slot; the confirm
+      // has words, so it takes its own full-width row under the content (the
+      // connected-site grammar) instead of squeezing a label and two buttons
+      // beside a 300px-wide row.
+      const confirmRow = h('div', { className: 'bm-confirm' });
+      let confirming = false;
+      const drawResting = () => {
+        confirming = false;
+        item.classList.remove('bm-confirming');
+        confirmRow.remove();
+        confirmRow.textContent = '';
+        actions.textContent = '';
+        actions.append(iconButton('Remove bookmark', 'x', (e) => {
+          e.stopPropagation();
+          drawConfirm();
+        }));
+      };
+      const drawConfirm = () => {
+        confirming = true;
+        item.classList.add('bm-confirming');
+        confirmRow.textContent = '';
+        const yes = h('button', { className: 'mini del-confirm', textContent: 'Remove' });
+        const no = h('button', { className: 'mini ghost', textContent: 'Cancel' });
+        yes.addEventListener('click', async (e) => {
+          e.stopPropagation();
+          yes.disabled = true;
+          yes.textContent = 'Removing…';
+          // Republish the owning list minus EVERY e-tag for this id — a client
+          // that wrote the same bookmark twice should see both copies go. The
+          // 30001's d-tag rides through untouched (only e-tags are filtered),
+          // so the category stays the same replaceable stream.
+          const tags = parent.tags.filter((t) => !(t[0] === 'e' && t[1] === id));
+          try {
+            const signed = await call({ type: 'SIDECAR_OWNER_SIGN', event: { kind: parent.kind, created_at: Math.floor(Date.now() / 1000), tags, content: parent.content || '' } });
+            await publishSigned(signed);
+            parent.tags = tags; // keep the in-memory copy honest for this session
+            const group = item.closest('.bm-group');
+            item.remove();
+            if (group && !group.querySelector('.bm-item')) group.remove();
+            if (!list.querySelector('.bm-item')) empty();
+            toast('Bookmark removed', 'success');
+          } catch (err) {
+            toast((err && err.message) || 'Could not remove the bookmark', 'error');
+            drawResting();
+          }
+        });
+        no.addEventListener('click', (e) => { e.stopPropagation(); drawResting(); });
+        confirmRow.append(h('span', { className: 'confirm-msg', textContent: 'Remove this bookmark?' }), yes, no);
+        item.append(confirmRow);
+      };
+      drawResting();
+      item.addEventListener('click', async () => {
+        // While the confirm is open the row isn't a link — a tap on the message
+        // (or the gap beside it) must not open the client behind the confirm.
+        if (confirming) return;
+        const client = await preferredClient();
+        try {
+          openInClient(client.url(NT.nip19.neventEncode({ id, author: ref ? ref.pubkey : undefined, relays: [] })));
+        } catch (_) {}
+      });
+      item.append(main, actions);
+      return item;
+    };
+
+    sections.forEach((s) => {
+      // Found entries first, in the owning client's own order; entries whose
+      // events no longer resolve sort to the bottom under their own divider —
+      // they're still bookmarks, but they can't be previewed, and a wall of
+      // "not found" ahead of real notes reads as a broken modal.
+      const found = [];
+      const missing = [];
+      const seen = new Set();
+      s.ev.tags.forEach((t) => {
+        const id = t && t[0] === 'e' && t[1];
+        if (!HEX_ID.test(id || '') || seen.has(id)) return;
+        seen.add(id);
+        (events.has(id) ? found : missing).push(id);
+      });
+      if (!found.length && !missing.length) return;
+      const group = h('div', { className: 'bm-group' });
+      if (s.title) group.append(h('div', { className: 'bm-cat', textContent: s.title }));
+      found.forEach((id) => group.append(buildRow(id, s.ev, false)));
+      if (missing.length) {
+        if (found.length) group.append(h('div', { className: 'bm-missing-head', textContent: 'Not on your relays' }));
+        missing.forEach((id) => group.append(buildRow(id, s.ev, true)));
+      }
+      list.append(group);
+    });
+    if (!list.children.length) return empty();
+  }
+
   const BACKUP_TYPES = [
     { key: 'profile', label: 'Profile', kind: 0, dtag: 'sidecar:profile-backup' },
     { key: 'follows', label: 'Follows', kind: 3, dtag: 'sidecar:follows-backup' },

--- a/styles.css
+++ b/styles.css
@@ -1385,6 +1385,48 @@ a.notif-clickable:hover .notif-link { color: var(--lav); }
 .export-block .hint { margin-bottom: 10px; }
 .export-block .secondary { display: block; width: 100%; margin-bottom: 8px; }
 
+/* bookmarks modal — NIP-51 lists written by other clients, grouped by category.
+   Rows follow the notifications layout: full-width dividers between full-bleed
+   rows, no boxed containers (a box inside the modal sheet reads as a narrow
+   column and wastes the width). */
+.bm-scroll { overflow-y: auto; flex: 1; min-height: 0; margin: 0 -22px -22px; padding: 0 22px 22px; }
+.bm-list { display: flex; flex-direction: column; margin-top: 4px; }
+.bm-cat {
+  font-family: var(--font-ui); font-size: 12px; font-weight: 600; color: var(--muted);
+  margin: 16px 0 2px; letter-spacing: 0.03em;
+}
+.bm-list .bm-group:first-child .bm-cat { margin-top: 0; }
+.bm-item {
+  display: flex; align-items: center; justify-content: space-between; gap: 8px;
+  padding: 10px 8px; margin: 0 -8px; border-radius: 10px; cursor: pointer;
+  border-bottom: 1px solid var(--border);
+}
+.bm-item:hover { background: var(--hover-soft); }
+.bm-list .bm-group:last-child .bm-item:last-child { border-bottom: none; }
+.bm-main { flex: 1; min-width: 0; }
+.bm-head { display: flex; align-items: center; gap: 8px; min-width: 0; }
+.bm-av { width: 22px; height: 22px; border-radius: 50%; overflow: hidden; flex-shrink: 0; background: linear-gradient(180deg, var(--av-from), var(--av-to)); }
+.bm-av img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.bm-name { font-weight: 600; font-size: 13px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.bm-snippet { font-size: 12px; color: var(--muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; margin-top: 2px; }
+.bm-meta { font-size: 11px; color: var(--faint); margin-top: 2px; }
+/* entries whose events the relays no longer return: below the found ones,
+   under a divider, dimmed — present (they're still bookmarks) but quiet */
+/* remove confirm: the row becomes a column so "Remove this bookmark?" plus its
+   two buttons get the full width, with the bookmark still legible above them —
+   words never share the inline action slot beside the content */
+.bm-item.bm-confirming { flex-direction: column; align-items: stretch; gap: 10px; cursor: default; }
+.bm-item.bm-confirming:hover { background: none; }
+.bm-item.bm-confirming .item-actions { display: none; }
+.bm-confirm { display: flex; align-items: center; gap: 8px; }
+.bm-item.bm-missing { opacity: 0.55; }
+/* a dimmed row still gets an undimmed confirm — the red Remove has to keep its
+   contrast, so the dimming moves onto the content while the confirm is open */
+.bm-item.bm-missing.bm-confirming { opacity: 1; }
+.bm-item.bm-missing.bm-confirming .bm-main { opacity: 0.55; }
+.bm-item.bm-missing .bm-snippet { font-family: var(--font-mono); font-size: 11.5px; }
+.bm-missing-head { font-size: 11px; color: var(--faint); letter-spacing: 0.03em; margin: 12px 0 0; padding-top: 10px; border-top: 1px solid var(--border); }
+
 /* follow-list recovery modal */
 .modal .recovery-modal .actions { margin-top: 22px; }
 .mutable-credit { display: inline-flex; align-items: center; gap: 8px; margin-top: 14px; font-size: 13px; font-weight: 500; color: var(--muted); text-decoration: none; }

--- a/test/bookmark-sections.test.js
+++ b/test/bookmark-sections.test.js
@@ -1,0 +1,71 @@
+'use strict';
+
+// Unit coverage for bookmarkSections() — the shaping behind the Bookmarks tab.
+//
+// The fetch is network and the rows are DOM, but the ORDER is the part users
+// feel: the flat list first, categories after, newest copy of each list win.
+// Replaceable events arrive as copies from every relay, and an older copy of
+// the flat list beating the newer one is the same stale-read bug the backup
+// export had — so the rule is pinned here, not left to the query's mood.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const ROOT = path.join(__dirname, '..');
+const source = fs.readFileSync(path.join(ROOT, 'sidepanel.js'), 'utf8');
+
+const m = source.match(/function bookmarkSections\(evs\) \{[\s\S]*?\n  \}/);
+if (!m) throw new Error('Could not find bookmarkSections in sidepanel.js');
+const bookmarkSections = new vm.Script('(function(){' + m[0] + '\nreturn bookmarkSections;\n})()').runInNewContext({});
+
+const ev = (kind, created_at, d, ids) => ({
+  kind,
+  created_at,
+  tags: (d ? [['d', d]] : []).concat(ids.map((id) => ['e', id])),
+});
+
+test('flat list alone: one untitled section', () => {
+  const s = bookmarkSections([ev(10003, 100, null, ['a', 'b'])]);
+  assert.equal(s.length, 1);
+  assert.equal(s[0].title, '');
+  assert.equal(s[0].ev.kind, 10003);
+});
+
+test('flat first, then categories sorted by name', () => {
+  const s = bookmarkSections([
+    ev(30001, 100, 'tools', ['t1']),
+    ev(10003, 100, null, ['f1']),
+    ev(30001, 100, 'articles', ['a1']),
+  ]);
+  assert.deepEqual([...s.map((x) => x.title)], ['', 'articles', 'tools']); // spread: realm array → local
+});
+
+test('newest copy of the flat list wins over an older one', () => {
+  const s = bookmarkSections([ev(10003, 100, null, ['old']), ev(10003, 200, null, ['new'])]);
+  assert.equal(s.length, 1);
+  assert.deepEqual([...s[0].ev.tags.map((t) => t[1])], ['new']);
+});
+
+test('newest copy wins per category, not across categories', () => {
+  const s = bookmarkSections([
+    ev(30001, 500, 'a', ['a-old']),
+    ev(30001, 100, 'b', ['b-new']),
+    ev(30001, 900, 'a', ['a-new']),
+  ]);
+  assert.deepEqual([...s.map((x) => x.ev.tags.find((t) => t[0] === 'e')[1])], ['a-new', 'b-new']); // tags[0] is the d-tag
+});
+
+test('a 30001 without a d-tag is its own untitled section, not the flat list', () => {
+  const s = bookmarkSections([ev(10003, 100, null, ['flat']), ev(30001, 100, null, ['cat'])]);
+  assert.equal(s.length, 2);
+  assert.equal(s[0].ev.kind, 10003);
+  assert.deepEqual([...s[1].ev.tags.map((t) => t[1])], ['cat']);
+});
+
+test('no bookmark events at all: no sections', () => {
+  assert.equal(bookmarkSections([]).length, 0);
+  assert.equal(bookmarkSections(null).length, 0);
+});


### PR DESCRIPTION
A bookmark icon in the topbar's content group opens a full-height modal over the
active account's own bookmark lists: kind 10003 (the flat list every client
agrees on) and kind 30001 (one replaceable event per named category, grouped by
its d-tag). Rows show the referenced event as its author wrote it — avatar, name,
snippet, kind label, relative time — and a tap opens it in the preferred web
client. Sidecar writes no bookmark list of its own; it reads and edits what other
clients published.

Entries the relays no longer return still render, dimmed under a "Not on your
relays" divider at the foot of their section. They're still bookmarks — openable
by id, removable — and dropping them would make a list look shorter than it is.

Remove republishes the owning list minus every e-tag for that id, so a client
that wrote the same bookmark twice sees both copies go. Only e-tags are filtered,
so the 30001's d-tag rides through and the category stays the same replaceable
stream.

The remove confirm was the last thing fixed, and it's the reason CLAUDE.md is in
this branch. A label plus two buttons is ~200px of minimum width; beside content
in a 300px sheet the row collapsed to "Un…" with the confirm wrapped over four
lines. It now follows the connected-site grammar — the row becomes a column and
the confirm takes the full width under the bookmark it's about, with the row's
open-in-client tap gated while it's open so tapping "Remove this bookmark?"
can't open the note behind it. A dimmed "not found" row un-dims while confirming
so the red Remove keeps its contrast.

Reads chunk ids 64 at a time (relays cap ids per filter, and a long list asked
for in one filter comes back short). A per-pubkey session cache paints a reopen
instantly, then a quiet refresh re-renders only if the relays actually differ,
and never while a removal confirm is open.

relativeTime now switches to a date past a week and shows the year only when it
differs from the current one — "Mar 4" on a 2024 bookmark is a quiet lie.

Verified: node --check clean; suite 578 tests, 576 pass, the 2 pre-existing
failures (search-entity, web-comment). bookmarkSections is pure and covered by
6 tests. The confirm layout was checked by rendering the row markup against the
real styles.css at 344px, not just by reading it.

🍸 chilled with [GLM 5.3](https://z.ai)
