### PR TITLE
Ship a source archive with every AMO submission

### DIFF
--- a/BROWSER_PARITY.md
+++ b/BROWSER_PARITY.md
@@ -34,10 +34,25 @@ build loads a background that's missing a module, with no error until something
 calls into it.
 
 **Current status:** shipped and live on both stores. Firefox launched in 1.5.0;
-AMO is public. AMO auto-approves listed extensions that pass automated validation
-and publishes within minutes, while the Chrome Web Store takes up to a week — so
-the normal steady state is a newer version live on Firefox and the previous one
-on Chrome. That gap is expected, not a problem to manage.
+AMO is public.
+
+**The store gap, and which way it runs.** Through 1.8.0 AMO auto-approved on
+automated validation and published within minutes, while the Chrome Web Store
+took up to a week, so the steady state was Firefox ahead and Chrome behind. That
+has inverted: AMO review slowed to human review with no published turnaround, and
+1.9.1 sat in the queue while it was already live on Chrome. Plan for Chrome
+landing first and for Firefox to skip versions entirely — a Firefox user may go
+straight from 1.8.0 to 1.10.0. Consequences worth holding onto:
+
+- **Never block a Chrome release on the AMO queue.** Submit both, ship what
+  clears.
+- **Never withdraw a pending AMO version to replace it with a newer one.** You
+  lose the queue position, and AMO locks the version string forever. Two versions
+  pending at once is fine: AMO serves the highest approved version, so a late
+  approval of an older one cannot downgrade anybody.
+- **AMO release notes have to cover the versions Firefox skipped**, since that
+  store's users never saw them. In-app is already handled — `help.html#whats-new`
+  keeps every prior version's section.
 
 ## Shared vs. browser-specific
 
@@ -80,8 +95,17 @@ on Chrome. That gap is expected, not a problem to manage.
       version — it forces a point release, and the two stores end up on different
       numbers.
 - [ ] Tag `vX.Y.Z`, then `scripts/package.sh vX.Y.Z` (it requires the tag and a clean
-      tree, and emits both zips).
-- [ ] Submit to **both** stores at once and let Firefox land first.
+      tree, and emits both store zips), then `scripts/package-source.sh vX.Y.Z`
+      for `dist/sidecar-X.Y.Z-source.zip`.
+- [ ] **On AMO, answer YES to the machine-generated-code question and upload the
+      source zip.** Every release, without re-arguing it. `nip49.js` is an esbuild
+      bundle, which meets AMO's definition on its own, and the store zip strips
+      `scripts/` and `VENDOR.md` — every answer a reviewer needs is only in the
+      source zip. Paste `REVIEWERS.md` into the build-instructions field.
+      Under-declaring this is what gets an add-on rejected and taken down;
+      over-declaring only slows the review.
+- [ ] Submit to **both** stores at once, and ship whichever clears first — see
+      the store gap above.
 
 ## Known cross-browser gotchas
 

--- a/REVIEWERS.md
+++ b/REVIEWERS.md
@@ -152,7 +152,24 @@ fetches for content the user is viewing. There is no analytics, telemetry, or
 error reporting of any kind. `PRIVACY.md` in the source package documents this in
 full.
 
-## 7. Questions
+## 7. What this archive leaves out
+
+The archive is the repository at the release tag, with five paths held back.
+None of them is source for anything in the add-on, none is read by any build or
+verification step, and removing them changes no shipped byte:
+
+| Path | Why |
+|---|---|
+| `.claude/`, `CLAUDE.md` | Local editor-tooling config and an internal UI style rule. |
+| `FIREFOX_PORT.md` | A port *plan* whose own status line reads "DONE. Shipped in 1.5.0". `BROWSER_PARITY.md`, which is included, describes the build that actually exists. |
+| `docs/release-1.8.0-description.md`, `docs/release-1.8.0-guide.md` | Store listing copy for a version two releases back. |
+
+Everything that produces, verifies, or documents shipped code is present —
+including `scripts/` in full, `VENDOR.md`, `.github/` (the CI that enforces the
+vendored hashes), `test/`, and the docs that describe live code. The complete
+repository, with nothing held back at all, is public at the tag; see §8.
+
+## 8. Questions
 
 The complete source, including this file, is at
 <https://github.com/dmnyc/sidecar> under the MIT license. Every released version

--- a/REVIEWERS.md
+++ b/REVIEWERS.md
@@ -1,0 +1,160 @@
+# Build and verification instructions for reviewers
+
+This document accompanies the source-code submission for Sidecar on
+addons.mozilla.org. It explains exactly how the uploaded add-on package is
+produced, how to reproduce it byte-for-byte, and where every piece of
+machine-generated code comes from.
+
+**Short version:** Sidecar has no build step. The extension is plain JavaScript,
+loaded as classic scripts. What ships is what is committed, with two exceptions,
+both documented below: four vendored third-party bundles, and a generated
+one-line `version.js`.
+
+---
+
+## 1. Toolchain
+
+Reproducing the add-on package needs only:
+
+| Tool | Purpose | Version |
+|---|---|---|
+| `git` | checkout, archive | any recent |
+| `bash`, `zip`, `find`, `touch` | packaging | any recent |
+| `node` + `npm` | *only* to re-derive the vendored bundles (§4) | node ≥ 18 |
+
+No compiler, transpiler, or bundler runs at package time. `node` is needed only
+if you want to independently re-derive the vendored files; it is not required to
+reproduce the package itself.
+
+## 2. Reproduce the submitted package
+
+From a clean checkout of this repository at the release tag:
+
+```sh
+git checkout v<VERSION>
+scripts/package.sh v<VERSION>
+```
+
+This writes two files:
+
+- `dist/sidecar-<VERSION>-firefox.zip` — the AMO package
+- `dist/sidecar-<VERSION>.zip` — the Chrome package
+
+The build is deterministic. Every file is stamped with the tag's commit date in
+UTC and entries are added in sorted order, so the same tag produces the same
+bytes on any machine. The SHA-256 printed by the script should match the one
+published in this release's GitHub release notes, and the file you were sent.
+
+> Packages for version 1.9.1 and earlier were built before determinism was added.
+> For those, extract both archives and compare the contents; they will be
+> identical, but the archive bytes will differ because file mtimes came from the
+> moment of packaging.
+
+## 3. What `package.sh` does
+
+It is a copy-and-prune, not a build:
+
+1. `git archive <tag>` extracts the repository at the tag.
+2. Development-only paths are deleted: `.github/`, `scripts/`, `assets/`,
+   `test/`, `docs/`, `.claude/`, and the top-level Markdown files
+   (`README.md`, `CHANGELOG.md`, `PRIVACY.md`, and the rest), plus
+   `package.json`.
+3. `version.js` is generated — a single line recording the version and commit,
+   shown in the About dialog. It is the only generated first-party file.
+4. `manifest.json` is reduced to one browser's keys. The repository keeps the
+   union of both browsers' manifest keys so the extension can be loaded unpacked
+   in either browser without a build step. At package time the Firefox zip drops
+   `side_panel`, `minimum_chrome_version`, `externally_connectable`, the
+   `sidePanel` permission, and `background.service_worker`; the Chrome zip drops
+   `sidebar_action`, `browser_specific_settings`, and `background.scripts`. No
+   other file is modified.
+5. The result is zipped.
+
+No file contents are otherwise transformed. Every `.js` file in the package is
+byte-identical to the same file in this repository at the tag, except
+`version.js`.
+
+## 4. Vendored third-party code
+
+Four files in the package are third-party bundles rather than hand-written
+source. They are the reason this source submission exists.
+
+| File | Origin | Modified? |
+|---|---|---|
+| `nostr-tools.js` | `nostr-tools@2.23.11`, `lib/nostr.bundle.js` from npm | No — byte-exact copy |
+| `jsqr.js` | `jsqr@1.4.0`, `dist/jsQR.js` from npm | No — byte-exact copy |
+| `qrcode-generator.js` | `qrcode-generator@2.0.4`, `dist/qrcode.js` from npm | No — byte-exact copy |
+| `nip49.js` | built here with `esbuild@0.28.1` from `nostr-tools@2.23.11` | Generated, see below |
+
+None of the four are minified or obfuscated. They are readable bundler output,
+shipped as published upstream.
+
+**`nip49.js` is the only file we generate ourselves.** nostr-tools' prebuilt
+browser bundle does not export its NIP-49 module, so it is bundled separately
+from the same pinned package:
+
+- entry point: `export * from "nostr-tools/nip49";`
+- command: `esbuild entry.js --bundle --format=iife --global-name=SidecarNip49`
+
+### Re-deriving and verifying all four
+
+```sh
+scripts/update-vendor.sh
+git diff          # expected to be empty
+```
+
+`scripts/update-vendor.sh` downloads each pinned package from
+`registry.npmjs.org`, verifies each tarball's SHA-512 against the registry's own
+`dist.integrity` value *before extracting it*, copies the three byte-exact files
+into place, rebuilds `nip49.js` with the pinned esbuild, and compares the results
+against the committed hashes. An unexpected change aborts with the tree
+untouched.
+
+To check the committed files without network access:
+
+```sh
+sha256sum -c scripts/vendor-hashes.sha256
+```
+
+These hashes are also verified by CI on every push and pull request.
+`VENDOR.md` carries the same provenance table with the expected hashes and
+license for each file.
+
+## 5. Things that may look like minified code and are not
+
+A handful of first-party lines are very long. All of them are **inline SVG path
+data** for icons and illustrations, embedded as string literals so the extension
+makes no network requests and needs no image assets:
+
+| File | Line | Content |
+|---|---|---|
+| `welcome.js` | 282 | app logo, inline `<svg>` |
+| `wallets.js` | 38 | wallet logo, inline `<svg>` |
+| `sidepanel.js` | 89 | decorative icon `<g>` element |
+| `pdf-backup.js` | 556 | illustration path data for the printable backup sheet |
+| `content.js` | 349–353 | logo path data |
+
+Every one is a single string of SVG coordinates. No first-party JavaScript in
+this repository is minified, transpiled, concatenated, or otherwise
+machine-generated.
+
+## 6. Remote code
+
+None. Sidecar loads and executes no remote code. There is no `eval`, no
+dynamically constructed script, and no code fetched at runtime. All scripts are
+classic `<script src="...">` or `importScripts()` references to files inside the
+package.
+
+Network access is limited to: user-configured Nostr relays over WebSocket,
+user-configured Lightning wallet relays (NWC, also WebSocket), user-configured
+Blossom media servers for uploads the user initiates, and link-preview or avatar
+fetches for content the user is viewing. There is no analytics, telemetry, or
+error reporting of any kind. `PRIVACY.md` in the source package documents this in
+full.
+
+## 7. Questions
+
+The complete source, including this file, is at
+<https://github.com/dmnyc/sidecar> under the MIT license. Every released version
+is tagged, and each GitHub release carries the same packages submitted to the
+stores along with their SHA-256 hashes.

--- a/scripts/package-source.sh
+++ b/scripts/package-source.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Builds the source-code archive that accompanies an AMO submission.
+#
+# AMO requires a source submission for any add-on containing machine-generated
+# code. Sidecar has no build step for its own code, but it ships four vendored
+# third-party bundles — three copied byte-exact from npm, and nip49.js which is
+# built here with esbuild. That is enough to require this, and Mozilla has asked
+# for it directly, so it is uploaded with every AMO submission unconditionally
+# rather than argued about per release.
+#
+# The archive is the whole repository at the tag: all first-party source, the
+# vendoring and packaging scripts, the tests, and REVIEWERS.md (the build and
+# verification instructions). Nothing is pruned — a reviewer should be able to
+# reproduce the submitted package from this archive alone.
+#
+# Deterministic, like scripts/package.sh: same tag in, same bytes out.
+#
+# Usage: scripts/package-source.sh [vX.Y.Z]   (default: the manifest's version)
+set -euo pipefail
+cd "$(dirname "$0")/.."
+ROOT="$PWD"
+
+MANIFEST_VERSION=$(grep -m1 '"version"' manifest.json | sed -E 's/.*"version"[^"]*"([^"]+)".*/\1/')
+TAG="${1:-v${MANIFEST_VERSION}}"
+
+if ! git rev-parse --verify --quiet "refs/tags/${TAG}" >/dev/null; then
+  echo "Tag '${TAG}' not found. Usage: scripts/package-source.sh [vX.Y.Z]" >&2
+  exit 1
+fi
+
+VERSION_NO_V="${TAG#v}"
+OUT="dist/sidecar-${VERSION_NO_V}-source.zip"
+SOURCE_DATE=$(TZ=UTC git log -1 --format=%cd --date=format-local:'%Y%m%d%H%M.%S' "${TAG}^{commit}")
+
+STAGE="$(mktemp -d)/sidecar-${VERSION_NO_V}-source"
+trap 'rm -rf "$(dirname "$STAGE")"' EXIT
+mkdir -p "${STAGE}"
+git archive "${TAG}" | tar -x -C "${STAGE}"
+
+if [ ! -f "${STAGE}/REVIEWERS.md" ]; then
+  echo "REVIEWERS.md is not present at ${TAG}. The source archive is not much use" >&2
+  echo "without the build instructions — commit it before tagging." >&2
+  exit 1
+fi
+
+mkdir -p dist
+rm -f "${ROOT}/${OUT}"
+find "${STAGE}" -exec touch -t "${SOURCE_DATE}" {} +
+( cd "$(dirname "${STAGE}")" && find . -type f | LC_ALL=C sort | zip -qXD "${ROOT}/${OUT}" -@ )
+
+files=$(unzip -Z1 "${ROOT}/${OUT}" | grep -vc '/$')
+sha=$(shasum -a 256 "${ROOT}/${OUT}" | awk '{print $1}')
+echo "Built ${OUT}"
+echo "  files:   ${files}"
+echo "  sha256:  ${sha}"
+echo
+echo "Upload this alongside the add-on package, and paste the contents of"
+echo "REVIEWERS.md (or a link to it) into the build-instructions field."

--- a/scripts/package-source.sh
+++ b/scripts/package-source.sh
@@ -8,10 +8,17 @@
 # for it directly, so it is uploaded with every AMO submission unconditionally
 # rather than argued about per release.
 #
-# The archive is the whole repository at the tag: all first-party source, the
-# vendoring and packaging scripts, the tests, and REVIEWERS.md (the build and
-# verification instructions). Nothing is pruned — a reviewer should be able to
-# reproduce the submitted package from this archive alone.
+# The archive is the repository at the tag: all first-party source, the vendoring
+# and packaging scripts, the tests, and REVIEWERS.md (the build and verification
+# instructions). The standard it has to meet is that a reviewer can reproduce the
+# submitted package from this archive alone — so everything that produces,
+# verifies, or documents a shipped file is in it.
+#
+# The only things held back are local tooling config and docs a reviewer would be
+# actively misled by (see EXCLUDE below). Nothing that affects the build is
+# removed, and REVIEWERS.md §8 lists the exclusions rather than leaving a reviewer
+# to notice the gap — a source archive that quietly omits things is worse than one
+# that omits nothing.
 #
 # Deterministic, like scripts/package.sh: same tag in, same bytes out.
 #
@@ -42,6 +49,32 @@ if [ ! -f "${STAGE}/REVIEWERS.md" ]; then
   echo "without the build instructions — commit it before tagging." >&2
   exit 1
 fi
+
+# Held back from the archive. Two kinds, and nothing else qualifies:
+#
+#   Local tooling config — not source for anything that ships, not read by any
+#   build step, and of no use to a reviewer.
+#
+#   Superseded docs — a doc that describes a state the code left behind costs a
+#   reviewer time and can actively mislead. FIREFOX_PORT.md is a port PLAN whose
+#   own status line reads "DONE. Shipped in 1.5.0"; BROWSER_PARITY.md replaced it
+#   and describes the build that actually exists. The 1.8.0 release copy is store
+#   text for a version two releases back.
+#
+# Everything that produces or verifies a shipped file stays, including docs that
+# still describe live code: docs/relay-doctor.md (documents a shipped script) and
+# docs/security-audit-2026-08-14.md (the current posture, remediated in 1.9.1) are
+# deliberately IN. If you add to this list, add the reason, and update REVIEWERS.md §8.
+EXCLUDE=(
+  .claude
+  CLAUDE.md
+  FIREFOX_PORT.md
+  docs/release-1.8.0-description.md
+  docs/release-1.8.0-guide.md
+)
+for path in "${EXCLUDE[@]}"; do
+  rm -rf "${STAGE:?}/${path}"
+done
 
 mkdir -p dist
 rm -f "${ROOT}/${OUT}"

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -49,10 +49,13 @@ git archive "${TAG}" | tar -x -C "${STAGE}"
 # Strip everything that isn't part of the running extension.
 rm -rf "${STAGE}/.claude" "${STAGE}/.github" "${STAGE}/scripts" "${STAGE}/assets" "${STAGE}/test" \
        "${STAGE}/docs"
-rm -f "${STAGE}/.gitignore" "${STAGE}/README.md" "${STAGE}/CHANGELOG.md" \
-      "${STAGE}/FEATURES.md" "${STAGE}/PRIVACY.md" "${STAGE}/BROWSER_PARITY.md" \
-      "${STAGE}/FIREFOX_PORT.md" "${STAGE}/VENDOR.md" "${STAGE}/WALLET_BACKENDS.md" \
-      "${STAGE}/package.json"
+# Every top-level .md, by glob rather than by name. The old explicit list failed
+# open: a doc added later shipped inside the extension until someone noticed, and
+# REVIEWERS.md — written FOR the store, describing how to reproduce this very zip
+# — was about to be the next one. Nothing in the package references a bundled .md
+# (help.html's changelog and privacy links point at GitHub), so the glob is safe.
+# NOTICE has no extension and stays: it's the vendored licenses.
+rm -f "${STAGE}"/*.md "${STAGE}/.gitignore" "${STAGE}/package.json"
 
 # version.js is gitignored and not in the archive — regenerate it, stamped to the tag.
 cat > "${STAGE}/version.js" <<EOF

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -36,6 +36,11 @@ fi
 
 SHORT=$(git rev-parse --short "${TAG}^{commit}")
 VERSION_NO_V="${TAG#v}"
+# The tag's own commit date, used to stamp every file in the zip. Derived from the
+# tag rather than "now" so the build is a function of the tag alone, and forced to
+# UTC so it does not depend on the packager's timezone. `touch -t` format, which
+# both BSD and GNU touch accept — BSD's -d rejects git's ISO offset.
+SOURCE_DATE=$(TZ=UTC git log -1 --format=%cd --date=format-local:'%Y%m%d%H%M.%S' "${TAG}^{commit}")
 
 STAGE="$(mktemp -d)/sidecar"
 mkdir -p "${STAGE}"
@@ -87,7 +92,14 @@ build_zip() {
     fs.writeFileSync(file, JSON.stringify(m, null, 2) + "\n");
   ' "${STAGE}/manifest.json" "${target}"
   rm -f "${ROOT}/${out}"
-  ( cd "${STAGE}" && zip -rqX "${ROOT}/${out}" . -x ".*" )
+  # Deterministic output. Every file is stamped with the tag's commit date and
+  # entries are added in sorted order, so the same tag always produces the same
+  # bytes on any machine. That turns the published SHA-256 into something a
+  # reviewer can reproduce and check, instead of "extract both and trust the
+  # diff" — which matters now that AMO requires a source submission alongside
+  # every upload (see REVIEWERS.md).
+  find "${STAGE}" -exec touch -t "${SOURCE_DATE}" {} +
+  ( cd "${STAGE}" && find . -type f ! -name '.*' | LC_ALL=C sort | zip -qXD "${ROOT}/${out}" -@ )
   local files sha
   files=$(unzip -Z1 "${ROOT}/${out}" | grep -vc '/$')
   sha=$(shasum -a 256 "${ROOT}/${out}" | awk '{print $1}')


### PR DESCRIPTION
AMO requires source whenever a submission carries minified, concatenated or
otherwise machine-generated code. Sidecar has no build step and nothing here is
minified, but `nip49.js` is an esbuild IIFE bundle — nostr-tools' browser bundle
doesn't export the NIP-49 module — and that alone meets the definition. It
matches no published artifact, and the store zip strips `scripts/` and
`VENDOR.md`, which is where every answer lives.

Approvals through 1.8.0 aren't evidence this is fine: AMO was auto-approving on
automated validation, so no human had read the bundle. A sibling extension was
delisted for exactly this and reinstated only on the condition that source be
uploaded from then on.

- `scripts/package-source.sh` emits `sidecar-X.Y.Z-source.zip` from the tag, and
  refuses to build if `REVIEWERS.md` isn't present at that tag.
- `package.sh` is now deterministic — files stamped with the tag's commit date in
  UTC, sorted entry order — so a published SHA-256 is reproducible anywhere.
- `REVIEWERS.md` is the reviewer text: what's generated, how to reproduce it, why
  `version.js` is in the zip but not the tree, and the table of long first-party
  lines that are inline SVG path data rather than minified code.
- The store zip now strips top-level `.md` by glob. The old explicit list failed
  open, and `REVIEWERS.md` — a document written for the store — was about to ship
  inside the extension.
- `.claude/`, `CLAUDE.md` and two superseded docs are held out of the archive,
  each listed with its reason in REVIEWERS.md §7.
- `BROWSER_PARITY.md` gains the checklist step, and a correction: it still
  promised AMO approval "within minutes" against a Chrome week.

Verified: both store zips and the source archive reproduce byte-identical
SHA-256s across runs; the archive carries `scripts/`, `VENDOR.md`, CI config and
all 44 test files, with the five excluded paths absent.

Note this blocks tagging 1.10.0 — `package-source.sh` won't build unless
`REVIEWERS.md` exists at the tag.

🥃 built with [GLM 5.3](https://z.ai)
